### PR TITLE
fix(settings): 修复快捷键设置升级后新增字段丢失的问题

### DIFF
--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -581,6 +581,55 @@ export const useSettingsStore = create<SettingsState>()(
     {
       name: 'enso-settings',
       storage: createJSONStorage(() => electronStorage),
+      // Deep merge nested objects to preserve new default fields when upgrading
+      merge: (persistedState, currentState) => {
+        const persisted = persistedState as Partial<SettingsState>;
+        return {
+          ...currentState,
+          ...persisted,
+          // Deep merge keybindings to ensure new fields get default values
+          terminalKeybindings: {
+            ...currentState.terminalKeybindings,
+            ...persisted.terminalKeybindings,
+          },
+          mainTabKeybindings: {
+            ...currentState.mainTabKeybindings,
+            ...persisted.mainTabKeybindings,
+          },
+          agentKeybindings: {
+            ...currentState.agentKeybindings,
+            ...persisted.agentKeybindings,
+          },
+          sourceControlKeybindings: {
+            ...currentState.sourceControlKeybindings,
+            ...persisted.sourceControlKeybindings,
+          },
+          searchKeybindings: {
+            ...currentState.searchKeybindings,
+            ...persisted.searchKeybindings,
+          },
+          editorSettings: {
+            ...currentState.editorSettings,
+            ...persisted.editorSettings,
+          },
+          claudeCodeIntegration: {
+            ...currentState.claudeCodeIntegration,
+            ...persisted.claudeCodeIntegration,
+          },
+          commitMessageGenerator: {
+            ...currentState.commitMessageGenerator,
+            ...persisted.commitMessageGenerator,
+          },
+          codeReview: {
+            ...currentState.codeReview,
+            ...persisted.codeReview,
+          },
+          hapiSettings: {
+            ...currentState.hapiSettings,
+            ...persisted.hapiSettings,
+          },
+        };
+      },
       onRehydrateStorage: () => (state) => {
         if (state) {
           if (state.theme === 'sync-terminal') {


### PR DESCRIPTION
## Summary
- 修复 agent 和 terminal 的上/下一个标签快捷键不可用的问题
- zustand persist 默认浅合并导致新增的 `nextTab`/`prevTab`/`nextSession`/`prevSession` 字段被覆盖为 `undefined`
- 添加 `merge` 函数对嵌套设置对象进行深度合并

## Test plan
- [ ] 清除本地设置文件后启动应用，验证默认快捷键生效
- [ ] 使用旧版本设置文件启动应用，验证新增快捷键字段正确填充默认值
- [ ] 在设置中修改快捷键，验证保存和加载正常