### PR TITLE
fix(keybinding): 修复 macOS Option 键组合快捷键录制问题

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -19,6 +19,7 @@ import {
 import { useEditor } from './hooks/useEditor';
 import { useGitBranches, useGitInit } from './hooks/useGit';
 import { useWorktreeCreate, useWorktreeList, useWorktreeRemove } from './hooks/useWorktree';
+import { matchesKeybinding } from './lib/keybinding';
 import { useNavigationStore } from './stores/navigation';
 import { useSettingsStore } from './stores/settings';
 import { useWorkspaceStore } from './stores/workspace';
@@ -170,19 +171,6 @@ export default function App() {
 
   // Listen for main tab switching keyboard shortcuts
   useEffect(() => {
-    const matchesKeybinding = (
-      e: KeyboardEvent,
-      binding: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }
-    ) => {
-      const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-      const ctrlMatch = binding.ctrl !== undefined ? e.ctrlKey === binding.ctrl : true;
-      const altMatch = binding.alt !== undefined ? e.altKey === binding.alt : true;
-      const shiftMatch = binding.shift !== undefined ? e.shiftKey === binding.shift : true;
-      const metaMatch = binding.meta !== undefined ? e.metaKey === binding.meta : true;
-
-      return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-    };
-
     const switchTab = (tab: TabId) => {
       setActiveTab(tab);
       const worktreePath = activeWorktree?.path;

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { matchesKeybinding } from '@/lib/keybinding';
 import { BUILTIN_AGENT_IDS, useSettingsStore } from '@/stores/settings';
 import { AgentTerminal } from './AgentTerminal';
 import { type Session, SessionBar } from './SessionBar';
@@ -278,23 +279,6 @@ export function AgentPanel({ repoPath, cwd, isActive = false }: AgentPanelProps)
     [cwd, customAgents]
   );
 
-  // Check if a keyboard event matches a keybinding
-  const matchesKeybinding = useCallback(
-    (
-      e: KeyboardEvent,
-      binding: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }
-    ) => {
-      const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-      const ctrlMatch = binding.ctrl !== undefined ? e.ctrlKey === binding.ctrl : true;
-      const altMatch = binding.alt !== undefined ? e.altKey === binding.alt : true;
-      const shiftMatch = binding.shift !== undefined ? e.shiftKey === binding.shift : true;
-      const metaMatch = binding.meta !== undefined ? e.metaKey === binding.meta : true;
-
-      return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-    },
-    []
-  );
-
   // Agent session keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -347,7 +331,6 @@ export function AgentPanel({ repoPath, cwd, isActive = false }: AgentPanelProps)
     isActive,
     activeSessionId,
     agentKeybindings,
-    matchesKeybinding,
     handleNewSession,
     handleCloseSession,
     handleNextSession,

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -42,6 +42,7 @@ import {
   getXtermTheme,
   type XtermTheme,
 } from '@/lib/ghosttyTheme';
+import { codeToKey } from '@/lib/keybinding';
 import { cn } from '@/lib/utils';
 import {
   type FontWeight,
@@ -768,9 +769,12 @@ function KeybindingInput({
     // Ignore modifier-only keys
     if (['Control', 'Alt', 'Shift', 'Meta'].includes(e.key)) return;
 
+    // Use e.code to get the physical key (avoids Option key special chars on macOS)
+    const key = codeToKey(e.code) || e.key.toLowerCase();
+
     // Record exactly what the user pressed
     const newBinding: TerminalKeybinding = {
-      key: e.key.toLowerCase(),
+      key,
     };
 
     // Only set modifier keys if they are actually pressed

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/components/ui/empty';
 import { useFileDiff } from '@/hooks/useSourceControl';
 import { getXtermTheme, isTerminalThemeDark } from '@/lib/ghosttyTheme';
+import { matchesKeybinding } from '@/lib/keybinding';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settings';
 import { useSourceControlStore } from '@/stores/sourceControl';
@@ -278,19 +279,6 @@ export function DiffViewer({
 
   // Keyboard shortcuts for diff navigation
   useEffect(() => {
-    const matchesKeybinding = (
-      e: KeyboardEvent,
-      binding: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }
-    ) => {
-      const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-      const ctrlMatch = binding.ctrl !== undefined ? e.ctrlKey === binding.ctrl : !e.ctrlKey;
-      const altMatch = binding.alt !== undefined ? e.altKey === binding.alt : !e.altKey;
-      const shiftMatch = binding.shift !== undefined ? e.shiftKey === binding.shift : !e.shiftKey;
-      const metaMatch = binding.meta !== undefined ? e.metaKey === binding.meta : !e.metaKey;
-
-      return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-    };
-
     const handleKeyDown = (e: KeyboardEvent) => {
       if (!file) return;
 

--- a/src/renderer/components/terminal/ShellTerminal.tsx
+++ b/src/renderer/components/terminal/ShellTerminal.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useXterm } from '@/hooks/useXterm';
+import { matchesKeybinding } from '@/lib/keybinding';
 import { useSettingsStore } from '@/stores/settings';
 import { TerminalSearchBar, type TerminalSearchBarRef } from './TerminalSearchBar';
 
@@ -35,23 +36,6 @@ export function ShellTerminal({
   const searchBarRef = useRef<TerminalSearchBarRef>(null);
   const terminalKeybindings = useSettingsStore((state) => state.terminalKeybindings);
 
-  // Check if a keyboard event matches a keybinding
-  const matchesKeybinding = useCallback(
-    (
-      e: KeyboardEvent,
-      binding: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }
-    ) => {
-      const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-      const ctrlMatch = binding.ctrl !== undefined ? e.ctrlKey === binding.ctrl : true;
-      const altMatch = binding.alt !== undefined ? e.altKey === binding.alt : true;
-      const shiftMatch = binding.shift !== undefined ? e.shiftKey === binding.shift : true;
-      const metaMatch = binding.meta !== undefined ? e.metaKey === binding.meta : true;
-
-      return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-    },
-    []
-  );
-
   // Handle keyboard shortcuts
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
@@ -73,7 +57,7 @@ export function ShellTerminal({
         return;
       }
     },
-    [isSearchOpen, terminalKeybindings, matchesKeybinding, clear]
+    [isSearchOpen, terminalKeybindings, clear]
   );
 
   // Handle right-click context menu

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -1,5 +1,6 @@
 import { List, Plus, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { matchesKeybinding } from '@/lib/keybinding';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settings';
 import { ShellTerminal } from './ShellTerminal';
@@ -167,23 +168,6 @@ export function TerminalPanel({ cwd, isActive = false }: TerminalPanelProps) {
     });
   }, [cwd]);
 
-  // Check if a keyboard event matches a keybinding
-  const matchesKeybinding = useCallback(
-    (
-      e: KeyboardEvent,
-      binding: { key: string; ctrl?: boolean; alt?: boolean; shift?: boolean; meta?: boolean }
-    ) => {
-      const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-      const ctrlMatch = binding.ctrl !== undefined ? e.ctrlKey === binding.ctrl : true;
-      const altMatch = binding.alt !== undefined ? e.altKey === binding.alt : true;
-      const shiftMatch = binding.shift !== undefined ? e.shiftKey === binding.shift : true;
-      const metaMatch = binding.meta !== undefined ? e.metaKey === binding.meta : true;
-
-      return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-    },
-    []
-  );
-
   // Terminal tab keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -236,7 +220,6 @@ export function TerminalPanel({ cwd, isActive = false }: TerminalPanelProps) {
     activeId,
     currentTabs,
     terminalKeybindings,
-    matchesKeybinding,
     handleNewTab,
     handleCloseTab,
     handleNextTab,

--- a/src/renderer/hooks/useKeybindingInterceptor.ts
+++ b/src/renderer/hooks/useKeybindingInterceptor.ts
@@ -1,16 +1,8 @@
 import { useEffect } from 'react';
-import { type TerminalKeybinding, useSettingsStore } from '@/stores/settings';
+import { matchesKeybinding } from '@/lib/keybinding';
+import { useSettingsStore } from '@/stores/settings';
 
 type KeybindingType = 'closeTab' | 'newTab' | 'nextTab' | 'prevTab' | 'clear';
-
-function matchesKeybinding(e: KeyboardEvent, binding: TerminalKeybinding): boolean {
-  const keyMatch = e.key.toLowerCase() === binding.key.toLowerCase();
-  const ctrlMatch = binding.ctrl ? e.ctrlKey : !e.ctrlKey;
-  const altMatch = binding.alt ? e.altKey : !e.altKey;
-  const shiftMatch = binding.shift ? e.shiftKey : !e.shiftKey;
-  const metaMatch = binding.meta ? e.metaKey : !e.metaKey;
-  return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
-}
 
 /**
  * Intercept terminal keybindings when a condition is met.

--- a/src/renderer/lib/keybinding.ts
+++ b/src/renderer/lib/keybinding.ts
@@ -1,0 +1,56 @@
+import type { TerminalKeybinding } from '@/stores/settings';
+
+// Convert e.code to readable key name (handles Option key special chars on macOS)
+export function codeToKey(code: string): string | null {
+  // Digits
+  if (code.startsWith('Digit')) return code.slice(5);
+  // Letters
+  if (code.startsWith('Key')) return code.slice(3).toLowerCase();
+  // Function keys
+  if (/^F\d+$/.test(code)) return code;
+  // Special keys mapping
+  const specialKeys: Record<string, string> = {
+    BracketLeft: '[',
+    BracketRight: ']',
+    Semicolon: ';',
+    Quote: "'",
+    Backquote: '`',
+    Comma: ',',
+    Period: '.',
+    Slash: '/',
+    Backslash: '\\',
+    Minus: '-',
+    Equal: '=',
+    Space: 'space',
+    Enter: 'enter',
+    Escape: 'escape',
+    Tab: 'tab',
+    Backspace: 'backspace',
+    Delete: 'delete',
+    ArrowUp: 'arrowup',
+    ArrowDown: 'arrowdown',
+    ArrowLeft: 'arrowleft',
+    ArrowRight: 'arrowright',
+    Home: 'home',
+    End: 'end',
+    PageUp: 'pageup',
+    PageDown: 'pagedown',
+  };
+  return specialKeys[code] || null;
+}
+
+// Get the actual key from a keyboard event (using code to avoid Option key issues)
+export function getKeyFromEvent(e: KeyboardEvent): string {
+  return codeToKey(e.code) || e.key.toLowerCase();
+}
+
+// Check if a keyboard event matches a keybinding
+export function matchesKeybinding(e: KeyboardEvent, binding: TerminalKeybinding): boolean {
+  const key = getKeyFromEvent(e);
+  const keyMatch = key === binding.key.toLowerCase();
+  const ctrlMatch = binding.ctrl ? e.ctrlKey : !e.ctrlKey;
+  const altMatch = binding.alt ? e.altKey : !e.altKey;
+  const shiftMatch = binding.shift ? e.shiftKey : !e.shiftKey;
+  const metaMatch = binding.meta ? e.metaKey : !e.metaKey;
+  return keyMatch && ctrlMatch && altMatch && shiftMatch && metaMatch;
+}


### PR DESCRIPTION
## Summary
- 修复 macOS 上录制快捷键时 Option+数字 显示特殊字符的问题（如 Option+1 显示 ¡）
- 使用 `e.code`（物理按键）代替 `e.key`（字符）识别按键
- 统一所有快捷键匹配逻辑到共享模块

## Changes
- 新增 `src/renderer/lib/keybinding.ts` 共享模块
- `codeToKey()` 函数将 `Digit1` → `1`，`KeyA` → `a`
- 更新 8 个文件使用统一的 `matchesKeybinding` 函数

## Test plan
- [ ] 在设置中录制 Option+1、Option+2 等快捷键，确认显示正确
- [ ] 验证录制后的快捷键可以正常触发