### PR TITLE
feat(editor): 增加自动保存功能，支持切换和关闭标签页时保存;增加当前tab文件磁盘监听，获取最新文件内容;

### DIFF
--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -16,6 +16,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { toastManager } from '@/components/ui/toast';
+import { useDebouncedSave } from '@/hooks/useDebouncedSave';
 import { useI18n } from '@/i18n';
 import { getXtermTheme, isTerminalThemeDark } from '@/lib/ghosttyTheme';
 import type { EditorTab, PendingCursor } from '@/stores/editor';
@@ -125,9 +126,9 @@ interface EditorAreaProps {
   activeTabPath: string | null;
   pendingCursor: PendingCursor | null;
   onTabClick: (path: string) => void;
-  onTabClose: (path: string) => void;
+  onTabClose: (path: string) => void | Promise<void>;
   onTabReorder: (fromIndex: number, toIndex: number) => void;
-  onContentChange: (path: string, content: string) => void;
+  onContentChange: (path: string, content: string, isDirty?: boolean) => void;
   onViewStateChange: (path: string, viewState: unknown) => void;
   onSave: (path: string) => void;
   onClearPendingCursor: () => void;
@@ -154,6 +155,110 @@ export function EditorArea({
   const selectionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectionWidgetRef = useRef<monaco.editor.IContentWidget | null>(null);
   const widgetRootRef = useRef<Root | null>(null);
+  const hasPendingAutoSaveRef = useRef(false);
+  const blurDisposableRef = useRef<monaco.IDisposable | null>(null);
+  const activeTabPathRef = useRef<string | null>(null);
+
+  // Keep ref in sync with activeTabPath
+  useEffect(() => {
+    activeTabPathRef.current = activeTabPath;
+  }, [activeTabPath]);
+
+  // Auto save: Debounced save for 'afterDelay' mode
+  // Use ref-based debounce to avoid closure issues with activeTabPath
+  const {
+    trigger: triggerDebouncedSave,
+    cancel: cancelDebouncedSave,
+    flush: flushDebouncedSave,
+  } = useDebouncedSave(editorSettings.autoSaveDelay);
+
+  // Auto save: Handle blur listener for onFocusChange mode
+  // This effect ensures listener is properly registered/unregistered when autoSave mode changes
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) return;
+
+    // Cleanup previous listener
+    if (blurDisposableRef.current) {
+      blurDisposableRef.current.dispose();
+      blurDisposableRef.current = null;
+    }
+
+    // Register new listener if onFocusChange mode
+    if (editorSettings.autoSave === 'onFocusChange') {
+      const handleBlur = () => {
+        const path = activeTabPathRef.current;
+        if (path && hasPendingAutoSaveRef.current) {
+          onSave(path);
+          hasPendingAutoSaveRef.current = false;
+        }
+      };
+      blurDisposableRef.current = editor.onDidBlurEditorText(handleBlur);
+    }
+
+    return () => {
+      if (blurDisposableRef.current) {
+        blurDisposableRef.current.dispose();
+        blurDisposableRef.current = null;
+      }
+    };
+  }, [editorSettings.autoSave, onSave]);
+
+  // Auto save: Save on window focus change
+  useEffect(() => {
+    const handleWindowBlur = () => {
+      if (
+        activeTabPath &&
+        editorSettings.autoSave === 'onWindowChange' &&
+        hasPendingAutoSaveRef.current
+      ) {
+        onSave(activeTabPath);
+        hasPendingAutoSaveRef.current = false;
+      }
+    };
+
+    window.addEventListener('blur', handleWindowBlur);
+    return () => window.removeEventListener('blur', handleWindowBlur);
+  }, [activeTabPath, editorSettings.autoSave, onSave]);
+
+  // Listen for external file changes and update open tabs
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.file.onChange(async (event) => {
+      // Only handle update events (create/delete don't need tab updates)
+      if (event.type !== 'update') return;
+
+      // Check if the changed file is open in any tab
+      const changedTab = tabs.find((tab) => tab.path === event.path);
+      if (!changedTab) return;
+
+      // Read the latest content from disk
+      try {
+        const latestContent = await window.electronAPI.file.read(event.path);
+        // Update the tab content
+        onContentChange(event.path, latestContent, changedTab.isDirty);
+
+        // If this is the active tab, update the editor content
+        if (event.path === activeTabPath && editorRef.current) {
+          const editor = editorRef.current;
+          const currentValue = editor.getValue();
+          // Only update if content is different to avoid cursor jump
+          if (currentValue !== latestContent) {
+            const position = editor.getPosition();
+            editor.setValue(latestContent);
+            if (position) {
+              editor.setPosition(position);
+            }
+          }
+        }
+      } catch (error) {
+        console.warn(`Failed to reload file ${event.path}:`, error);
+      }
+    });
+
+    return () => {
+      unsubscribe();
+    };
+  }, [tabs, activeTabPath, onContentChange]);
 
   // Define custom theme on mount and when terminal theme changes
   useEffect(() => {
@@ -401,15 +506,63 @@ export function EditorArea({
   const handleEditorChange = useCallback(
     (value: string | undefined) => {
       if (activeTabPath && value !== undefined) {
-        onContentChange(activeTabPath, value);
+        const autoSaveEnabled = editorSettings.autoSave !== 'off';
+        // Show dirty indicator when auto save is off or when it triggers on focus/window change
+        const shouldShowDirty =
+          !autoSaveEnabled ||
+          editorSettings.autoSave === 'onFocusChange' ||
+          editorSettings.autoSave === 'onWindowChange';
+        onContentChange(activeTabPath, value, shouldShowDirty);
+
+        // Mark as pending for focus/window change modes
+        if (autoSaveEnabled) {
+          hasPendingAutoSaveRef.current = true;
+        }
+
+        // Trigger auto save based on mode
+        if (editorSettings.autoSave === 'afterDelay') {
+          triggerDebouncedSave(activeTabPath, (path) => {
+            onSave(path);
+            hasPendingAutoSaveRef.current = false;
+          });
+        }
       }
     },
-    [activeTabPath, onContentChange]
+    [activeTabPath, onContentChange, editorSettings.autoSave, triggerDebouncedSave, onSave]
   );
 
   const handleTabClose = useCallback(
-    (path: string, e: React.MouseEvent) => {
+    async (path: string, e: React.MouseEvent) => {
       e.stopPropagation();
+
+      // Auto-save before closing based on mode (VS Code behavior):
+      // - afterDelay: save (debounced save may still be pending)
+      // - onFocusChange: save (closing tab should trigger save like focus change)
+      // - onWindowChange: don't save (user needs to manually save)
+      // - off: don't save (manual save only)
+      const shouldAutoSaveOnClose =
+        editorSettings.autoSave === 'afterDelay' || editorSettings.autoSave === 'onFocusChange';
+
+      // Sync save before closing (await to ensure file is written before tab is removed)
+      // We need to save directly because saveFile.mutate reads from tabs which will be removed
+      if (
+        path === activeTabPath &&
+        editorRef.current &&
+        hasPendingAutoSaveRef.current &&
+        shouldAutoSaveOnClose
+      ) {
+        const currentContent = editorRef.current.getValue();
+        // Sync content to store and mark as not dirty (isDirty: false)
+        onContentChange(path, currentContent, false);
+        // Save to disk directly (await to ensure it completes before closing)
+        await window.electronAPI.file.write(path, currentContent);
+        // Note: We don't call onSave here because we already wrote the file directly above.
+        // Calling onSave would trigger saveFile.mutate which writes the file again.
+        hasPendingAutoSaveRef.current = false;
+      }
+
+      // Cancel pending debounced save
+      cancelDebouncedSave();
 
       // Save view state before closing
       if (editorRef.current && path === activeTabPath) {
@@ -421,12 +574,22 @@ export function EditorArea({
 
       onTabClose(path);
     },
-    [activeTabPath, onTabClose, onViewStateChange]
+    [
+      activeTabPath,
+      onTabClose,
+      onViewStateChange,
+      cancelDebouncedSave,
+      editorSettings.autoSave,
+      onContentChange,
+    ]
   );
 
   // Save view state when switching tabs
   const handleTabClick = useCallback(
     (path: string) => {
+      // Flush pending debounced save when switching tabs (save immediately)
+      flushDebouncedSave();
+
       if (editorRef.current && activeTabPath && activeTabPath !== path) {
         const viewState = editorRef.current.saveViewState();
         if (viewState) {
@@ -435,7 +598,7 @@ export function EditorArea({
       }
       onTabClick(path);
     },
-    [activeTabPath, onTabClick, onViewStateChange]
+    [activeTabPath, onTabClick, onViewStateChange, flushDebouncedSave]
   );
 
   // Determine Monaco theme - use custom theme synced with terminal

--- a/src/renderer/components/files/EditorTabs.tsx
+++ b/src/renderer/components/files/EditorTabs.tsx
@@ -9,7 +9,7 @@ interface EditorTabsProps {
   tabs: EditorTab[];
   activeTabPath: string | null;
   onTabClick: (path: string) => void;
-  onTabClose: (path: string, e: React.MouseEvent) => void;
+  onTabClose: (path: string, e: React.MouseEvent) => void | Promise<void>;
   onTabReorder?: (fromIndex: number, toIndex: number) => void;
 }
 

--- a/src/renderer/hooks/useDebouncedSave.ts
+++ b/src/renderer/hooks/useDebouncedSave.ts
@@ -1,0 +1,76 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/**
+ * A ref-based debounce hook that avoids closure issues
+ *
+ * @param delay - Delay in milliseconds
+ * @returns Object with trigger, cancel, and flush functions
+ *
+ * @example
+ * ```ts
+ * const { trigger, cancel, flush } = useDebouncedSave(1000);
+ *
+ * // Trigger debounced action
+ * trigger('value', (val) => console.log(val));
+ *
+ * // Cancel pending action
+ * cancel();
+ *
+ * // Execute pending action immediately
+ * flush();
+ * ```
+ */
+export function useDebouncedSave<T = string>(delay: number) {
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const valueRef = useRef<T | null>(null);
+  const callbackRef = useRef<((value: T) => void) | null>(null);
+
+  // Cleanup timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  const trigger = useCallback(
+    (value: T, callback: (value: T) => void) => {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current);
+      }
+      valueRef.current = value;
+      callbackRef.current = callback;
+      timeoutRef.current = setTimeout(() => {
+        if (valueRef.current && callbackRef.current) {
+          callbackRef.current(valueRef.current);
+        }
+        timeoutRef.current = null;
+        valueRef.current = null;
+        callbackRef.current = null;
+      }, delay);
+    },
+    [delay]
+  );
+
+  const cancel = useCallback(() => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    valueRef.current = null;
+    callbackRef.current = null;
+  }, []);
+
+  const flush = useCallback(() => {
+    if (timeoutRef.current && valueRef.current && callbackRef.current) {
+      clearTimeout(timeoutRef.current);
+      callbackRef.current(valueRef.current);
+      timeoutRef.current = null;
+      valueRef.current = null;
+      callbackRef.current = null;
+    }
+  }, []);
+
+  return { trigger, cancel, flush };
+}

--- a/src/renderer/stores/editor.ts
+++ b/src/renderer/stores/editor.ts
@@ -22,7 +22,7 @@ interface EditorState {
   openFile: (file: Omit<EditorTab, 'title' | 'viewState'> & { title?: string }) => void;
   closeFile: (path: string) => void;
   setActiveFile: (path: string | null) => void;
-  updateFileContent: (path: string, content: string) => void;
+  updateFileContent: (path: string, content: string, isDirty?: boolean) => void;
   markFileSaved: (path: string) => void;
   setTabViewState: (path: string, viewState: unknown) => void;
   reorderTabs: (fromIndex: number, toIndex: number) => void;
@@ -73,9 +73,9 @@ export const useEditorStore = create<EditorState>((set) => ({
 
   setActiveFile: (path) => set({ activeTabPath: path }),
 
-  updateFileContent: (path, content) =>
+  updateFileContent: (path, content, isDirty = true) =>
     set((state) => ({
-      tabs: state.tabs.map((tab) => (tab.path === path ? { ...tab, content, isDirty: true } : tab)),
+      tabs: state.tabs.map((tab) => (tab.path === path ? { ...tab, content, isDirty } : tab)),
     })),
 
   markFileSaved: (path) =>

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -173,6 +173,8 @@ export type EditorRenderLineHighlight = 'none' | 'gutter' | 'line' | 'all';
 export type EditorAutoClosingBrackets = 'always' | 'languageDefined' | 'beforeWhitespace' | 'never';
 export type EditorAutoClosingQuotes = 'always' | 'languageDefined' | 'beforeWhitespace' | 'never';
 
+export type EditorAutoSave = 'off' | 'afterDelay' | 'onFocusChange' | 'onWindowChange';
+
 export interface EditorSettings {
   // Display
   minimapEnabled: boolean;
@@ -200,6 +202,9 @@ export interface EditorSettings {
   // Editing
   autoClosingBrackets: EditorAutoClosingBrackets;
   autoClosingQuotes: EditorAutoClosingQuotes;
+  // Auto Save
+  autoSave: EditorAutoSave;
+  autoSaveDelay: number;
 }
 
 export const defaultEditorSettings: EditorSettings = {
@@ -229,6 +234,9 @@ export const defaultEditorSettings: EditorSettings = {
   // Editing
   autoClosingBrackets: 'languageDefined',
   autoClosingQuotes: 'languageDefined',
+  // Auto Save
+  autoSave: 'off',
+  autoSaveDelay: 1000,
 };
 
 export const defaultTerminalKeybindings: TerminalKeybindings = {

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -462,6 +462,19 @@ export const zhTranslations: Record<string, string> = {
   'Sent to Claude Code': '已发送到 Claude Code',
   'Send to Claude': '发送到 Claude',
   lines: '行',
+  // Auto Save section
+  'Auto Save': '自动保存',
+  'Auto save settings': '自动保存设置',
+  'Auto save': '自动保存',
+  'After delay': '延迟后',
+  'On focus change': '失去焦点时',
+  'On window change': '窗口失焦时',
+  'Auto save is disabled': '关闭自动保存',
+  'Auto save after a short delay': '短暂延迟后自动保存',
+  'Auto save when editor loses focus': '编辑器失去焦点时自动保存',
+  'Auto save when window loses focus': '窗口失去焦点时自动保存',
+  Delay: '延迟',
+  ms: '毫秒',
 };
 
 export function normalizeLocale(input?: string): Locale {


### PR DESCRIPTION
## Summary

添加编辑器自动保存功能，支持多种保存模式配置；实现文件磁盘变更监听，自动同步最新内容

## Changes

| 文件 | 更改内容 |
|------|----------|
| src/renderer/components/files/EditorArea.tsx | 实现自动保存逻辑（失焦/窗口失焦/延迟后）；添加文件磁盘变更监听，同步最新内容到编辑器 |
| src/renderer/components/files/EditorTabs.tsx | 调整 onTabClose 类型定义支持异步 |
| src/renderer/components/settings/SettingsDialog.tsx | 添加自动保存设置 UI，包含模式选择下拉框和延迟时间配置输入框 |
| src/renderer/hooks/useDebouncedSave.ts | 新增基于 ref 的防抖 hook，支持 trigger/cancel/flush 操作 |
| src/renderer/stores/editor.ts | updateFileContent 增加 isDirty 可选参数，支持控制 dirty 状态显示 |
| src/renderer/stores/settings.ts | 新增 EditorAutoSave 类型定义和 autoSave、autoSaveDelay 配置项 |
| src/shared/i18n.ts | 添加自动保存相关的中英文翻译条目 |

## Test plan

- [ ] 在设置面板中切换自动保存模式（关闭/延迟后/失焦时/窗口失焦时）
- [ ] 验证"延迟后"模式下，停止输入指定时间后正确触发自动保存
- [ ] 验证"失焦时"模式下，编辑器失去焦点后正确触发自动保存
- [ ] 验证"窗口失焦时"模式下，切换窗口后正确触发自动保存
- [ ] 验证关闭自动保存后，文件修改时正确显示 dirty 状态指示器
- [ ] 验证自动保存延迟时间在 100ms-10000ms 范围内可正常调节
- [ ] 验证外部修改文件后，编辑器自动同步最新内容
- [ ] 验证切换/关闭标签页时正确保存文件