### PR TITLE
fix(windows): 修复退出应用时未正确杀死进程树的问题

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -5,7 +5,7 @@ import path from 'node:path';
 import { type FileChangeStatus, IPC_CHANNELS } from '@shared/types';
 import { ipcMain } from 'electron';
 import { GitService } from '../services/git/GitService';
-import { getEnvForCommand, getShellForCommand } from '../utils/shell';
+import { getEnvForCommand, getShellForCommand, killProcessTree } from '../utils/shell';
 
 const gitServices = new Map<string, GitService>();
 
@@ -278,7 +278,7 @@ ${truncatedDiff}`;
         let stderr = '';
 
         const timer = setTimeout(() => {
-          proc.kill('SIGTERM');
+          killProcessTree(proc);
           resolve({ success: false, error: 'timeout' });
         }, timeoutMs);
 
@@ -516,7 +516,7 @@ ${gitLog || '(No commit history available)'}`;
   ipcMain.handle(IPC_CHANNELS.GIT_CODE_REVIEW_STOP, async (_, reviewId: string): Promise<void> => {
     const proc = activeCodeReviews.get(reviewId);
     if (proc) {
-      proc.kill('SIGTERM');
+      killProcessTree(proc);
       activeCodeReviews.delete(reviewId);
     }
   });

--- a/src/main/utils/processUtils.ts
+++ b/src/main/utils/processUtils.ts
@@ -1,0 +1,70 @@
+/**
+ * Process management utilities for consistent process tree handling across the app.
+ */
+
+import type { ChildProcess } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+
+const isWindows = process.platform === 'win32';
+
+/**
+ * Generic interface for process-like objects with pid and kill method
+ */
+interface ProcessLike {
+  pid?: number;
+  kill(signal?: NodeJS.Signals | string): void;
+}
+
+/**
+ * Kill a process and all its children (process tree).
+ * On Windows: uses taskkill /T to kill the process tree synchronously.
+ * On Unix: kills the process group using negative PID, or falls back to regular kill.
+ *
+ * @param target - PID number, ChildProcess, or any object with pid and kill method (e.g., IPty)
+ * @param signal - Signal to send on Unix (default: SIGKILL)
+ */
+export function killProcessTree(
+  target: number | ChildProcess | ProcessLike,
+  signal: NodeJS.Signals = 'SIGKILL'
+): void {
+  // Extract PID from target
+  let pid: number | undefined;
+  if (typeof target === 'number') {
+    pid = target;
+  } else if ('pid' in target) {
+    pid = target.pid;
+  }
+
+  if (!pid) {
+    // No PID available, try to kill directly if possible
+    if (typeof target !== 'number' && 'kill' in target) {
+      try {
+        target.kill(signal);
+      } catch {
+        // Ignore
+      }
+    }
+    return;
+  }
+
+  try {
+    if (isWindows) {
+      // Windows: use taskkill synchronously to kill the entire process tree
+      spawnSync('taskkill', ['/pid', String(pid), '/t', '/f'], { stdio: 'ignore' });
+    } else {
+      // Unix: try to kill the process group first
+      try {
+        process.kill(-pid, signal);
+      } catch {
+        // If process group kill fails, fall back to regular kill
+        if (typeof target !== 'number' && 'kill' in target) {
+          target.kill(signal);
+        } else {
+          process.kill(pid, signal);
+        }
+      }
+    }
+  } catch {
+    // Process may have already exited, ignore errors
+  }
+}


### PR DESCRIPTION
## Summary

修复 Windows 平台退出 Enso 应用后子进程未被正确杀死的问题。

### 问题
- Windows 任务管理器显示 EnsoAI 有大量残留子进程
- `cloudflared` 库的 `tunnel.stop()` 只发送 `SIGINT`，不会杀死进程树
- `PluginsManager.ts` 中的 `execInPty` 超时时只调用 `ptyProcess.kill()`
- `git.ts` 中的 Claude 命令超时/停止时只调用 `proc.kill()`

### 修复
- 新增 `src/main/utils/processUtils.ts` 统一进程树杀死逻辑
- Windows 使用 `taskkill /T /F /PID` 杀死进程树
- Unix 使用负 PID 杀死进程组，fallback 到普通 kill
- 重构合并 6 个文件中重复的 `killProcessTree` 实现

### 影响范围
| 文件 | 变更 |
|------|------|
| `processUtils.ts` | 新增统一的 `killProcessTree` 函数 |
| `shell.ts` | 删除本地实现，改为导入并重新导出 |
| `git.ts` | 删除本地实现，修复 commit msg 超时和 code review 停止 |
| `PtyManager.ts` | 删除内联 taskkill 代码，使用统一函数 |
| `HapiServerManager.ts` | 删除私有方法，使用统一函数 |
| `CloudflaredManager.ts` | 修复 tunnel 进程杀死逻辑 |
| `PluginsManager.ts` | 删除重复的 execInPty 实现，使用 shell.ts 版本 |

## Test Plan

- [ ] Windows 上启动应用，打开终端运行 agent
- [ ] 退出应用后检查任务管理器，确认无残留 node/claude 进程
- [ ] 测试 Hapi 服务器启动/停止
- [ ] 测试 Cloudflared 隧道启动/停止