### PR TITLE
feat(app): 完善 Windows 应用检测路径

### DIFF
--- a/src/main/services/app/constants.ts
+++ b/src/main/services/app/constants.ts
@@ -112,10 +112,60 @@ export const WINDOWS_APPS: WindowsApp[] = (() => {
       exePaths: [
         join(programFiles, 'Alacritty', 'alacritty.exe'),
         join(appData, 'alacritty', 'alacritty.exe'),
+        'alacritty.exe',
       ],
     },
+    {
+      name: 'Kitty',
+      id: 'net.kovidgoyal.kitty',
+      category: AppCategory.Terminal,
+      exePaths: [join(programFiles, 'kitty', 'kitty.exe'), 'kitty.exe'],
+    },
+    {
+      name: 'WezTerm',
+      id: 'org.wezfurlong.wezterm',
+      category: AppCategory.Terminal,
+      exePaths: [
+        join(programFiles, 'WezTerm', 'wezterm-gui.exe'),
+        join(localAppData, 'Programs', 'WezTerm', 'wezterm-gui.exe'),
+        'wezterm.exe',
+      ],
+    },
+    {
+      name: 'Hyper',
+      id: 'co.zeit.hyper',
+      category: AppCategory.Terminal,
+      exePaths: [
+        join(localAppData, 'Programs', 'hyper', 'Hyper.exe'),
+        join(localAppData, 'hyper', 'Hyper.exe'),
+      ],
+    },
+    {
+      name: 'Tabby',
+      id: 'org.tabby',
+      category: AppCategory.Terminal,
+      exePaths: [
+        join(localAppData, 'Programs', 'Tabby', 'Tabby.exe'),
+        join(programFiles, 'Tabby', 'Tabby.exe'),
+      ],
+    },
+    {
+      name: 'Git Bash',
+      id: 'git.bash',
+      category: AppCategory.Terminal,
+      exePaths: [
+        join(programFiles, 'Git', 'git-bash.exe'),
+        join(programFilesX86, 'Git', 'git-bash.exe'),
+      ],
+    },
+    {
+      name: 'Cmder',
+      id: 'cmder',
+      category: AppCategory.Terminal,
+      exePaths: ['cmder.exe'],
+    },
 
-    // Editors
+    // Editors - Mainstream
     {
       name: 'VS Code',
       id: 'com.microsoft.VSCode',
@@ -123,13 +173,46 @@ export const WINDOWS_APPS: WindowsApp[] = (() => {
       exePaths: [
         join(localAppData, 'Programs', 'Microsoft VS Code', 'Code.exe'),
         join(programFiles, 'Microsoft VS Code', 'Code.exe'),
+        'code.cmd',
+      ],
+    },
+    {
+      name: 'VSCodium',
+      id: 'com.vscodium.codium',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'Programs', 'VSCodium', 'VSCodium.exe'),
+        join(programFiles, 'VSCodium', 'VSCodium.exe'),
+        'codium.cmd',
       ],
     },
     {
       name: 'Cursor',
       id: 'com.todesktop.230313mzl4w4u92',
       category: AppCategory.Editor,
-      exePaths: [join(localAppData, 'Programs', 'cursor', 'Cursor.exe')],
+      exePaths: [
+        join(localAppData, 'Programs', 'cursor', 'Cursor.exe'),
+        join(localAppData, 'cursor', 'Cursor.exe'),
+      ],
+    },
+    {
+      name: 'Windsurf',
+      id: 'com.exafunction.windsurf',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'Programs', 'windsurf', 'Windsurf.exe'),
+        join(localAppData, 'windsurf', 'Windsurf.exe'),
+      ],
+    },
+    {
+      name: 'Zed',
+      id: 'dev.zed.Zed',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'Programs', 'Zed', 'Zed.exe'),
+        join(localAppData, 'Zed', 'Zed.exe'),
+        'zed.exe',
+      ],
     },
     {
       name: 'Sublime Text',
@@ -138,6 +221,7 @@ export const WINDOWS_APPS: WindowsApp[] = (() => {
       exePaths: [
         join(programFiles, 'Sublime Text', 'sublime_text.exe'),
         join(programFiles, 'Sublime Text 3', 'sublime_text.exe'),
+        'subl.exe',
       ],
     },
     {
@@ -149,19 +233,156 @@ export const WINDOWS_APPS: WindowsApp[] = (() => {
         join(programFilesX86, 'Notepad++', 'notepad++.exe'),
       ],
     },
+    {
+      name: 'Vim',
+      id: 'org.vim.vim',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(programFiles, 'Vim', 'vim91', 'gvim.exe'),
+        join(programFiles, 'Vim', 'vim90', 'gvim.exe'),
+        join(programFilesX86, 'Vim', 'vim91', 'gvim.exe'),
+        'gvim.exe',
+        'vim.exe',
+      ],
+    },
+    {
+      name: 'Neovim',
+      id: 'io.neovim.nvim',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(programFiles, 'Neovim', 'bin', 'nvim.exe'),
+        join(localAppData, 'Programs', 'Neovim', 'bin', 'nvim.exe'),
+        'nvim.exe',
+      ],
+    },
+    {
+      name: 'Emacs',
+      id: 'org.gnu.emacs',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(programFiles, 'Emacs', 'emacs-29.1', 'bin', 'runemacs.exe'),
+        join(programFiles, 'Emacs', 'bin', 'runemacs.exe'),
+        'emacs.exe',
+      ],
+    },
+    {
+      name: 'Android Studio',
+      id: 'com.google.android.studio',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(programFiles, 'Android', 'Android Studio', 'bin', 'studio64.exe'),
+        join(localAppData, 'Programs', 'Android Studio', 'bin', 'studio64.exe'),
+        'studio64.exe',
+      ],
+    },
+    {
+      name: 'Fleet',
+      id: 'com.jetbrains.fleet',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'Fleet', 'ch-0'),
+        join(localAppData, 'Programs', 'Fleet', 'Fleet.exe'),
+      ],
+    },
 
-    // JetBrains (Toolbox installs)
+    // JetBrains IDEs
     {
       name: 'IntelliJ IDEA',
       id: 'com.jetbrains.intellij',
       category: AppCategory.Editor,
-      exePaths: [join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'IDEA-U', 'ch-0')],
+      exePaths: [
+        // Toolbox install
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'IDEA-U', 'ch-0'),
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'IDEA-C', 'ch-0'),
+        // Standalone install
+        join(programFiles, 'JetBrains', 'IntelliJ IDEA', 'bin', 'idea64.exe'),
+        join(programFiles, 'JetBrains', 'IntelliJ IDEA Community Edition', 'bin', 'idea64.exe'),
+        // CLI command
+        'idea64.exe',
+        'idea.exe',
+      ],
     },
     {
       name: 'WebStorm',
       id: 'com.jetbrains.WebStorm',
       category: AppCategory.Editor,
-      exePaths: [join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'WebStorm', 'ch-0')],
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'WebStorm', 'ch-0'),
+        join(programFiles, 'JetBrains', 'WebStorm', 'bin', 'webstorm64.exe'),
+        'webstorm64.exe',
+      ],
+    },
+    {
+      name: 'PyCharm',
+      id: 'com.jetbrains.pycharm',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'PyCharm-P', 'ch-0'),
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'PyCharm-C', 'ch-0'),
+        join(programFiles, 'JetBrains', 'PyCharm', 'bin', 'pycharm64.exe'),
+        join(programFiles, 'JetBrains', 'PyCharm Community Edition', 'bin', 'pycharm64.exe'),
+        'pycharm64.exe',
+      ],
+    },
+    {
+      name: 'GoLand',
+      id: 'com.jetbrains.goland',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'Goland', 'ch-0'),
+        join(programFiles, 'JetBrains', 'GoLand', 'bin', 'goland64.exe'),
+        'goland64.exe',
+      ],
+    },
+    {
+      name: 'CLion',
+      id: 'com.jetbrains.CLion',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'CLion', 'ch-0'),
+        join(programFiles, 'JetBrains', 'CLion', 'bin', 'clion64.exe'),
+        'clion64.exe',
+      ],
+    },
+    {
+      name: 'RustRover',
+      id: 'com.jetbrains.rustrover',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'RustRover', 'ch-0'),
+        join(programFiles, 'JetBrains', 'RustRover', 'bin', 'rustrover64.exe'),
+        'rustrover64.exe',
+      ],
+    },
+    {
+      name: 'Rider',
+      id: 'com.jetbrains.rider',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'Rider', 'ch-0'),
+        join(programFiles, 'JetBrains', 'Rider', 'bin', 'rider64.exe'),
+        'rider64.exe',
+      ],
+    },
+    {
+      name: 'PhpStorm',
+      id: 'com.jetbrains.PhpStorm',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'PhpStorm', 'ch-0'),
+        join(programFiles, 'JetBrains', 'PhpStorm', 'bin', 'phpstorm64.exe'),
+        'phpstorm64.exe',
+      ],
+    },
+    {
+      name: 'DataGrip',
+      id: 'com.jetbrains.datagrip',
+      category: AppCategory.Editor,
+      exePaths: [
+        join(localAppData, 'JetBrains', 'Toolbox', 'apps', 'datagrip', 'ch-0'),
+        join(programFiles, 'JetBrains', 'DataGrip', 'bin', 'datagrip64.exe'),
+        'datagrip64.exe',
+      ],
     },
 
     // System


### PR DESCRIPTION
## Summary
- 新增终端检测: Kitty, WezTerm, Hyper, Tabby, Git Bash, Cmder
- 新增编辑器检测: VSCodium, Windsurf, Zed, Vim, Neovim, Emacs, Android Studio, Fleet
- 完善 JetBrains IDE 检测: PyCharm, GoLand, CLion, RustRover, Rider, PhpStorm, DataGrip
- IntelliJ IDEA/WebStorm 增加独立安装路径支持

## Test plan
- [ ] Windows 环境下测试各软件检测
- [ ] 验证 Toolbox 安装方式检测
- [ ] 验证独立安装方式检测
- [ ] 验证 PATH 命令检测