### PR TITLE
feat(worktree): 添加打开文件夹功能

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -333,6 +333,7 @@ const electronAPI = {
     resolveForCommand: (config: ShellConfig): Promise<{ shell: string; execArgs: string[] }> =>
       ipcRenderer.invoke(IPC_CHANNELS.SHELL_RESOLVE_FOR_COMMAND, config),
     openExternal: (url: string): Promise<void> => shell.openExternal(url),
+    openPath: (path: string): Promise<string> => shell.openPath(path),
   },
 
   // Menu actions from main process

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -4,6 +4,7 @@ import {
   ChevronRight,
   FolderGit2,
   FolderMinus,
+  FolderOpen,
   GitBranch,
   GitMerge,
   PanelLeftClose,
@@ -514,9 +515,15 @@ export function TreeSidebar({
                           isSelected ? 'text-accent-foreground' : 'text-muted-foreground'
                         )}
                       />
-                      <span className="min-w-0 flex-1 truncate font-medium text-sm text-left">
-                        {repo.name}
-                      </span>
+                      <div className="min-w-0 flex-1 flex flex-col">
+                        <span className="truncate font-medium text-sm text-left">{repo.name}</span>
+                        <span
+                          className="overflow-hidden whitespace-nowrap text-ellipsis text-xs text-muted-foreground [direction:rtl] [text-align:left]"
+                          title={repo.path}
+                        >
+                          {repo.path}
+                        </span>
+                      </div>
                     </button>
                     {/* Drop indicator - bottom */}
                     {dropRepoTargetIndex === index &&
@@ -654,7 +661,7 @@ export function TreeSidebar({
           >
             <button
               type="button"
-              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent"
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-red-600 dark:text-red-400 hover:bg-accent"
               onClick={handleRemoveRepoClick}
             >
               <FolderMinus className="h-4 w-4" />
@@ -917,11 +924,8 @@ function WorktreeTreeItem({
                   : 'text-muted-foreground'
             )}
           />
-          <div className="min-w-0 flex-1 flex flex-col">
+          <div className="min-w-0 flex-1">
             <span className={cn('truncate', isPrunable && 'line-through')}>{branchDisplay}</span>
-            <span className="truncate text-[10px] text-muted-foreground" title={worktree.path}>
-              {worktree.path}
-            </span>
           </div>
           {isPrunable ? (
             <span className="shrink-0 rounded bg-destructive/20 px-1 py-0.5 text-[9px] font-medium uppercase text-destructive">
@@ -1037,6 +1041,19 @@ function WorktreeTreeItem({
             {/* Separator if there are activity options */}
             {hasActivity && <div className="my-1 h-px bg-border" />}
 
+            {/* Open Folder */}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent/50"
+              onClick={() => {
+                setMenuOpen(false);
+                window.electronAPI.shell.openPath(worktree.path);
+              }}
+            >
+              <FolderOpen className="h-4 w-4" />
+              {t('Open folder')}
+            </button>
+
             {/* Merge to Branch */}
             {onMerge && !isMain && !isPrunable && (
               <button
@@ -1059,7 +1076,7 @@ function WorktreeTreeItem({
             <button
               type="button"
               className={cn(
-                'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-accent/50',
+                'flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-red-600 dark:text-red-400 hover:bg-accent/50',
                 isMain && 'pointer-events-none opacity-50'
               )}
               onClick={() => {

--- a/src/renderer/components/layout/WorktreePanel.tsx
+++ b/src/renderer/components/layout/WorktreePanel.tsx
@@ -608,13 +608,14 @@ function WorktreeItem({
             )}
           </div>
 
-          {/* Path */}
+          {/* Path - use rtl direction to show ellipsis at start, keeping end visible */}
           <div
             className={cn(
-              'w-full truncate pl-6 text-xs',
+              'w-full overflow-hidden whitespace-nowrap text-ellipsis pl-6 text-xs [direction:rtl] [text-align:left] [unicode-bidi:plaintext]',
               isPrunable && 'line-through',
               isActive ? 'text-accent-foreground/70' : 'text-muted-foreground'
             )}
+            title={worktree.path}
           >
             {worktree.path}
           </div>
@@ -723,6 +724,19 @@ function WorktreeItem({
 
             {/* Separator if there are activity options */}
             {hasActivity && <div className="my-1 h-px bg-border" />}
+
+            {/* Open Folder */}
+            <button
+              type="button"
+              className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent/50"
+              onClick={() => {
+                setMenuOpen(false);
+                window.electronAPI.shell.openPath(worktree.path);
+              }}
+            >
+              <FolderOpen className="h-4 w-4" />
+              {t('Open folder')}
+            </button>
 
             {/* Merge to Branch */}
             {onMerge && !isMain && !isPrunable && (


### PR DESCRIPTION
<img width="772" height="254" alt="image" src="https://github.com/user-attachments/assets/56e6568c-14a3-4fee-8965-4f0afd636e28" />

同时调整项目路径显示改到项目名称下面，同时改为显示末尾路径，因为前面路径都是一样的，无法看出来到底是哪一个目录
