### PR TITLE
fix(dev): 修复 Linux 下 Electron 沙箱启动失败问题

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -11,7 +11,12 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');
 
 // Start electron-vite in a new process group so we can kill the entire tree
-const child = spawn('npx', ['electron-vite', 'dev'], {
+// On Linux, --no-sandbox is needed when unprivileged user namespaces are disabled
+const electronArgs = ['electron-vite', 'dev'];
+if (process.platform === 'linux') {
+  electronArgs.push('--', '--no-sandbox');
+}
+const child = spawn('npx', electronArgs, {
   cwd: root,
   stdio: 'inherit',
   shell: process.platform === 'win32', // Use shell on Windows to avoid EINVAL errors


### PR DESCRIPTION
## Summary

- 在 Linux 系统上为 electron-vite dev 添加 `--no-sandbox` 参数
- 解决某些 Linux 发行版（如 Ubuntu/Debian）未启用非特权用户命名空间导致的 Electron 启动失败问题
- 仅对 Linux 平台生效，不影响 Windows 和 macOS

## 背景

Chromium 的 Linux 沙箱依赖于非特权用户命名空间（unprivileged user namespaces），但某些 Linux 内核配置未启用此功能，会导致 Electron 应用启动失败。添加 `--no-sandbox` 参数可以绕过此限制。

参考：
- [Electron Sandbox 文档](https://electronjs.org/docs/latest/tutorial/sandbox)
- [AppImage Electron 沙箱问题](https://docs.appimage.org/user-guide/troubleshooting/electron-sandboxing.html)

## Test plan

- [ ] 在 Linux 上运行 `pnpm dev` 验证可正常启动
- [ ] 在 Windows/macOS 上运行 `pnpm dev` 验证不受影响