### PR TITLE
feat(code-review): 添加继续对话功能与语言设置

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -314,10 +314,22 @@ ${truncatedDiff}`;
     async (
       event,
       workdir: string,
-      options: { model: string; language?: string; reviewId: string }
-    ): Promise<{ success: boolean; error?: string }> => {
+      options: {
+        model: string;
+        language?: string;
+        continueConversation?: boolean;
+        sessionId?: string;
+        reviewId: string;
+      }
+    ): Promise<{ success: boolean; error?: string; sessionId?: string }> => {
       const resolved = validateWorkdir(workdir);
-      const { model, language = '中文', reviewId } = options;
+      const {
+        model,
+        language = '中文',
+        continueConversation = false,
+        sessionId,
+        reviewId,
+      } = options;
 
       // Helper to run git commands
       const runGit = (cmd: string): string => {
@@ -380,7 +392,9 @@ ${gitLog || '(No commit history available)'}`;
         '-p',
         '--output-format',
         'stream-json',
-        '--no-session-persistence',
+        ...(continueConversation && sessionId
+          ? ['--session-id', sessionId]
+          : ['--no-session-persistence']),
         '--disallowedTools',
         '"Bash(git:*)" Edit',
         '--model',
@@ -454,7 +468,7 @@ ${gitLog || '(No commit history available)'}`;
         }
       });
 
-      return { success: true };
+      return { success: true, sessionId: continueConversation ? sessionId : undefined };
     }
   );
 

--- a/src/renderer/components/layout/MainContent.tsx
+++ b/src/renderer/components/layout/MainContent.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/empty';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
+import { useCodeReviewContinueStore } from '@/stores/codeReviewContinue';
 import { TerminalPanel } from '../terminal';
 
 type TabId = 'chat' | 'file' | 'terminal' | 'source-control';
@@ -65,6 +66,17 @@ export function MainContent({
       lastValidWorktreePathRef.current = worktreePath;
     }
   }, [repoPath, worktreePath]);
+
+  // 监听 code review 继续对话请求，切换到 chat tab
+  const shouldSwitchToChat = useCodeReviewContinueStore((s) => s.shouldSwitchToChat);
+  const clearTabSwitch = useCodeReviewContinueStore((s) => s.clearTabSwitch);
+
+  useEffect(() => {
+    if (shouldSwitchToChat) {
+      onTabChange('chat');
+      clearTabSwitch();
+    }
+  }, [shouldSwitchToChat, onTabChange, clearTabSwitch]);
 
   // Use current values if available, otherwise use last valid values
   const effectiveRepoPath = repoPath || lastValidRepoPathRef.current;

--- a/src/renderer/components/settings/IntegrationSettings.tsx
+++ b/src/renderer/components/settings/IntegrationSettings.tsx
@@ -269,7 +269,7 @@ export function IntegrationSettings() {
               <span className="text-sm font-medium">{t('Language')}</span>
               <div className="space-y-1.5">
                 <Input
-                  value={codeReview.language}
+                  value={codeReview.language ?? '中文'}
                   onChange={(e) => setCodeReview({ language: e.target.value })}
                   placeholder="中文"
                   className="w-32"
@@ -278,6 +278,20 @@ export function IntegrationSettings() {
                   {t('Language for code review output')}
                 </p>
               </div>
+            </div>
+
+            {/* Continue Conversation */}
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <span className="text-sm font-medium">{t('Continue Conversation')}</span>
+                <p className="text-xs text-muted-foreground">
+                  {t('Preserve session for follow-up conversations after review')}
+                </p>
+              </div>
+              <Switch
+                checked={codeReview.continueConversation ?? true}
+                onCheckedChange={(checked) => setCodeReview({ continueConversation: checked })}
+              />
             </div>
           </div>
         )}

--- a/src/renderer/stores/codeReviewContinue.ts
+++ b/src/renderer/stores/codeReviewContinue.ts
@@ -1,0 +1,28 @@
+import { create } from 'zustand';
+
+interface CodeReviewContinueState {
+  // Pending session to continue
+  pendingSessionId: string | null;
+  // Flag to switch to chat tab
+  shouldSwitchToChat: boolean;
+
+  // Request to continue a code review conversation
+  requestContinue: (sessionId: string) => void;
+
+  // Clear pending request (called after handling)
+  clearRequest: () => void;
+
+  // Clear tab switch flag (called after tab switched)
+  clearTabSwitch: () => void;
+}
+
+export const useCodeReviewContinueStore = create<CodeReviewContinueState>((set) => ({
+  pendingSessionId: null,
+  shouldSwitchToChat: false,
+
+  requestContinue: (sessionId) => set({ pendingSessionId: sessionId, shouldSwitchToChat: true }),
+
+  clearRequest: () => set({ pendingSessionId: null }),
+
+  clearTabSwitch: () => set({ shouldSwitchToChat: false }),
+}));

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -181,12 +181,14 @@ export interface CodeReviewSettings {
   enabled: boolean;
   model: CodeReviewModel;
   language: string;
+  continueConversation: boolean;
 }
 
 export const defaultCodeReviewSettings: CodeReviewSettings = {
   enabled: true,
   model: 'haiku',
   language: '中文',
+  continueConversation: true,
 };
 
 // Editor settings

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -489,6 +489,8 @@ export const zhTranslations: Record<string, string> = {
   'Show code review button in source control': '在版本控制中显示代码审查按钮',
   'Claude model for code review': '用于代码审查的 Claude 模型',
   'Language for code review output': '代码审查输出语言',
+  'Continue Conversation': '继续对话',
+  'Preserve session for follow-up conversations after review': '审查后保留 session 以便继续对话',
   Review: '审查',
   'Start code review': '开始代码审查',
   'Initializing...': '初始化中...',


### PR DESCRIPTION
## Summary

- 新增代码审查**语言设置**，支持自定义输出语言（默认中文）
- 新增**继续对话**功能，审查完成后可一键跳转到 Agent Panel 继续交流
- 审查时使用 `--session-id` 保留会话，点击继续对话后以 `claude --resume` 恢复
- 统一 Modal footer 按钮样式

## Test plan

- [ ] 打开设置 → 集成 → Code Review，确认显示语言和继续对话设置项
- [ ] 修改语言设置，运行 Code Review，确认输出使用指定语言
- [ ] 开启继续对话，运行 Code Review，完成后确认显示"继续对话"按钮
- [ ] 点击"继续对话"，确认跳转到 Agent tab 并启动新 session
- [ ] 关闭继续对话设置，运行 Code Review，确认不显示"继续对话"按钮