### PR TITLE
fix(diff): 修复 Source Control DiffViewer 语法高亮不生效问题

### DIFF
--- a/src/renderer/components/files/monacoSetup.ts
+++ b/src/renderer/components/files/monacoSetup.ts
@@ -28,6 +28,40 @@ self.MonacoEnvironment = {
 // Tell @monaco-editor/react to use our pre-configured monaco instance
 loader.config({ monaco });
 
+// Pre-initialize Monaco to ensure it's ready before any editor renders
+const loadedMonaco = await loader.init();
+
+// Pre-create models to trigger language feature loading (tokenizers are lazy-loaded)
+// This ensures syntax highlighting works immediately for DiffEditor
+const preloadLanguages = [
+  'typescript',
+  'javascript',
+  'json',
+  'markdown',
+  'css',
+  'scss',
+  'html',
+  'xml',
+  'yaml',
+  'python',
+  'go',
+  'rust',
+  'swift',
+  'java',
+  'kotlin',
+  'shell',
+  'sql',
+  'graphql',
+];
+for (const lang of preloadLanguages) {
+  try {
+    const tempModel = monaco.editor.createModel('', lang);
+    tempModel.dispose();
+  } catch {
+    // Language may not be supported by Monaco, skip silently
+  }
+}
+
 // Languages to highlight with Shiki (not natively supported by Monaco)
 const SHIKI_LANGUAGES = ['vue', 'svelte', 'astro'];
 const SHIKI_THEMES = ['vitesse-dark', 'vitesse-light'];


### PR DESCRIPTION
## Summary
- 修复直接打开 Source Control panel 查看 diff 时没有代码高亮的问题
- 切换到 File panel 再切回来后才有高亮的 bug

## Root Cause
Monaco 的 TextMate tokenizer 是懒加载的，只有在首次创建某种语言的 model 时才会加载。DiffEditor 直接渲染时使用的是基础 tokenizer（只有简单的颜色），File panel 的 Editor 触发了完整 TextMate tokenizer 的加载。

## Solution
在 `monacoSetup.ts` 中预加载常用语言的 tokenizer，通过创建临时 model 触发加载：
- 同步预加载 TypeScript、JavaScript 等常用语言
- DiffViewer 从 monacoSetup 导入 monaco 实例，确保配置一致

## Test Plan
- [ ] 直接打开 Source Control panel，查看 diff 是否有语法高亮
- [ ] 切换文件测试不同语言的高亮（TS、JS、JSON、CSS 等）
- [ ] 确认 File panel 的编辑器高亮仍正常工作