### PR TITLE
feat(source-control): 添加 AI 生成 commit message 功能

### DIFF
--- a/src/main/services/terminal/PtyManager.ts
+++ b/src/main/services/terminal/PtyManager.ts
@@ -41,7 +41,7 @@ function adjustArgsForShell(shell: string, args: string[]): string[] {
 }
 
 // GUI apps don't inherit shell PATH, add common paths
-function getEnhancedPath(): string {
+export function getEnhancedPath(): string {
   const home = process.env.HOME || process.env.USERPROFILE || homedir();
   const currentPath = process.env.PATH || '';
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -69,6 +69,11 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.GIT_COMMIT_DIFF, workdir, hash, filePath, status),
     getDiffStats: (workdir: string): Promise<{ insertions: number; deletions: number }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_DIFF_STATS, workdir),
+    generateCommitMessage: (
+      workdir: string,
+      options: { maxDiffLines: number; timeout: number }
+    ): Promise<{ success: boolean; message?: string; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG, workdir, options),
   },
 
   // Worktree

--- a/src/renderer/components/settings/SettingsDialog.tsx
+++ b/src/renderer/components/settings/SettingsDialog.tsx
@@ -2198,7 +2198,12 @@ function AgentForm({ agent, onSubmit, onCancel }: AgentFormProps) {
 
 function IntegrationSettings() {
   const { t } = useI18n();
-  const { claudeCodeIntegration, setClaudeCodeIntegration } = useSettingsStore();
+  const {
+    claudeCodeIntegration,
+    setClaudeCodeIntegration,
+    commitMessageGenerator,
+    setCommitMessageGenerator,
+  } = useSettingsStore();
   const [bridgePort, setBridgePort] = React.useState<number | null>(null);
 
   const debounceOptions = React.useMemo(
@@ -2290,6 +2295,76 @@ function IntegrationSettings() {
           </div>
         </div>
       )}
+
+      {/* Commit Message Generator Section */}
+      <div className="mt-6 border-t pt-6">
+        <div>
+          <h3 className="text-lg font-medium">{t('Commit Message Generator')}</h3>
+          <p className="text-sm text-muted-foreground">
+            {t('Auto-generate commit messages using Claude')}
+          </p>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <div className="space-y-0.5">
+            <span className="text-sm font-medium">{t('Enable Generator')}</span>
+            <p className="text-xs text-muted-foreground">
+              {t('Generate commit messages with AI assistance')}
+            </p>
+          </div>
+          <Switch
+            checked={commitMessageGenerator.enabled}
+            onCheckedChange={(checked) => setCommitMessageGenerator({ enabled: checked })}
+          />
+        </div>
+
+        {commitMessageGenerator.enabled && (
+          <div className="mt-4 space-y-4 border-t pt-4">
+            {/* Max Diff Lines */}
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Max Diff Lines')}</span>
+              <div className="space-y-1.5">
+                <Input
+                  type="number"
+                  value={commitMessageGenerator.maxDiffLines}
+                  onChange={(e) =>
+                    setCommitMessageGenerator({ maxDiffLines: Number(e.target.value) || 1000 })
+                  }
+                  min={100}
+                  max={10000}
+                  className="w-32"
+                />
+                <p className="text-xs text-muted-foreground">
+                  {t('Maximum number of diff lines to include')}
+                </p>
+              </div>
+            </div>
+
+            {/* Timeout */}
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Timeout')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={String(commitMessageGenerator.timeout)}
+                  onValueChange={(v) => setCommitMessageGenerator({ timeout: Number(v) })}
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue>{commitMessageGenerator.timeout}s</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {[30, 60, 120, 180].map((sec) => (
+                      <SelectItem key={sec} value={String(sec)}>
+                        {sec}s
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">{t('Timeout in seconds')}</p>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -1,18 +1,28 @@
-import { GitCommit, Loader2 } from 'lucide-react';
+import { GitCommit, Loader2, Sparkles } from 'lucide-react';
 import { useState } from 'react';
 import { Button } from '@/components/ui/button';
+import { toastManager } from '@/components/ui/toast';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
+import { useSettingsStore } from '@/stores/settings';
 
 interface CommitBoxProps {
   stagedCount: number;
   onCommit: (message: string) => void;
   isCommitting?: boolean;
+  rootPath?: string | null;
 }
 
-export function CommitBox({ stagedCount, onCommit, isCommitting = false }: CommitBoxProps) {
+export function CommitBox({
+  stagedCount,
+  onCommit,
+  isCommitting = false,
+  rootPath,
+}: CommitBoxProps) {
   const { t } = useI18n();
   const [message, setMessage] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const { commitMessageGenerator } = useSettingsStore();
 
   const handleCommit = () => {
     const finalMessage = message.trim();
@@ -29,28 +39,79 @@ export function CommitBox({ stagedCount, onCommit, isCommitting = false }: Commi
     }
   };
 
+  const handleGenerateMessage = async () => {
+    if (!rootPath || isGenerating) return;
+
+    setIsGenerating(true);
+    try {
+      const result = await window.electronAPI.git.generateCommitMessage(rootPath, {
+        maxDiffLines: commitMessageGenerator.maxDiffLines,
+        timeout: commitMessageGenerator.timeout,
+      });
+
+      if (result.success && result.message) {
+        setMessage(result.message);
+      } else {
+        toastManager.add({
+          title: t('Failed to generate commit message'),
+          description: result.error === 'timeout' ? t('Generation timed out') : result.error,
+          type: 'error',
+          timeout: 5000,
+        });
+      }
+    } catch (error) {
+      toastManager.add({
+        title: t('Failed to generate commit message'),
+        description: error instanceof Error ? error.message : String(error),
+        type: 'error',
+        timeout: 5000,
+      });
+    } finally {
+      setIsGenerating(false);
+    }
+  };
+
   const hasMessage = message.trim().length > 0;
   const canCommit = hasMessage && stagedCount > 0 && !isCommitting;
+  const canGenerate = commitMessageGenerator.enabled && rootPath && !isGenerating && !isCommitting;
 
   return (
     <div className="flex shrink-0 flex-col border-t bg-background">
-      {/* Message Input */}
-      <textarea
-        className={cn(
-          'w-full resize-none border-0 bg-transparent px-3 py-2 text-sm',
-          'placeholder:text-muted-foreground focus:outline-none',
-          'min-h-[80px] max-h-[200px]'
+      {/* Message Input with Generate Button */}
+      <div className="relative">
+        <textarea
+          className={cn(
+            'w-full resize-none border-0 bg-transparent px-3 py-2 pr-10 text-sm',
+            'placeholder:text-muted-foreground focus:outline-none',
+            'min-h-[80px] max-h-[200px]'
+          )}
+          placeholder={
+            stagedCount > 0
+              ? t('Enter commit message... (Cmd/Ctrl+Enter to commit)')
+              : t('Stage changes before committing')
+          }
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={stagedCount === 0 || isCommitting}
+        />
+        {/* Generate Button - floating at bottom right of textarea */}
+        {commitMessageGenerator.enabled && (
+          <button
+            type="button"
+            className="absolute bottom-2 right-2 flex h-6 w-6 items-center justify-center rounded-md text-muted-foreground hover:bg-accent/50 hover:text-primary disabled:pointer-events-none disabled:opacity-50"
+            onClick={handleGenerateMessage}
+            disabled={!canGenerate}
+            title={t('Generate commit message')}
+          >
+            {isGenerating ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Sparkles className="h-3.5 w-3.5" />
+            )}
+          </button>
         )}
-        placeholder={
-          stagedCount > 0
-            ? t('Enter commit message... (Cmd/Ctrl+Enter to commit)')
-            : t('Stage changes before committing')
-        }
-        value={message}
-        onChange={(e) => setMessage(e.target.value)}
-        onKeyDown={handleKeyDown}
-        disabled={stagedCount === 0 || isCommitting}
-      />
+      </div>
 
       {/* Actions */}
       <div className="flex items-center justify-between gap-2 border-t px-3 py-2">

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -427,6 +427,7 @@ export function SourceControlPanel({
                       stagedCount={staged.length}
                       onCommit={handleCommit}
                       isCommitting={commitMutation.isPending}
+                      rootPath={rootPath}
                     />
                   </>
                 )}

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -157,6 +157,19 @@ export const defaultClaudeCodeIntegrationSettings: ClaudeCodeIntegrationSettings
   atMentionedKeybinding: { key: 'm', meta: true, shift: true }, // Cmd/Ctrl+Shift+M
 };
 
+// Commit message generator settings
+export interface CommitMessageGeneratorSettings {
+  enabled: boolean;
+  maxDiffLines: number;
+  timeout: number; // in seconds
+}
+
+export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettings = {
+  enabled: true,
+  maxDiffLines: 1000,
+  timeout: 60,
+};
+
 // Editor settings
 export type EditorLineNumbers = 'on' | 'off' | 'relative';
 export type EditorWordWrap = 'on' | 'off' | 'wordWrapColumn' | 'bounded';
@@ -290,6 +303,7 @@ interface SettingsState {
   agentNotificationDelay: number; // in seconds
   agentNotificationEnterDelay: number; // delay after Enter before starting idle timer
   claudeCodeIntegration: ClaudeCodeIntegrationSettings;
+  commitMessageGenerator: CommitMessageGeneratorSettings;
 
   setTheme: (theme: Theme) => void;
   setLanguage: (language: Locale) => void;
@@ -318,6 +332,7 @@ interface SettingsState {
   setAgentNotificationDelay: (delay: number) => void;
   setAgentNotificationEnterDelay: (delay: number) => void;
   setClaudeCodeIntegration: (settings: Partial<ClaudeCodeIntegrationSettings>) => void;
+  setCommitMessageGenerator: (settings: Partial<CommitMessageGeneratorSettings>) => void;
 }
 
 const defaultAgentSettings: AgentSettings = {
@@ -358,6 +373,7 @@ export const useSettingsStore = create<SettingsState>()(
       agentNotificationDelay: 3, // 3 seconds
       agentNotificationEnterDelay: 0, // 0 = disabled, start timer immediately
       claudeCodeIntegration: defaultClaudeCodeIntegrationSettings,
+      commitMessageGenerator: defaultCommitMessageGeneratorSettings,
 
       setTheme: (theme) => {
         const terminalTheme = get().terminalTheme;
@@ -463,6 +479,10 @@ export const useSettingsStore = create<SettingsState>()(
       setClaudeCodeIntegration: (settings) =>
         set((state) => ({
           claudeCodeIntegration: { ...state.claudeCodeIntegration, ...settings },
+        })),
+      setCommitMessageGenerator: (settings) =>
+        set((state) => ({
+          commitMessageGenerator: { ...state.commitMessageGenerator, ...settings },
         })),
     }),
     {

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -456,7 +456,7 @@ export const zhTranslations: Record<string, string> = {
   'Claude Code Integration': 'Claude Code 集成',
   'Connect to Claude Code CLI for enhanced IDE features':
     '连接 Claude Code CLI 以获得增强的 IDE 功能',
-  'Enable Integration': '启用集成',
+  'Enable Integration': '启动 IDE 集成',
   'Start WebSocket server for Claude Code connection': '启动 WebSocket 服务器以连接 Claude Code',
   'Debounce Time': '防抖时间',
   'Delay before sending selection changes to Claude Code':
@@ -466,6 +466,19 @@ export const zhTranslations: Record<string, string> = {
   'Sent to Claude Code': '已发送到 Claude Code',
   'Send to Claude': '发送到 Claude',
   lines: '行',
+  // Commit Message Generator
+  'Commit Message Generator': '生成 Commit Message',
+  'Auto-generate commit messages using Claude': '使用 Claude 自动生成 commit 消息',
+  'Enable Generator': '启用生成器',
+  'Generate commit messages with AI assistance': '使用 AI 辅助生成 commit 消息',
+  'Max Diff Lines': '最大 Diff 行数',
+  'Maximum number of diff lines to include': '包含的最大 diff 行数',
+  Timeout: '超时',
+  'Timeout in seconds': '超时时间（秒）',
+  seconds: '秒',
+  'Generate commit message': '生成 commit 消息',
+  'Failed to generate commit message': '生成 commit 消息失败',
+  'Generation timed out': '生成超时',
   // Auto Save section
   'Auto Save': '自动保存',
   'Auto save settings': '自动保存设置',

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -19,6 +19,7 @@ export const IPC_CHANNELS = {
   GIT_COMMIT_FILES: 'git:commit:files',
   GIT_COMMIT_DIFF: 'git:commit:diff',
   GIT_DIFF_STATS: 'git:diff:stats',
+  GIT_GENERATE_COMMIT_MSG: 'git:generate-commit-msg',
 
   // Worktree
   WORKTREE_LIST: 'worktree:list',


### PR DESCRIPTION
## Summary

- 在 Source Control 面板的 CommitBox 中添加 AI 生成 commit message 按钮（Sparkles 图标）
- 点击后调用 Claude CLI (haiku 模型) 根据 git diff 自动生成 commit message
- 在设置页面添加「生成 Commit Message」配置项，支持启用/禁用、最大 diff 行数、超时时间设置

## Test plan

- [ ] 在 Source Control 面板确认 Sparkles 按钮显示在 textarea 右下角
- [ ] 点击按钮后确认 loading 状态正常
- [ ] 确认生成的 commit message 自动填充到输入框
- [ ] 测试超时和错误情况下的 toast 提示
- [ ] 在设置页面测试配置项的启用/禁用