### PR TITLE
feat(settings): 添加自动保存功能

### DIFF
--- a/src/renderer/stores/editor.ts
+++ b/src/renderer/stores/editor.ts
@@ -22,7 +22,7 @@ interface EditorState {
   openFile: (file: Omit<EditorTab, 'title' | 'viewState'> & { title?: string }) => void;
   closeFile: (path: string) => void;
   setActiveFile: (path: string | null) => void;
-  updateFileContent: (path: string, content: string) => void;
+  updateFileContent: (path: string, content: string, isDirty?: boolean) => void;
   markFileSaved: (path: string) => void;
   setTabViewState: (path: string, viewState: unknown) => void;
   reorderTabs: (fromIndex: number, toIndex: number) => void;
@@ -73,9 +73,9 @@ export const useEditorStore = create<EditorState>((set) => ({
 
   setActiveFile: (path) => set({ activeTabPath: path }),
 
-  updateFileContent: (path, content) =>
+  updateFileContent: (path, content, isDirty = true) =>
     set((state) => ({
-      tabs: state.tabs.map((tab) => (tab.path === path ? { ...tab, content, isDirty: true } : tab)),
+      tabs: state.tabs.map((tab) => (tab.path === path ? { ...tab, content, isDirty } : tab)),
     })),
 
   markFileSaved: (path) =>

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -160,6 +160,8 @@ export type EditorRenderLineHighlight = 'none' | 'gutter' | 'line' | 'all';
 export type EditorAutoClosingBrackets = 'always' | 'languageDefined' | 'beforeWhitespace' | 'never';
 export type EditorAutoClosingQuotes = 'always' | 'languageDefined' | 'beforeWhitespace' | 'never';
 
+export type EditorAutoSave = 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
+
 export interface EditorSettings {
   // Display
   minimapEnabled: boolean;
@@ -187,6 +189,9 @@ export interface EditorSettings {
   // Editing
   autoClosingBrackets: EditorAutoClosingBrackets;
   autoClosingQuotes: EditorAutoClosingQuotes;
+  // Auto Save
+  autoSave: EditorAutoSave;
+  autoSaveDelay: number;
 }
 
 export const defaultEditorSettings: EditorSettings = {
@@ -216,6 +221,9 @@ export const defaultEditorSettings: EditorSettings = {
   // Editing
   autoClosingBrackets: 'languageDefined',
   autoClosingQuotes: 'languageDefined',
+  // Auto Save
+  autoSave: 'off',
+  autoSaveDelay: 1000,
 };
 
 export const defaultTerminalKeybindings: TerminalKeybindings = {

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -447,6 +447,19 @@ export const zhTranslations: Record<string, string> = {
   'Auto quotes': '自动引号',
   'Language defined': '跟随语言',
   'Before whitespace': '空白字符前',
+  // Auto Save section
+  'Auto Save': '自动保存',
+  'Auto save settings': '自动保存设置',
+  'Auto save': '自动保存',
+  'After delay': '延迟后',
+  'On focus change': '失去焦点时',
+  'On window change': '窗口失焦时',
+  'Auto save is disabled': '关闭自动保存',
+  'Auto save after a short delay': '短暂延迟后自动保存',
+  'Auto save when editor loses focus': '编辑器失去焦点时自动保存',
+  'Auto save when window loses focus': '窗口失去焦点时自动保存',
+  Delay: '延迟',
+  ms: '毫秒',
 };
 
 export function normalizeLocale(input?: string): Locale {


### PR DESCRIPTION
## Summary

添加编辑器自动保存功能，支持多种自动保存模式配置

## Changes

| 文件                                                | 更改内容                                                         |
|-----------------------------------------------------|------------------------------------------------------------------|
| src/renderer/components/files/EditorArea.tsx        | 实现 useDebouncedSave hook，支持失焦/窗口失焦/延迟后自动保存     |
| src/renderer/components/settings/SettingsDialog.tsx | 添加自动保存设置 UI，包含模式选择和延迟配置输入框                |
| src/renderer/stores/editor.ts                       | updateFileContent 增加 isDirty 可选参数，支持控制 dirty 状态显示 |
| src/renderer/stores/settings.ts                     | 新增 EditorAutoSave 类型定义和 autoSave、autoSaveDelay 配置项    |
| src/shared/i18n.ts                                  | 添加自动保存相关的中文翻译条目                                   |

## Test plan

- [ ] 在设置面板中切换自动保存模式（关闭/延迟后/失焦时/窗口失焦时）
- [ ] 验证"延迟后"模式下，停止输入后正确触发自动保存
- [ ] 验证"失焦时"模式下，编辑器失去焦点后正确触发自动保存
- [ ] 验证"窗口失焦时"模式下，切换窗口后正确触发自动保存
- [ ] 验证关闭自动保存后，文件正确显示 dirty 状态指示器
- [ ] 验证自动保存延迟时间在 100ms-10000ms 范围内可调节