### PR TITLE
feat: 添加源代码管理树形视图和提交功能

### DIFF
--- a/src/renderer/components/source-control/ChangesList.tsx
+++ b/src/renderer/components/source-control/ChangesList.tsx
@@ -1,7 +1,19 @@
 import type { FileChange, FileChangeStatus } from '@shared/types';
-import { FileEdit, FilePlus, FileWarning, FileX, Minus, Plus, RotateCcw } from 'lucide-react';
+import {
+  FileEdit,
+  FilePlus,
+  FileWarning,
+  FileX,
+  List,
+  Minus,
+  Plus,
+  RotateCcw,
+  TreeDeciduous,
+} from 'lucide-react';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
+import { useSourceControlStore } from '@/stores/sourceControl';
+import { ChangesTree } from './ChangesTree';
 
 interface ChangesListProps {
   staged: FileChange[];
@@ -11,6 +23,7 @@ interface ChangesListProps {
   onStage: (paths: string[]) => void;
   onUnstage: (paths: string[]) => void;
   onDiscard: (path: string) => void;
+  onDeleteUntracked?: (path: string) => void;
 }
 
 // M=Modified, A=Added, D=Deleted, R=Renamed, C=Copied, U=Untracked, X=Conflict
@@ -113,7 +126,14 @@ export function ChangesList({
   onStage,
   onUnstage,
   onDiscard,
+  onDeleteUntracked,
 }: ChangesListProps) {
+  const { viewMode, setViewMode } = useSourceControlStore();
+
+  // Separate tracked and untracked changes
+  const trackedChanges = unstaged.filter((f) => f.status !== 'U');
+  const untrackedChanges = unstaged.filter((f) => f.status === 'U');
+
   const handleStageAll = () => {
     const paths = unstaged.map((f) => f.path);
     if (paths.length > 0) onStage(paths);
@@ -124,79 +144,188 @@ export function ChangesList({
     if (paths.length > 0) onUnstage(paths);
   };
 
-  return (
-    <ScrollArea className="h-full">
-      <div className="space-y-4 p-3">
-        {/* Staged Changes */}
-        {staged.length > 0 && (
-          <div className="space-y-1">
-            <div className="flex items-center justify-between px-2">
-              <h3 className="text-xs font-medium text-muted-foreground">
-                暂存的更改 ({staged.length})
-              </h3>
-              <button
-                type="button"
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                onClick={handleUnstageAll}
-              >
-                全部取消暂存
-              </button>
-            </div>
-            <div className="space-y-0.5">
-              {staged.map((file) => (
-                <FileItem
-                  key={`staged-${file.path}`}
-                  file={file}
-                  isSelected={selectedFile?.path === file.path && selectedFile?.staged === true}
-                  onFileClick={() => onFileClick({ path: file.path, staged: true })}
-                  onAction={() => onUnstage([file.path])}
-                  actionIcon={Minus}
-                  actionTitle="取消暂存"
-                />
-              ))}
-            </div>
-          </div>
-        )}
+  const handleStageTracked = () => {
+    const paths = trackedChanges.map((f) => f.path);
+    if (paths.length > 0) onStage(paths);
+  };
 
-        {/* Unstaged Changes */}
-        {unstaged.length > 0 && (
-          <div className="space-y-1">
-            <div className="flex items-center justify-between px-2">
-              <h3 className="text-xs font-medium text-muted-foreground">
-                更改 ({unstaged.length})
-              </h3>
-              <button
-                type="button"
-                className="text-xs text-muted-foreground hover:text-foreground transition-colors"
-                onClick={handleStageAll}
-              >
-                全部暂存
-              </button>
-            </div>
-            <div className="space-y-0.5">
-              {unstaged.map((file) => (
-                <FileItem
-                  key={`unstaged-${file.path}`}
-                  file={file}
-                  isSelected={selectedFile?.path === file.path && selectedFile?.staged === false}
-                  onFileClick={() => onFileClick({ path: file.path, staged: false })}
-                  onAction={() => onStage([file.path])}
-                  actionIcon={Plus}
-                  actionTitle="暂存"
-                  onDiscard={() => onDiscard(file.path)}
-                />
-              ))}
-            </div>
-          </div>
-        )}
+  const handleStageUntracked = () => {
+    const paths = untrackedChanges.map((f) => f.path);
+    if (paths.length > 0) onStage(paths);
+  };
 
-        {/* Empty State */}
-        {staged.length === 0 && unstaged.length === 0 && (
-          <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
-            <p className="text-sm">没有更改</p>
-          </div>
-        )}
+  // If tree mode, use ChangesTree component
+  if (viewMode === 'tree') {
+    return (
+      <div className="flex h-full flex-col">
+        {/* View Mode Toggle */}
+        <div className="flex h-9 shrink-0 items-center justify-end border-b px-3">
+          <button
+            type="button"
+            className="flex h-7 items-center gap-1.5 rounded-md border bg-background px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            onClick={() => setViewMode(viewMode === 'list' ? 'tree' : 'list')}
+            title={viewMode === 'list' ? '切换到树形视图' : '切换到列表视图'}
+          >
+            {viewMode === 'list' ? (
+              <>
+                <TreeDeciduous className="h-3.5 w-3.5" />
+                <span>树形视图</span>
+              </>
+            ) : (
+              <>
+                <List className="h-3.5 w-3.5" />
+                <span>列表视图</span>
+              </>
+            )}
+          </button>
+        </div>
+        {/* Tree View */}
+        <div className="flex-1 overflow-hidden">
+          <ChangesTree
+            staged={staged}
+            trackedChanges={trackedChanges}
+            untrackedChanges={untrackedChanges}
+            selectedFile={selectedFile}
+            onFileClick={onFileClick}
+            onStage={onStage}
+            onUnstage={onUnstage}
+            onDiscard={onDiscard}
+            onDeleteUntracked={onDeleteUntracked}
+          />
+        </div>
       </div>
-    </ScrollArea>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* View Mode Toggle */}
+      <div className="flex h-9 shrink-0 items-center justify-end border-b px-3">
+        <button
+          type="button"
+          className="flex h-7 items-center gap-1.5 rounded-md border bg-background px-2.5 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          onClick={() => setViewMode(viewMode === 'list' ? 'tree' : 'list')}
+          title={viewMode === 'list' ? '切换到树形视图' : '切换到列表视图'}
+        >
+          {viewMode === 'list' ? (
+            <>
+              <TreeDeciduous className="h-3.5 w-3.5" />
+              <span>树形视图</span>
+            </>
+          ) : (
+            <>
+              <List className="h-3.5 w-3.5" />
+              <span>列表视图</span>
+            </>
+          )}
+        </button>
+      </div>
+      {/* List View */}
+      <ScrollArea className="flex-1">
+        <div className="space-y-4 p-3">
+          {/* Staged Changes */}
+          {staged.length > 0 && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between px-2">
+                <h3 className="text-xs font-medium text-muted-foreground">
+                  暂存的更改 ({staged.length})
+                </h3>
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={handleUnstageAll}
+                >
+                  全部取消暂存
+                </button>
+              </div>
+              <div className="space-y-0.5">
+                {staged.map((file) => (
+                  <FileItem
+                    key={`staged-${file.path}`}
+                    file={file}
+                    isSelected={selectedFile?.path === file.path && selectedFile?.staged === true}
+                    onFileClick={() => onFileClick({ path: file.path, staged: true })}
+                    onAction={() => onUnstage([file.path])}
+                    actionIcon={Minus}
+                    actionTitle="取消暂存"
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Tracked Changes */}
+          {trackedChanges.length > 0 && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between px-2">
+                <h3 className="text-xs font-medium text-muted-foreground">
+                  更改 ({trackedChanges.length})
+                </h3>
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={handleStageTracked}
+                >
+                  全部暂存
+                </button>
+              </div>
+              <div className="space-y-0.5">
+                {trackedChanges.map((file) => (
+                  <FileItem
+                    key={`unstaged-${file.path}`}
+                    file={file}
+                    isSelected={selectedFile?.path === file.path && selectedFile?.staged === false}
+                    onFileClick={() => onFileClick({ path: file.path, staged: false })}
+                    onAction={() => onStage([file.path])}
+                    actionIcon={Plus}
+                    actionTitle="暂存"
+                    onDiscard={() => onDiscard(file.path)}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Untracked Changes */}
+          {untrackedChanges.length > 0 && (
+            <div className="space-y-1">
+              <div className="flex items-center justify-between px-2">
+                <h3 className="text-xs font-medium text-muted-foreground">
+                  未跟踪的更改 ({untrackedChanges.length})
+                </h3>
+                <button
+                  type="button"
+                  className="text-xs text-muted-foreground hover:text-foreground transition-colors"
+                  onClick={handleStageUntracked}
+                >
+                  全部暂存
+                </button>
+              </div>
+              <div className="space-y-0.5">
+                {untrackedChanges.map((file) => (
+                  <FileItem
+                    key={`untracked-${file.path}`}
+                    file={file}
+                    isSelected={selectedFile?.path === file.path && selectedFile?.staged === false}
+                    onFileClick={() => onFileClick({ path: file.path, staged: false })}
+                    onAction={() => onStage([file.path])}
+                    actionIcon={Plus}
+                    actionTitle="暂存"
+                    onDiscard={onDeleteUntracked ? () => onDeleteUntracked(file.path) : undefined}
+                  />
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Empty State */}
+          {staged.length === 0 && trackedChanges.length === 0 && untrackedChanges.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-8 text-center text-muted-foreground">
+              <p className="text-sm">没有更改</p>
+            </div>
+          )}
+        </div>
+      </ScrollArea>
+    </div>
   );
 }

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -1,0 +1,80 @@
+import { GitCommit, Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface CommitBoxProps {
+  stagedCount: number;
+  onCommit: (message: string) => void;
+  isCommitting?: boolean;
+}
+
+export function CommitBox({ stagedCount, onCommit, isCommitting = false }: CommitBoxProps) {
+  const [message, setMessage] = useState('');
+
+  const handleCommit = () => {
+    const finalMessage = message.trim();
+    if (finalMessage && stagedCount > 0) {
+      onCommit(finalMessage);
+      setMessage('');
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      handleCommit();
+    }
+  };
+
+  const hasMessage = message.trim().length > 0;
+  const canCommit = hasMessage && stagedCount > 0 && !isCommitting;
+
+  return (
+    <div className="flex shrink-0 flex-col border-t bg-background">
+      {/* Message Input */}
+      <textarea
+        className={cn(
+          'w-full resize-none border-0 bg-transparent px-3 py-2 text-sm',
+          'placeholder:text-muted-foreground focus:outline-none',
+          'min-h-[80px] max-h-[200px]'
+        )}
+        placeholder={
+          stagedCount > 0 ? '输入提交信息... (Cmd/Ctrl+Enter 提交)' : '暂存更改后才能提交'
+        }
+        value={message}
+        onChange={(e) => setMessage(e.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={stagedCount === 0 || isCommitting}
+      />
+
+      {/* Actions */}
+      <div className="flex items-center justify-between gap-2 border-t px-3 py-2">
+        {/* Staged count */}
+        <span className="text-xs text-muted-foreground">
+          {stagedCount > 0 ? `${stagedCount} 个已暂存的更改` : '没有暂存的更改'}
+        </span>
+
+        {/* Commit button */}
+        <Button
+          size="sm"
+          onClick={handleCommit}
+          disabled={!canCommit}
+          className="h-7 gap-1.5 text-xs"
+        >
+          {isCommitting ? (
+            <>
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              提交中...
+            </>
+          ) : (
+            <>
+              <GitCommit className="h-3.5 w-3.5" />
+              提交
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/source-control/index.ts
+++ b/src/renderer/components/source-control/index.ts
@@ -1,3 +1,5 @@
 export { ChangesList } from './ChangesList';
+export { ChangesTree } from './ChangesTree';
+export { CommitBox } from './CommitBox';
 export { DiffViewer } from './DiffViewer';
 export { SourceControlPanel } from './SourceControlPanel';

--- a/src/renderer/hooks/useSourceControl.ts
+++ b/src/renderer/hooks/useSourceControl.ts
@@ -67,3 +67,18 @@ export function useGitDiscard() {
     },
   });
 }
+
+export function useGitCommit() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ workdir, message }: { workdir: string; message: string }) => {
+      return window.electronAPI.git.commit(workdir, message);
+    },
+    onSuccess: (_, { workdir }) => {
+      queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'status', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'log', workdir] });
+    },
+  });
+}

--- a/src/renderer/stores/sourceControl.ts
+++ b/src/renderer/stores/sourceControl.ts
@@ -6,12 +6,17 @@ interface SelectedFile {
 }
 
 type NavigationDirection = 'next' | 'prev' | null;
+type ViewMode = 'list' | 'tree';
 
 interface SourceControlState {
   selectedFile: SelectedFile | null;
   setSelectedFile: (file: SelectedFile | null) => void;
   navigationDirection: NavigationDirection;
   setNavigationDirection: (direction: NavigationDirection) => void;
+  viewMode: ViewMode;
+  setViewMode: (mode: ViewMode) => void;
+  expandedFolders: Set<string>;
+  toggleFolder: (path: string) => void;
 }
 
 export const useSourceControlStore = create<SourceControlState>((set) => ({
@@ -19,4 +24,17 @@ export const useSourceControlStore = create<SourceControlState>((set) => ({
   setSelectedFile: (selectedFile) => set({ selectedFile }),
   navigationDirection: null,
   setNavigationDirection: (navigationDirection) => set({ navigationDirection }),
+  viewMode: 'list',
+  setViewMode: (viewMode) => set({ viewMode }),
+  expandedFolders: new Set<string>(),
+  toggleFolder: (path) =>
+    set((state) => {
+      const newExpanded = new Set(state.expandedFolders);
+      if (newExpanded.has(path)) {
+        newExpanded.delete(path);
+      } else {
+        newExpanded.add(path);
+      }
+      return { expandedFolders: newExpanded };
+    }),
 }));


### PR DESCRIPTION
## Summary
- 新增树形视图模式,支持按目录结构显示文件
- 添加视图模式切换按钮(列表/树形)
- 实现文件夹展开/折叠功能,支持一键全部展开/折叠
- 新增提交信息输入框,支持Cmd/Ctrl+Enter快捷键提交
- 区分已跟踪和未跟踪的更改,分别显示
- 支持放弃已跟踪文件的更改和删除未跟踪文件
- 添加删除/放弃更改的确认对话框

## Changes
### 新增文件
- `src/renderer/components/source-control/ChangesTree.tsx` - 树形视图组件
- `src/renderer/components/source-control/CommitBox.tsx` - 提交信息输入框组件

### 修改文件
- `src/renderer/components/source-control/ChangesList.tsx` - 添加视图模式切换,分离已跟踪和未跟踪更改
- `src/renderer/components/source-control/SourceControlPanel.tsx` - 集成CommitBox,添加提交和删除功能
- `src/renderer/stores/sourceControl.ts` - 添加viewMode和expandedFolders状态管理
- `src/renderer/hooks/useSourceControl.ts` - 添加useGitCommit hook

## Screenshots
_请添加功能截图_

## Test Plan
- [ ] 测试列表视图和树形视图切换
- [ ] 测试文件夹展开/折叠功能
- [ ] 测试一键全部展开/折叠
- [ ] 测试暂存/取消暂存文件
- [ ] 测试提交功能
- [ ] 测试放弃已跟踪文件更改
- [ ] 测试删除未跟踪文件
- [ ] 测试Cmd/Ctrl+Enter快捷键提交
<!-- trigger code review -->