### PR TITLE
feat(panel): 支持拖拽调整标签页顺序并持久化存储

### DIFF
--- a/src/renderer/App/constants.ts
+++ b/src/renderer/App/constants.ts
@@ -4,6 +4,16 @@ export const panelTransition = { type: 'spring' as const, stiffness: 400, dampin
 // Tab types
 export type TabId = 'chat' | 'file' | 'terminal' | 'source-control';
 
+// Tab metadata configuration
+export interface TabConfig {
+  id: TabId;
+  icon: React.ElementType;
+  labelKey: string;
+}
+
+// Default tab order
+export const DEFAULT_TAB_ORDER: TabId[] = ['chat', 'file', 'terminal', 'source-control'];
+
 // Repository type
 export interface Repository {
   name: string;


### PR DESCRIPTION
  ## 更改内容

  ✨ 支持拖拽调整标签页顺序并持久化存储

  ### 主要改动
  - 实现标签页拖拽排序功能
  - 标签页顺序持久化存储，重启后保持用户自定义顺序
  - 改进面板交互体验

  ### 文件变更
  - `src/renderer/App.tsx`: 添加相关配置
  - `src/renderer/App/constants.ts`: 新增常量定义
  - `src/renderer/App/storage.ts`: 扩展存储功能
  - `src/renderer/components/layout/MainContent.tsx`: 核心拖拽逻辑实现

  ### 统计
  - 4 个文件修改
  - 231 行新增
  - 25 行删除
