### PR TITLE
fix(dev): 修复开发模式下 Ctrl+C 退出时子进程残留问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "type": "module",
   "packageManager": "pnpm@10.26.2",
   "scripts": {
-    "dev": "electron-vite dev",
+    "dev": "node scripts/dev.js",
     "build": "electron-vite build",
     "preview": "electron-vite preview",
     "start": "electron-vite preview",

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Dev server wrapper that ensures clean shutdown on Ctrl+C.
+ * electron-vite doesn't properly forward SIGINT to Electron subprocess.
+ */
+import { spawn, spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = join(__dirname, '..');
+
+// Start electron-vite in a new process group so we can kill the entire tree
+const child = spawn(process.platform === 'win32' ? 'npx.cmd' : 'npx', ['electron-vite', 'dev'], {
+  cwd: root,
+  stdio: 'inherit',
+  detached: process.platform !== 'win32', // Create new process group on Unix
+});
+
+let shuttingDown = false;
+
+function sleep(ms) {
+  const durationMs = Number(ms);
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return;
+
+  if (process.platform === 'win32') {
+    // `ping -n` is seconds-based; `-n (seconds + 1)` because the first ping is sent immediately.
+    const seconds = Math.ceil(durationMs / 1000);
+    spawnSync('ping', ['-n', String(seconds + 1), '127.0.0.1'], { stdio: 'ignore' });
+    return;
+  }
+
+  // macOS/Linux: `sleep` supports fractional seconds on typical environments.
+  spawnSync('sleep', [String(durationMs / 1000)], { stdio: 'ignore' });
+}
+
+function collectProcessTreePids(rootPid) {
+  const ps = spawnSync('ps', ['-A', '-o', 'pid=', '-o', 'ppid='], { encoding: 'utf8' });
+  if (ps.status !== 0 || typeof ps.stdout !== 'string') return [rootPid];
+
+  const childrenByParent = new Map();
+  for (const line of ps.stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const [pidStr, ppidStr] = trimmed.split(/\s+/, 2);
+    const pid = Number(pidStr);
+    const ppid = Number(ppidStr);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    const siblings = childrenByParent.get(ppid);
+    if (siblings) siblings.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+
+  const pids = [];
+  const seen = new Set();
+  const stack = [rootPid];
+  while (stack.length) {
+    const pid = stack.pop();
+    if (!pid || seen.has(pid)) continue;
+    seen.add(pid);
+    pids.push(pid);
+    const children = childrenByParent.get(pid);
+    if (children) stack.push(...children);
+  }
+  return pids;
+}
+
+function signalPids(pids, signal) {
+  for (const pid of [...pids].reverse()) {
+    try {
+      process.kill(pid, signal);
+    } catch {
+      // ignore
+    }
+  }
+}
+
+function shutdown(signal) {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  console.log(`\n[dev] ${signal} - shutting down...`);
+
+  if (child.pid) {
+    if (process.platform === 'win32') {
+      // Windows: use taskkill to kill process tree
+      spawnSync('taskkill', ['/pid', child.pid.toString(), '/t', '/f'], { stdio: 'ignore' });
+    } else {
+      // Unix: kill the entire process tree (Electron may spawn its own process group)
+      const pids = collectProcessTreePids(child.pid);
+      signalPids(pids, 'SIGTERM');
+      if (pids.length <= 1) {
+        // Fallback: try killing the whole process group when process tree is unavailable
+        try {
+          process.kill(-child.pid, 'SIGTERM');
+        } catch {
+          // ignore
+        }
+      }
+      sleep(400);
+      signalPids(pids, 'SIGKILL');
+      if (pids.length <= 1) {
+        try {
+          process.kill(-child.pid, 'SIGKILL');
+        } catch {
+          // ignore
+        }
+      }
+    }
+  }
+
+  process.exit(0);
+}
+
+process.on('SIGINT', () => shutdown('SIGINT'));
+process.on('SIGTERM', () => shutdown('SIGTERM'));
+child.on('close', (code) => process.exit(shuttingDown ? 0 : (code ?? 0)));

--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -152,3 +152,14 @@ export async function stopAllFileWatchers(): Promise<void> {
   await Promise.all(stopPromises);
   watchers.clear();
 }
+
+/**
+ * Synchronous version for signal handlers.
+ * Fires unsubscribe without waiting - process will exit anyway.
+ */
+export function stopAllFileWatchersSync(): void {
+  for (const watcher of watchers.values()) {
+    watcher.stop().catch(() => {});
+  }
+  watchers.clear();
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -3,7 +3,7 @@ import { registerAgentHandlers } from './agent';
 import { registerAppHandlers } from './app';
 import { registerCliHandlers } from './cli';
 import { registerDialogHandlers } from './dialog';
-import { registerFileHandlers, stopAllFileWatchers } from './files';
+import { registerFileHandlers, stopAllFileWatchers, stopAllFileWatchersSync } from './files';
 import { clearAllGitServices, registerGitHandlers } from './git';
 import { autoStartHapi, cleanupHapi, registerHapiHandlers } from './hapi';
 
@@ -77,4 +77,31 @@ export async function cleanupAllResources(): Promise<void> {
 
   // Dispose Claude IDE Bridge
   disposeClaudeIdeBridge();
+}
+
+/**
+ * Synchronous cleanup for signal handlers (SIGINT/SIGTERM).
+ * Kills child processes immediately without waiting for graceful shutdown.
+ * This ensures clean exit when electron-vite terminates quickly.
+ */
+export function cleanupAllResourcesSync(): void {
+  console.log('[app] Sync cleanup starting...');
+
+  // Kill Hapi/Cloudflared processes (sync)
+  cleanupHapi();
+
+  // Kill all PTY sessions immediately (sync)
+  destroyAllTerminals();
+
+  // Stop file watchers (sync)
+  stopAllFileWatchersSync();
+
+  // Clear service caches (sync)
+  clearAllGitServices();
+  clearAllWorktreeServices();
+
+  // Dispose Claude IDE Bridge (sync)
+  disposeClaudeIdeBridge();
+
+  console.log('[app] Sync cleanup done');
 }


### PR DESCRIPTION
只测试了mac下，目前当使用pnpm dev 使用ctrl + c 结束进程会导致electron进程残留，从而当再次启动pnpm dev 时无法加载项目列表