### PR TITLE
feat: 支持将文件编辑器状态同步到外部编辑器

### DIFF
--- a/src/main/ipc/app.ts
+++ b/src/main/ipc/app.ts
@@ -7,9 +7,22 @@ export function registerAppHandlers() {
     return await appDetector.detectApps();
   });
 
-  ipcMain.handle(IPC_CHANNELS.APP_OPEN_WITH, async (_, path: string, bundleId: string) => {
-    await appDetector.openPath(path, bundleId);
-  });
+  ipcMain.handle(
+    IPC_CHANNELS.APP_OPEN_WITH,
+    async (
+      _,
+      path: string,
+      bundleId: string,
+      options?: {
+        line?: number;
+        workspacePath?: string;
+        openFiles?: string[];
+        activeFile?: string;
+      }
+    ) => {
+      await appDetector.openPath(path, bundleId, options);
+    }
+  );
 
   ipcMain.handle(IPC_CHANNELS.APP_GET_ICON, async (_, bundleId: string) => {
     return await appDetector.getAppIcon(bundleId);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -204,8 +204,16 @@ const electronAPI = {
   // App Detector
   appDetector: {
     detectApps: (): Promise<DetectedApp[]> => ipcRenderer.invoke(IPC_CHANNELS.APP_DETECT),
-    openWith: (path: string, bundleId: string): Promise<void> =>
-      ipcRenderer.invoke(IPC_CHANNELS.APP_OPEN_WITH, path, bundleId),
+    openWith: (
+      path: string,
+      bundleId: string,
+      options?: {
+        line?: number;
+        workspacePath?: string;
+        openFiles?: string[];
+        activeFile?: string;
+      }
+    ): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.APP_OPEN_WITH, path, bundleId, options),
     getIcon: (bundleId: string): Promise<string | undefined> =>
       ipcRenderer.invoke(IPC_CHANNELS.APP_GET_ICON, bundleId),
   },

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -27,6 +27,7 @@ import { toastManager } from '@/components/ui/toast';
 import { useI18n } from '@/i18n';
 import { getXtermTheme, isTerminalThemeDark } from '@/lib/ghosttyTheme';
 import type { EditorTab, PendingCursor } from '@/stores/editor';
+import { useEditorStore } from '@/stores/editor';
 import { useSettingsStore } from '@/stores/settings';
 import { EditorTabs } from './EditorTabs';
 
@@ -213,6 +214,7 @@ export function EditorArea({
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const { terminalTheme, editorSettings, claudeCodeIntegration } = useSettingsStore();
+  const setCurrentCursorLine = useEditorStore((state) => state.setCurrentCursorLine);
   const themeDefinedRef = useRef(false);
   const selectionDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const selectionWidgetRef = useRef<monaco.editor.IContentWidget | null>(null);
@@ -405,6 +407,9 @@ export function EditorArea({
           const model = editor.getModel();
           if (!model) return;
 
+          // Update cursor line in store for "Open in editor" functionality
+          setCurrentCursorLine(selection.startLineNumber);
+
           const selectedText = model.getValueInRange(selection);
 
           // Show/hide selection widget
@@ -458,6 +463,7 @@ export function EditorArea({
       claudeCodeIntegration.selectionChangedDebounce,
       buildAtMentionedKeybinding,
       t,
+      setCurrentCursorLine,
     ]
   );
 

--- a/src/renderer/components/layout/MainContent.tsx
+++ b/src/renderer/components/layout/MainContent.tsx
@@ -144,7 +144,7 @@ export function MainContent({
 
         {/* Right: Open In Menu */}
         <div className="flex items-center gap-2 no-drag">
-          <OpenInMenu path={worktreePath} />
+          <OpenInMenu path={worktreePath} activeTab={activeTab} />
         </div>
       </header>
 

--- a/src/renderer/hooks/useAppDetector.ts
+++ b/src/renderer/hooks/useAppDetector.ts
@@ -12,8 +12,21 @@ export function useDetectedApps() {
 
 export function useOpenWith() {
   return useMutation({
-    mutationFn: async ({ path, bundleId }: { path: string; bundleId: string }) => {
-      await window.electronAPI.appDetector.openWith(path, bundleId);
+    mutationFn: async ({
+      path,
+      bundleId,
+      options,
+    }: {
+      path: string;
+      bundleId: string;
+      options?: {
+        line?: number;
+        workspacePath?: string;
+        openFiles?: string[];
+        activeFile?: string;
+      };
+    }) => {
+      await window.electronAPI.appDetector.openWith(path, bundleId, options);
     },
   });
 }

--- a/src/renderer/stores/editor.ts
+++ b/src/renderer/stores/editor.ts
@@ -18,6 +18,7 @@ interface EditorState {
   tabs: EditorTab[];
   activeTabPath: string | null;
   pendingCursor: PendingCursor | null;
+  currentCursorLine: number | null; // Current cursor line in active editor
 
   openFile: (file: Omit<EditorTab, 'title' | 'viewState'> & { title?: string }) => void;
   closeFile: (path: string) => void;
@@ -27,6 +28,7 @@ interface EditorState {
   setTabViewState: (path: string, viewState: unknown) => void;
   reorderTabs: (fromIndex: number, toIndex: number) => void;
   setPendingCursor: (cursor: PendingCursor | null) => void;
+  setCurrentCursorLine: (line: number | null) => void;
 }
 
 const getTabTitle = (path: string) => path.split(/[/\\]/).pop() || path;
@@ -35,6 +37,7 @@ export const useEditorStore = create<EditorState>((set) => ({
   tabs: [],
   activeTabPath: null,
   pendingCursor: null,
+  currentCursorLine: null,
 
   openFile: (file) =>
     set((state) => {
@@ -99,4 +102,6 @@ export const useEditorStore = create<EditorState>((set) => ({
     }),
 
   setPendingCursor: (cursor) => set({ pendingCursor: cursor }),
+
+  setCurrentCursorLine: (line) => set({ currentCursorLine: line }),
 }));


### PR DESCRIPTION
## Summary
- 点击 "Open in Cursor/VSCode" 时同步所有已打开文件
- 自动跳转到当前文件的光标行号  
- 支持 Cursor、VSCode、Zed 等编辑器的 CLI 工具
- 添加编辑器 store 的光标位置追踪

## 实现细节
1. **后端 (AppDetector.ts)**：使用两步策略打开编辑器
   - 第一步：打开工作区和所有文件
   - 第二步：使用 `-g` 参数跳转到指定行

2. **前端 (OpenInMenu.tsx)**：从编辑器 store 收集状态
   - 所有打开的文件路径
   - 当前激活的文件
   - 当前光标行号

3. **编辑器追踪 (EditorArea.tsx)**：监听 Monaco 编辑器的光标变化并更新 store

## Test Plan
- [x] 在文件编辑器打开多个文件
- [x] 移动光标到特定行
- [x] 点击 "Open in Cursor"
- [x] 验证 Cursor 打开了工作区、所有文件并跳转到正确行号