### PR TITLE
fix(shell): 统一 shell 配置，修复 commit message 生成解析失败问题

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { type FileChangeStatus, IPC_CHANNELS } from '@shared/types';
 import { ipcMain } from 'electron';
 import { GitService } from '../services/git/GitService';
-import { findLoginShell, getEnhancedPath } from '../services/terminal/PtyManager';
+import { getEnvForCommand, getShellForCommand } from '../utils/shell';
 
 const gitServices = new Map<string, GitService>();
 
@@ -250,14 +250,13 @@ ${truncatedDiff}`;
           options.model || 'haiku',
         ];
 
-        // Use login shell to load user environment (nvm, homebrew, etc.)
-        // Same approach as AgentTerminal for consistent shell configuration
+        // Use user's configured shell to load environment (nvm, homebrew, etc.)
         const claudeCommand = `claude ${claudeArgs.join(' ')}`;
-        const { shell, args: shellArgs } = findLoginShell();
+        const { shell, args: shellArgs } = getShellForCommand();
 
         const proc = spawn(shell, [...shellArgs, claudeCommand], {
           cwd: resolved,
-          env: { ...process.env, PATH: getEnhancedPath() },
+          env: getEnvForCommand(),
         });
 
         // Handle stdin errors to prevent EPIPE crashes
@@ -417,11 +416,11 @@ ${gitLog || '(No commit history available)'}`;
       ];
 
       const claudeCommand = `claude ${claudeArgs.join(' ')}`;
-      const { shell, args: shellArgs } = findLoginShell();
+      const { shell, args: shellArgs } = getShellForCommand();
 
       const proc = spawn(shell, [...shellArgs, claudeCommand], {
         cwd: resolved,
-        env: { ...process.env, PATH: getEnhancedPath() },
+        env: getEnvForCommand(),
       });
 
       activeCodeReviews.set(reviewId, proc);

--- a/src/main/ipc/hapi.ts
+++ b/src/main/ipc/hapi.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { IPC_CHANNELS, type ShellConfig } from '@shared/types';
+import { IPC_CHANNELS } from '@shared/types';
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { type CloudflaredConfig, cloudflaredManager } from '../services/hapi/CloudflaredManager';
 import { type HapiConfig, hapiServerManager } from '../services/hapi/HapiServerManager';
@@ -21,20 +21,14 @@ interface StoredHapiSettings {
 
 export function registerHapiHandlers(): void {
   // Check global hapi installation (cached)
-  ipcMain.handle(
-    IPC_CHANNELS.HAPI_CHECK_GLOBAL,
-    async (_, forceRefresh?: boolean, shellConfig?: ShellConfig) => {
-      return await hapiServerManager.checkGlobalInstall(forceRefresh, shellConfig);
-    }
-  );
+  ipcMain.handle(IPC_CHANNELS.HAPI_CHECK_GLOBAL, async (_, forceRefresh?: boolean) => {
+    return await hapiServerManager.checkGlobalInstall(forceRefresh);
+  });
 
   // Check global happy installation (cached)
-  ipcMain.handle(
-    IPC_CHANNELS.HAPPY_CHECK_GLOBAL,
-    async (_, forceRefresh?: boolean, shellConfig?: ShellConfig) => {
-      return await hapiServerManager.checkHappyGlobalInstall(forceRefresh, shellConfig);
-    }
-  );
+  ipcMain.handle(IPC_CHANNELS.HAPPY_CHECK_GLOBAL, async (_, forceRefresh?: boolean) => {
+    return await hapiServerManager.checkHappyGlobalInstall(forceRefresh);
+  });
 
   // Hapi Server handlers
   ipcMain.handle(IPC_CHANNELS.HAPI_START, async (_, config: HapiConfig) => {

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -7,6 +7,22 @@ function getSettingsPath(): string {
   return join(app.getPath('userData'), 'settings.json');
 }
 
+/**
+ * Read settings from disk (for use in main process)
+ */
+export function readSettings(): Record<string, unknown> | null {
+  try {
+    const settingsPath = getSettingsPath();
+    if (existsSync(settingsPath)) {
+      const data = readFileSync(settingsPath, 'utf-8');
+      return JSON.parse(data);
+    }
+  } catch {
+    // Return null if file doesn't exist or is corrupted
+  }
+  return null;
+}
+
 export function registerSettingsHandlers(): void {
   ipcMain.handle(IPC_CHANNELS.SETTINGS_READ, async () => {
     try {

--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared shell utilities for consistent shell configuration across the app.
+ * Reads user's shell config from settings and provides consistent environment.
+ */
+
+import type { ShellConfig } from '@shared/types';
+import { readSettings } from '../ipc/settings';
+import { findLoginShell, getEnhancedPath } from '../services/terminal/PtyManager';
+import { shellDetector } from '../services/terminal/ShellDetector';
+
+/**
+ * Get shell configuration for executing commands.
+ * Uses user's configured shell from settings, falls back to findLoginShell.
+ */
+export function getShellForCommand(): { shell: string; args: string[] } {
+  const settings = readSettings();
+  const shellConfig = settings?.shellConfig as ShellConfig | undefined;
+
+  if (shellConfig) {
+    const { shell, execArgs } = shellDetector.resolveShellForCommand(shellConfig);
+    return { shell, args: execArgs };
+  }
+
+  return findLoginShell();
+}
+
+/**
+ * Get environment variables for executing commands.
+ * Includes enhanced PATH and proper locale settings.
+ */
+export function getEnvForCommand(additionalEnv?: Record<string, string>): Record<string, string> {
+  return {
+    ...process.env,
+    PATH: getEnhancedPath(),
+    LANG: process.env.LANG || 'en_US.UTF-8',
+    LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
+    ...additionalEnv,
+  } as Record<string, string>;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -290,13 +290,13 @@ const electronAPI = {
   cli: {
     detect: (
       customAgents?: CustomAgent[],
-      options?: { includeWsl?: boolean; forceRefresh?: boolean; shellConfig?: ShellConfig }
+      options?: { includeWsl?: boolean; forceRefresh?: boolean }
     ): Promise<AgentCliStatus> =>
       ipcRenderer.invoke(IPC_CHANNELS.CLI_DETECT, customAgents, options),
     detectOne: (
       agentId: string,
       customAgent?: CustomAgent,
-      options?: { shellConfig?: ShellConfig }
+      options?: { includeWsl?: boolean }
     ): Promise<AgentCliInfo> =>
       ipcRenderer.invoke(IPC_CHANNELS.CLI_DETECT_ONE, agentId, customAgent, options),
     // CLI Installer
@@ -427,11 +427,8 @@ const electronAPI = {
 
   // Hapi Remote Sharing
   hapi: {
-    checkGlobal: (
-      forceRefresh?: boolean,
-      shellConfig?: ShellConfig
-    ): Promise<{ installed: boolean; version?: string }> =>
-      ipcRenderer.invoke(IPC_CHANNELS.HAPI_CHECK_GLOBAL, forceRefresh, shellConfig),
+    checkGlobal: (forceRefresh?: boolean): Promise<{ installed: boolean; version?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.HAPI_CHECK_GLOBAL, forceRefresh),
     start: (config: {
       webappPort: number;
       cliApiToken: string;
@@ -487,11 +484,8 @@ const electronAPI = {
 
   // Happy
   happy: {
-    checkGlobal: (
-      forceRefresh?: boolean,
-      shellConfig?: ShellConfig
-    ): Promise<{ installed: boolean; version?: string }> =>
-      ipcRenderer.invoke(IPC_CHANNELS.HAPPY_CHECK_GLOBAL, forceRefresh, shellConfig),
+    checkGlobal: (forceRefresh?: boolean): Promise<{ installed: boolean; version?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.HAPPY_CHECK_GLOBAL, forceRefresh),
   },
 
   // Cloudflared Tunnel

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -61,11 +61,11 @@ export function AgentTerminal({
   // Check hapi global installation on mount (only for hapi environment)
   useEffect(() => {
     if (environment === 'hapi') {
-      window.electronAPI.hapi.checkGlobal(false, shellConfig).then((status) => {
+      window.electronAPI.hapi.checkGlobal(false).then((status) => {
         setHapiGlobalInstalled(status.installed);
       });
     }
-  }, [environment, shellConfig]);
+  }, [environment]);
   const outputBufferRef = useRef('');
   const startTimeRef = useRef<number | null>(null);
   const hasInitializedRef = useRef(false);

--- a/src/renderer/components/chat/SessionBar.tsx
+++ b/src/renderer/components/chat/SessionBar.tsx
@@ -76,7 +76,7 @@ export function SessionBar({
   const dragStart = useRef({ x: 0, y: 0, startX: 0, startY: 0 });
 
   // Get enabled agents from settings
-  const { agentSettings, customAgents, hapiSettings, shellConfig } = useSettingsStore();
+  const { agentSettings, customAgents, hapiSettings } = useSettingsStore();
 
   // Detect installed agents on mount only (uses cached results from main process)
   useEffect(() => {
@@ -94,17 +94,13 @@ export function SessionBar({
         const baseId = agentId.slice(0, -5);
         const customAgent = customAgents.find((a) => a.id === baseId);
         // Check native first
-        const nativeResult = await window.electronAPI.cli.detectOne(baseId, customAgent, {
-          shellConfig,
-        });
+        const nativeResult = await window.electronAPI.cli.detectOne(baseId, customAgent);
         if (nativeResult.installed) {
           newInstalled.add(agentId);
           return;
         }
         // If not installed natively, check WSL (Windows only)
-        const wslResult = await window.electronAPI.cli.detectOne(`${baseId}-wsl`, customAgent, {
-          shellConfig,
-        });
+        const wslResult = await window.electronAPI.cli.detectOne(`${baseId}-wsl`, customAgent);
         if (wslResult.installed) {
           newInstalled.add(agentId);
         }
@@ -115,23 +111,19 @@ export function SessionBar({
       const isHappy = agentId.endsWith('-happy');
       if (isHappy) {
         // Check if happy is globally installed first
-        const happyStatus = await window.electronAPI.happy.checkGlobal(false, shellConfig);
+        const happyStatus = await window.electronAPI.happy.checkGlobal(false);
         if (!happyStatus.installed) return;
 
         const baseId = agentId.slice(0, -6);
         const customAgent = customAgents.find((a) => a.id === baseId);
         // Check native first
-        const nativeResult = await window.electronAPI.cli.detectOne(baseId, customAgent, {
-          shellConfig,
-        });
+        const nativeResult = await window.electronAPI.cli.detectOne(baseId, customAgent);
         if (nativeResult.installed) {
           newInstalled.add(agentId);
           return;
         }
         // If not installed natively, check WSL (Windows only)
-        const wslResult = await window.electronAPI.cli.detectOne(`${baseId}-wsl`, customAgent, {
-          shellConfig,
-        });
+        const wslResult = await window.electronAPI.cli.detectOne(`${baseId}-wsl`, customAgent);
         if (wslResult.installed) {
           newInstalled.add(agentId);
         }
@@ -143,7 +135,7 @@ export function SessionBar({
       const baseId = isWsl ? agentId.slice(0, -4) : agentId;
       const customAgent = customAgents.find((a) => a.id === baseId);
 
-      const result = await window.electronAPI.cli.detectOne(agentId, customAgent, { shellConfig });
+      const result = await window.electronAPI.cli.detectOne(agentId, customAgent);
       if (result.installed) {
         newInstalled.add(agentId);
       }
@@ -152,7 +144,7 @@ export function SessionBar({
     Promise.all(detectPromises).then(() => {
       setInstalledAgents(newInstalled);
     });
-  }, [agentSettings, customAgents, hapiSettings.enabled, shellConfig]);
+  }, [agentSettings, customAgents, hapiSettings.enabled]);
 
   // Filter to only enabled AND installed agents (includes WSL/Hapi variants)
   // For Hapi agents, also check if hapi is still enabled

--- a/src/renderer/components/settings/AgentSettings.tsx
+++ b/src/renderer/components/settings/AgentSettings.tsx
@@ -101,7 +101,6 @@ export function AgentSettings() {
     customAgents,
     wslEnabled,
     hapiSettings,
-    shellConfig,
     setAgentEnabled,
     setAgentDefault,
     addCustomAgent,
@@ -192,10 +191,10 @@ export function AgentSettings() {
 
   // Check happy global installation on mount
   React.useEffect(() => {
-    window.electronAPI.happy.checkGlobal(false, shellConfig).then((result) => {
+    window.electronAPI.happy.checkGlobal(false).then((result) => {
       setHappyGlobal(result);
     });
-  }, [shellConfig]);
+  }, []);
 
   // Get all agents including WSL and Hapi variants
   const allAgentInfos = React.useMemo(() => {

--- a/src/renderer/components/settings/HapiSettings.tsx
+++ b/src/renderer/components/settings/HapiSettings.tsx
@@ -72,12 +72,12 @@ export function HapiSettings() {
   // Fetch initial status
   React.useEffect(() => {
     // Check hapi global installation
-    window.electronAPI.hapi.checkGlobal(false, shellConfig).then((result) => {
+    window.electronAPI.hapi.checkGlobal(false).then((result) => {
       setHapiGlobal(result);
     });
 
     // Check happy global installation
-    window.electronAPI.happy.checkGlobal(false, shellConfig).then((result) => {
+    window.electronAPI.happy.checkGlobal(false).then((result) => {
       setHappyGlobal(result);
     });
 
@@ -110,7 +110,7 @@ export function HapiSettings() {
       cleanupHapi();
       cleanupCf();
     };
-  }, [setHapiSettings, shellConfig]);
+  }, [setHapiSettings]);
 
   const getConfig = React.useCallback(() => {
     return {


### PR DESCRIPTION
## Summary
- 创建共享 shell 工具模块 (`src/main/utils/shell.ts`)，提供 `getShellForCommand()` 和 `getEnvForCommand()` 函数
- 统一从 settings 读取用户配置的 shell，移除 `setShellConfig` 依赖
- 添加 `LANG`/`LC_ALL` 环境变量确保 UTF-8 输出，修复 JSON 解析失败问题
- 简化 API，移除调用方传入 `shellConfig` 的需求

## 修复问题
- Commit Message 生成时 `Failed to parse response` 错误
- Code Review 可能遇到的相同问题
- Shell 配置不一致导致的环境变量缺失

## 修改范围
| 文件 | 修改内容 |
|------|---------|
| `src/main/utils/shell.ts` | 新增共享 shell 工具模块 |
| `src/main/ipc/settings.ts` | 导出 `readSettings()` 函数 |
| `src/main/ipc/git.ts` | 使用共享模块 |
| `src/main/ipc/hapi.ts` | 移除 `shellConfig` 参数 |
| `src/main/services/hapi/HapiServerManager.ts` | 使用共享模块 |
| `src/main/services/cli/CliDetector.ts` | 使用共享模块 |
| `src/preload/index.ts` | 移除 `shellConfig` 参数 |
| `src/renderer/components/*` | 移除 `shellConfig` 参数传递 |

## Test plan
- [ ] 测试 Commit Message 生成功能
- [ ] 测试 Code Review 功能
- [ ] 测试 Agent CLI 检测功能
- [ ] 测试 Hapi 全局安装检测