### PR TITLE
fix(worktree): cleanup terminals, agents, and watchers before removal

### DIFF
--- a/src/main/ipc/agent.ts
+++ b/src/main/ipc/agent.ts
@@ -4,7 +4,7 @@ import { AgentRegistry, BUILTIN_AGENTS } from '../services/agent/AgentRegistry';
 import { AgentSessionManager } from '../services/agent/AgentSession';
 
 const registry = new AgentRegistry(BUILTIN_AGENTS);
-const sessionManager = new AgentSessionManager();
+export const agentSessionManager = new AgentSessionManager();
 
 export function registerAgentHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.AGENT_LIST, async () => {
@@ -22,7 +22,7 @@ export function registerAgentHandlers(): void {
       throw new Error(`Agent not found: ${agentId}`);
     }
 
-    const session = await sessionManager.create(agent, workdir, (message) => {
+    const session = await agentSessionManager.create(agent, workdir, (message) => {
       if (!window.isDestroyed()) {
         window.webContents.send(IPC_CHANNELS.AGENT_MESSAGE, message);
       }
@@ -32,10 +32,10 @@ export function registerAgentHandlers(): void {
   });
 
   ipcMain.handle(IPC_CHANNELS.AGENT_STOP, async (_, sessionId: string) => {
-    await sessionManager.stop(sessionId);
+    await agentSessionManager.stop(sessionId);
   });
 
   ipcMain.handle(IPC_CHANNELS.AGENT_SEND, async (_, sessionId: string, content: string) => {
-    await sessionManager.send(sessionId, content);
+    await agentSessionManager.send(sessionId, content);
   });
 }

--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -6,6 +6,21 @@ import { FileWatcher } from '../services/files/FileWatcher';
 
 const watchers = new Map<string, FileWatcher>();
 
+/**
+ * Stop all file watchers for paths under the given directory
+ */
+export async function stopWatchersInDirectory(dirPath: string): Promise<void> {
+  const normalizedDir = dirPath.replace(/\\/g, '/').toLowerCase();
+
+  for (const [path, watcher] of watchers.entries()) {
+    const normalizedPath = path.replace(/\\/g, '/').toLowerCase();
+    if (normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}/`)) {
+      await watcher.stop();
+      watchers.delete(path);
+    }
+  }
+}
+
 export function registerFileHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.FILE_READ, async (_, filePath: string) => {
     const content = await readFile(filePath, 'utf-8');

--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -6,7 +6,7 @@ import {
 import { BrowserWindow, ipcMain } from 'electron';
 import { PtyManager } from '../services/terminal/PtyManager';
 
-const ptyManager = new PtyManager();
+export const ptyManager = new PtyManager();
 
 export function registerTerminalHandlers(): void {
   ipcMain.handle(

--- a/src/main/ipc/worktree.ts
+++ b/src/main/ipc/worktree.ts
@@ -5,6 +5,9 @@ import {
 } from '@shared/types';
 import { ipcMain } from 'electron';
 import { WorktreeService } from '../services/git/WorktreeService';
+import { agentSessionManager } from './agent';
+import { stopWatchersInDirectory } from './files';
+import { ptyManager } from './terminal';
 
 const worktreeServices = new Map<string, WorktreeService>();
 
@@ -32,6 +35,14 @@ export function registerWorktreeHandlers(): void {
   ipcMain.handle(
     IPC_CHANNELS.WORKTREE_REMOVE,
     async (_, workdir: string, options: WorktreeRemoveOptions) => {
+      // Stop all resources using the worktree directory before removal
+      await stopWatchersInDirectory(options.path);
+      ptyManager.destroyByWorkdir(options.path);
+      agentSessionManager.stopByWorkdir(options.path);
+
+      // Wait for processes to fully terminate
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+
       const service = getWorktreeService(workdir);
       await service.remove(options);
     }

--- a/src/main/services/agent/AgentSession.ts
+++ b/src/main/services/agent/AgentSession.ts
@@ -114,4 +114,18 @@ export class AgentSessionManager {
     }
     this.sessions.clear();
   }
+
+  stopByWorkdir(workdir: string): void {
+    const normalizedWorkdir = workdir.replace(/\\/g, '/').toLowerCase();
+    for (const [id, session] of this.sessions.entries()) {
+      const normalizedCwd = session.workdir.replace(/\\/g, '/').toLowerCase();
+      if (
+        normalizedCwd === normalizedWorkdir ||
+        normalizedCwd.startsWith(`${normalizedWorkdir}/`)
+      ) {
+        session.process.kill();
+        this.sessions.delete(id);
+      }
+    }
+  }
 }

--- a/src/main/services/git/WorktreeService.ts
+++ b/src/main/services/git/WorktreeService.ts
@@ -1,5 +1,34 @@
+import { exec } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { promisify } from 'node:util';
 import type { GitWorktree, WorktreeCreateOptions, WorktreeRemoveOptions } from '@shared/types';
 import simpleGit, { type SimpleGit } from 'simple-git';
+
+const execAsync = promisify(exec);
+
+/**
+ * Kill processes that have their working directory under the specified path (Windows only)
+ */
+async function killProcessesInDirectory(dirPath: string): Promise<void> {
+  if (process.platform !== 'win32') return;
+
+  try {
+    // Use PowerShell to find and kill node.exe processes with working directory under the path
+    const normalizedPath = dirPath.replace(/\//g, '\\');
+    const psScript = `
+      Get-Process node -ErrorAction SilentlyContinue | Where-Object {
+        try {
+          $cwd = (Get-CimInstance Win32_Process -Filter "ProcessId = $($_.Id)").CommandLine
+          $cwd -like "*${normalizedPath.replace(/\\/g, '\\\\')}*"
+        } catch { $false }
+      } | Stop-Process -Force -ErrorAction SilentlyContinue
+    `;
+    await execAsync(`powershell -Command "${psScript.replace(/"/g, '\\"').replace(/\n/g, ' ')}"`);
+  } catch {
+    // Ignore errors - process killing is best effort
+  }
+}
 
 export class WorktreeService {
   private git: SimpleGit;
@@ -66,18 +95,62 @@ export class WorktreeService {
   }
 
   async remove(options: WorktreeRemoveOptions): Promise<void> {
-    const args = ['worktree', 'remove'];
+    // Prune stale worktree entries first
+    await this.prune();
 
+    const args = ['worktree', 'remove'];
     if (options.force) {
       args.push('--force');
     }
-
     args.push(options.path);
-    await this.git.raw(args);
+
+    try {
+      await this.git.raw(args);
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+
+      // Handle "Permission denied" or "not a working tree" errors
+      const isPermissionDenied = errorMessage.includes('Permission denied');
+      const isNotWorktree = errorMessage.includes('is not a working tree');
+
+      if (isPermissionDenied || isNotWorktree) {
+        // Try to clean up the directory manually
+        if (existsSync(options.path)) {
+          // First attempt: try to kill processes using the directory
+          await killProcessesInDirectory(options.path);
+
+          // Wait a bit for processes to terminate
+          await new Promise((resolve) => setTimeout(resolve, 500));
+
+          try {
+            if (process.platform === 'win32') {
+              // Use Windows rmdir which can be more effective for locked files
+              await execAsync(`rmdir /s /q "${options.path}"`);
+            } else {
+              await rm(options.path, { recursive: true, force: true });
+            }
+          } catch (rmError) {
+            // If manual deletion also fails, throw a more helpful error
+            throw new Error(
+              `Failed to remove worktree directory: ${options.path}. ` +
+                `Please close any programs using this directory and try again.`
+            );
+          }
+        }
+        // Prune again to clean up any stale entries
+        await this.prune();
+      } else {
+        throw error;
+      }
+    }
 
     // Delete branch if requested
     if (options.deleteBranch && options.branch) {
-      await this.git.raw(['branch', '-D', options.branch]);
+      try {
+        await this.git.raw(['branch', '-D', options.branch]);
+      } catch {
+        // Ignore branch deletion errors (branch may not exist or be in use)
+      }
     }
   }
 

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -8,6 +8,14 @@ export function useTerminal() {
     useTerminalStore();
   const shellConfig = useSettingsStore((s) => s.shellConfig);
 
+  // Listen for terminal exit events from main process
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.terminal.onExit(({ id }) => {
+      removeSession(id);
+    });
+    return unsubscribe;
+  }, [removeSession]);
+
   const createTerminal = useCallback(
     async (options?: TerminalCreateOptions) => {
       const createOptions: TerminalCreateOptions = {


### PR DESCRIPTION
- Stop file watchers in worktree directory before deletion
- Destroy terminal sessions (with taskkill for Windows process tree)
- Stop agent sessions running in the worktree
- Add fallback killProcessesInDirectory for untracked node processes
- Handle Permission denied and not a working tree errors gracefully
- Listen for TERMINAL_EXIT events in renderer to sync session state