### PR TITLE
refactor(search): 使用 @vscode/ripgrep 替代系统 ripgrep

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@shikijs/monaco": "^3.20.0",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-query": "^5.90.16",
+    "@vscode/ripgrep": "^1.17.0",
     "@xterm/addon-fit": "^0.12.0-beta.91",
     "@xterm/addon-search": "^0.17.0-beta.91",
     "@xterm/addon-unicode11": "^0.10.0-beta.91",
@@ -96,6 +97,9 @@
       "dmg-builder": "26.4.0",
       "app-builder-lib": "26.4.0",
       "electron-builder-squirrel-windows": "26.4.0"
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@vscode/ripgrep"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.16
         version: 5.90.16(react@19.2.3)
+      '@vscode/ripgrep':
+        specifier: ^1.17.0
+        version: 1.17.0
       '@xterm/addon-fit':
         specifier: ^0.12.0-beta.91
         version: 0.12.0-beta.91(@xterm/xterm@6.1.0-beta.91)
@@ -1332,6 +1335,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  '@vscode/ripgrep@1.17.0':
+    resolution: {integrity: sha512-mBRKm+ASPkUcw4o9aAgfbusIu6H4Sdhw09bjeP1YOBFTJEZAnrnk6WZwzv8NEjgC82f7ILvhmb1WIElSugea6g==}
 
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
@@ -3024,6 +3030,9 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
@@ -4695,6 +4704,14 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
       vite: 7.3.0(@types/node@25.0.3)(jiti@2.6.1)(lightningcss@1.30.2)(yaml@2.8.2)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vscode/ripgrep@1.17.0':
+    dependencies:
+      https-proxy-agent: 7.0.6
+      proxy-from-env: 1.1.0
+      yauzl: 2.10.0
     transitivePeerDependencies:
       - supports-color
 
@@ -6817,6 +6834,8 @@ snapshots:
       retry: 0.12.0
 
   property-information@7.1.0: {}
+
+  proxy-from-env@1.1.0: {}
 
   pump@3.0.3:
     dependencies:

--- a/src/main/ipc/search.ts
+++ b/src/main/ipc/search.ts
@@ -13,8 +13,4 @@ export function registerSearchHandlers(): void {
     const results = await searchService.searchContent(params);
     return results;
   });
-
-  ipcMain.handle(IPC_CHANNELS.SEARCH_CHECK_RG, () => {
-    return searchService.checkRipgrep();
-  });
 }

--- a/src/main/services/search/SearchService.ts
+++ b/src/main/services/search/SearchService.ts
@@ -1,7 +1,7 @@
-import { execSync, spawn } from 'node:child_process';
-import { existsSync, readFileSync } from 'node:fs';
-import { readdir, readFile, stat } from 'node:fs/promises';
-import { basename, extname, join, relative } from 'node:path';
+import { spawn } from 'node:child_process';
+import { readdir, stat } from 'node:fs/promises';
+import { basename, join, relative } from 'node:path';
+import { rgPath } from '@vscode/ripgrep';
 import type {
   ContentSearchMatch,
   ContentSearchParams,
@@ -13,174 +13,6 @@ import type {
 const MAX_FILE_RESULTS = 100;
 const MAX_CONTENT_RESULTS = 500;
 const SEARCH_TIMEOUT_MS = 10000; // 10 seconds timeout for ripgrep
-
-// Gitignore pattern matcher
-class GitignoreMatcher {
-  private patterns: { regex: RegExp; negated: boolean }[] = [];
-
-  constructor(rootPath: string) {
-    this.loadGitignore(rootPath);
-  }
-
-  private loadGitignore(rootPath: string) {
-    const gitignorePath = join(rootPath, '.gitignore');
-    if (!existsSync(gitignorePath)) return;
-
-    try {
-      const content = readFileSync(gitignorePath, 'utf-8');
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        // Skip empty lines and comments
-        if (!trimmed || trimmed.startsWith('#')) continue;
-
-        let pattern = trimmed;
-        let negated = false;
-
-        // Handle negation
-        if (pattern.startsWith('!')) {
-          negated = true;
-          pattern = pattern.slice(1);
-        }
-
-        // Convert gitignore pattern to regex
-        const regex = this.patternToRegex(pattern);
-        if (regex) {
-          this.patterns.push({ regex, negated });
-        }
-      }
-    } catch {
-      // Ignore errors reading .gitignore
-    }
-  }
-
-  private patternToRegex(pattern: string): RegExp | null {
-    try {
-      // Remove trailing slash (directory indicator)
-      const isDir = pattern.endsWith('/');
-      if (isDir) pattern = pattern.slice(0, -1);
-
-      // Check if pattern is anchored to root
-      const anchored = pattern.startsWith('/');
-      if (anchored) pattern = pattern.slice(1);
-
-      // Escape special regex chars except * and ?
-      let regexStr = pattern
-        .replace(/[.+^${}()|[\]\\]/g, '\\$&')
-        .replace(/\*\*/g, '{{GLOBSTAR}}')
-        .replace(/\*/g, '[^/]*')
-        .replace(/\?/g, '[^/]')
-        .replace(/\{\{GLOBSTAR\}\}/g, '.*');
-
-      // If not anchored, match anywhere in path
-      if (!anchored) {
-        regexStr = `(^|/)${regexStr}`;
-      } else {
-        regexStr = `^${regexStr}`;
-      }
-
-      // Match end of string or followed by /
-      regexStr = `${regexStr}($|/)`;
-
-      return new RegExp(regexStr);
-    } catch {
-      return null;
-    }
-  }
-
-  isIgnored(relativePath: string): boolean {
-    let ignored = false;
-    for (const { regex, negated } of this.patterns) {
-      if (regex.test(relativePath)) {
-        ignored = !negated;
-      }
-    }
-    return ignored;
-  }
-}
-
-// Common paths where ripgrep might be installed
-const RG_PATHS = [
-  '/opt/homebrew/bin/rg',
-  '/usr/local/bin/rg',
-  '/usr/bin/rg',
-  // Add more if needed
-];
-
-// Find ripgrep executable
-function findRipgrep(): string | null {
-  const isWindows = process.platform === 'win32';
-
-  // Try common paths first (Unix only)
-  if (!isWindows) {
-    for (const rgPath of RG_PATHS) {
-      try {
-        execSync(`test -x "${rgPath}"`, { stdio: 'ignore' });
-        return rgPath;
-      } catch {
-        // Path doesn't exist or isn't executable
-      }
-    }
-  }
-
-  // Try to find in PATH
-  try {
-    // Use 'where.exe' on Windows (not 'where' which is PowerShell alias for Where-Object)
-    const command = isWindows ? 'where.exe rg' : 'which rg';
-    const result = execSync(command, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'ignore'] });
-    // 'where.exe' on Windows may return multiple lines, take the first one
-    const firstLine = result.trim().split('\n')[0];
-    return firstLine?.trim() || null;
-  } catch {
-    // Not found
-  }
-
-  return null;
-}
-
-// Text file extensions for content search
-const TEXT_EXTENSIONS = new Set([
-  '.ts',
-  '.tsx',
-  '.js',
-  '.jsx',
-  '.mjs',
-  '.cjs',
-  '.json',
-  '.yaml',
-  '.yml',
-  '.toml',
-  '.md',
-  '.mdx',
-  '.txt',
-  '.csv',
-  '.html',
-  '.css',
-  '.scss',
-  '.less',
-  '.py',
-  '.rb',
-  '.go',
-  '.rs',
-  '.java',
-  '.kt',
-  '.swift',
-  '.c',
-  '.cpp',
-  '.h',
-  '.hpp',
-  '.sh',
-  '.bash',
-  '.zsh',
-  '.sql',
-  '.graphql',
-  '.xml',
-  '.svg',
-  '.env',
-  '.gitignore',
-  '.dockerignore',
-  '.vue',
-  '.svelte',
-]);
 
 // 模糊匹配分数计算
 function fuzzyMatch(query: string, target: string): number {
@@ -225,8 +57,7 @@ async function walkDirectory(
   dir: string,
   rootPath: string,
   results: { path: string; name: string; relativePath: string }[],
-  maxResults: number,
-  gitignore: GitignoreMatcher | null = null
+  maxResults: number
 ): Promise<void> {
   if (results.length >= maxResults) return;
 
@@ -249,16 +80,11 @@ async function walkDirectory(
       const fullPath = join(dir, entry);
       const relativePath = relative(rootPath, fullPath);
 
-      // 检查 gitignore
-      if (gitignore?.isIgnored(relativePath)) {
-        continue;
-      }
-
       try {
         const stats = await stat(fullPath);
 
         if (stats.isDirectory()) {
-          await walkDirectory(fullPath, rootPath, results, maxResults, gitignore);
+          await walkDirectory(fullPath, rootPath, results, maxResults);
         } else {
           results.push({
             path: fullPath,
@@ -275,165 +101,15 @@ async function walkDirectory(
   }
 }
 
-// Check if file should be searched (based on extension)
-function isSearchableFile(filePath: string): boolean {
-  const ext = extname(filePath).toLowerCase();
-  // Files without extension might be config files
-  if (!ext) {
-    const name = basename(filePath);
-    return !name.startsWith('.');
-  }
-  return TEXT_EXTENSIONS.has(ext);
-}
-
-// Node.js fallback content search
-async function searchContentFallback(
-  rootPath: string,
-  query: string,
-  options: {
-    maxResults: number;
-    caseSensitive: boolean;
-    wholeWord: boolean;
-    regex: boolean;
-    useGitignore: boolean;
-  }
-): Promise<ContentSearchResult> {
-  const matches: ContentSearchMatch[] = [];
-  const fileSet = new Set<string>();
-  let totalMatches = 0;
-  let truncated = false;
-
-  // 初始化 gitignore 匹配器
-  const gitignore = options.useGitignore ? new GitignoreMatcher(rootPath) : null;
-
-  // Create regex for matching
-  let searchPattern: RegExp;
-  try {
-    if (options.regex) {
-      searchPattern = new RegExp(query, options.caseSensitive ? 'g' : 'gi');
-    } else {
-      const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-      const pattern = options.wholeWord ? `\\b${escaped}\\b` : escaped;
-      searchPattern = new RegExp(pattern, options.caseSensitive ? 'g' : 'gi');
-    }
-  } catch {
-    // Invalid regex, use simple string search
-    searchPattern = new RegExp(query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'gi');
-  }
-
-  async function searchInDirectory(dir: string): Promise<void> {
-    if (truncated) return;
-
-    try {
-      const entries = await readdir(dir);
-
-      for (const entry of entries) {
-        if (truncated) break;
-
-        // Skip hidden files and common ignore directories
-        if (
-          entry.startsWith('.') ||
-          entry === 'node_modules' ||
-          entry === 'dist' ||
-          entry === 'build'
-        ) {
-          continue;
-        }
-
-        const fullPath = join(dir, entry);
-        const relativePath = relative(rootPath, fullPath);
-
-        // 检查 gitignore
-        if (gitignore?.isIgnored(relativePath)) {
-          continue;
-        }
-
-        try {
-          const stats = await stat(fullPath);
-
-          if (stats.isDirectory()) {
-            await searchInDirectory(fullPath);
-          } else if (stats.isFile() && isSearchableFile(fullPath) && stats.size < 1024 * 1024) {
-            // Only search text files under 1MB
-            try {
-              const content = await readFile(fullPath, 'utf-8');
-              const lines = content.split('\n');
-
-              for (let i = 0; i < lines.length; i++) {
-                const line = lines[i];
-                searchPattern.lastIndex = 0; // Reset regex
-
-                if (searchPattern.test(line)) {
-                  totalMatches++;
-                  fileSet.add(fullPath);
-
-                  if (matches.length < options.maxResults) {
-                    // Find column position and match length
-                    searchPattern.lastIndex = 0;
-                    const match = searchPattern.exec(line);
-                    const column = match ? match.index : 0;
-                    const matchLength = match ? match[0].length : 0;
-
-                    matches.push({
-                      path: fullPath,
-                      relativePath: relative(rootPath, fullPath),
-                      line: i + 1,
-                      column,
-                      matchLength,
-                      content: line.trim(),
-                    });
-                  } else {
-                    truncated = true;
-                    break;
-                  }
-                }
-              }
-            } catch {
-              // Skip files that can't be read as text
-            }
-          }
-        } catch {
-          // Skip inaccessible files
-        }
-      }
-    } catch {
-      // Skip inaccessible directories
-    }
-  }
-
-  await searchInDirectory(rootPath);
-
-  return {
-    matches,
-    totalMatches,
-    totalFiles: fileSet.size,
-    truncated,
-  };
-}
-
 export class SearchService {
-  private rgPath: string | null = null;
-  private rgChecked = false;
-
-  // Check if ripgrep is available
-  checkRipgrep(): boolean {
-    if (!this.rgChecked) {
-      this.rgPath = findRipgrep();
-      this.rgChecked = true;
-    }
-    return this.rgPath !== null;
-  }
   // 文件名搜索
   async searchFiles(params: FileSearchParams): Promise<FileSearchResult[]> {
-    const { rootPath, query, maxResults = MAX_FILE_RESULTS, useGitignore = true } = params;
+    const { rootPath, query, maxResults = MAX_FILE_RESULTS } = params;
 
     if (!query.trim()) return [];
 
-    // 初始化 gitignore 匹配器
-    const gitignore = useGitignore ? new GitignoreMatcher(rootPath) : null;
-
     const allFiles: { path: string; name: string; relativePath: string }[] = [];
-    await walkDirectory(rootPath, rootPath, allFiles, maxResults * 10, gitignore);
+    await walkDirectory(rootPath, rootPath, allFiles, maxResults * 10);
 
     // 计算匹配分数并排序
     const scoredResults = allFiles
@@ -453,7 +129,7 @@ export class SearchService {
     return scoredResults;
   }
 
-  // 内容搜索（使用 ripgrep 或 Node.js 后备方案）
+  // 内容搜索（使用 ripgrep）
   async searchContent(params: ContentSearchParams): Promise<ContentSearchResult> {
     const {
       rootPath,
@@ -470,29 +146,6 @@ export class SearchService {
       return { matches: [], totalMatches: 0, totalFiles: 0, truncated: false };
     }
 
-    // Check for ripgrep availability (only once)
-    if (!this.rgChecked) {
-      this.rgPath = findRipgrep();
-      this.rgChecked = true;
-      if (this.rgPath) {
-        console.log('[SearchService] Using ripgrep at:', this.rgPath);
-      } else {
-        console.log('[SearchService] ripgrep not found, using Node.js fallback');
-      }
-    }
-
-    // Use Node.js fallback if ripgrep is not available
-    if (!this.rgPath) {
-      return searchContentFallback(rootPath, query, {
-        maxResults,
-        caseSensitive,
-        wholeWord,
-        regex,
-        useGitignore,
-      });
-    }
-
-    // Use ripgrep
     return new Promise((resolve) => {
       const args = [
         '--json',
@@ -528,7 +181,7 @@ export class SearchService {
       let truncated = false;
       let stderr = '';
 
-      const rg = spawn(this.rgPath!, args);
+      const rg = spawn(rgPath, args);
       let buffer = '';
 
       rg.stdout.on('data', (data) => {
@@ -570,9 +223,8 @@ export class SearchService {
         stderr += data.toString();
       });
 
-      // 超时处理 - 需要在 close handler 之前定义以便清除
+      // 超时处理
       const timeoutId = setTimeout(() => {
-        // Remove listeners before killing to prevent further processing
         rg.stdout.removeAllListeners('data');
         rg.stderr.removeAllListeners('data');
         rg.removeAllListeners('close');
@@ -587,7 +239,6 @@ export class SearchService {
       }, SEARCH_TIMEOUT_MS);
 
       rg.on('close', (code) => {
-        // Clear timeout when process ends normally
         clearTimeout(timeoutId);
 
         // 处理最后一行
@@ -627,20 +278,15 @@ export class SearchService {
         });
       });
 
-      rg.on('error', async (err) => {
-        // Clear timeout on error
+      rg.on('error', (err) => {
         clearTimeout(timeoutId);
-        // Fallback to Node.js search if ripgrep fails
-        console.log('[SearchService] ripgrep failed:', err.message, ', falling back to Node.js');
-        this.rgPath = null;
-        const result = await searchContentFallback(rootPath, query, {
-          maxResults,
-          caseSensitive,
-          wholeWord,
-          regex,
-          useGitignore,
+        console.error('[SearchService] ripgrep spawn error:', err.message);
+        resolve({
+          matches: [],
+          totalMatches: 0,
+          totalFiles: 0,
+          truncated: false,
         });
-        resolve(result);
       });
     });
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -542,7 +542,6 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.SEARCH_FILES, params),
     content: (params: ContentSearchParams): Promise<ContentSearchResult> =>
       ipcRenderer.invoke(IPC_CHANNELS.SEARCH_CONTENT, params),
-    checkRipgrep: (): Promise<boolean> => ipcRenderer.invoke(IPC_CHANNELS.SEARCH_CHECK_RG),
   },
 
   // Hapi Remote Sharing

--- a/src/renderer/components/search/GlobalSearchDialog.tsx
+++ b/src/renderer/components/search/GlobalSearchDialog.tsx
@@ -1,7 +1,6 @@
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import type { ContentSearchMatch, FileSearchResult } from '@shared/types';
 import {
-  AlertTriangle,
   CaseSensitive,
   FileCode,
   FileText,
@@ -36,14 +35,7 @@ export function GlobalSearchDialog({
 }: GlobalSearchDialogProps) {
   const { t } = useI18n();
   const inputRef = useRef<HTMLInputElement>(null);
-  const [dividerY, setDividerY] = useState(50); // percentage
-  const [hasRipgrep, setHasRipgrep] = useState<boolean | null>(null);
-  const [showRgWarning, setShowRgWarning] = useState(true);
-
-  // Check ripgrep availability on mount
-  useEffect(() => {
-    window.electronAPI.search.checkRipgrep().then(setHasRipgrep);
-  }, []);
+  const [dividerY, setDividerY] = useState(50);
 
   const {
     mode,
@@ -282,32 +274,6 @@ export function GlobalSearchDialog({
                 )}
               </div>
             </div>
-
-            {/* Ripgrep Warning */}
-            {hasRipgrep === false && showRgWarning && mode === 'content' && (
-              <div className="flex shrink-0 items-center gap-2 border-b border-warning/32 bg-warning/4 px-3 py-1.5 text-xs text-foreground">
-                <AlertTriangle className="h-3.5 w-3.5 shrink-0 text-warning" />
-                <span className="min-w-0 flex-1">
-                  {t('For better performance, install')}{' '}
-                  <button
-                    type="button"
-                    className="text-primary underline hover:text-primary/80"
-                    onClick={() =>
-                      window.electronAPI.shell.openExternal('https://github.com/BurntSushi/ripgrep')
-                    }
-                  >
-                    ripgrep
-                  </button>
-                </span>
-                <button
-                  type="button"
-                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent/50 hover:text-foreground"
-                  onClick={() => setShowRgWarning(false)}
-                >
-                  <X className="h-3.5 w-3.5" />
-                </button>
-              </div>
-            )}
 
             {/* Results Area */}
             <div className="flex min-h-0 flex-1 flex-col">

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -159,7 +159,6 @@ export const IPC_CHANNELS = {
   // Search
   SEARCH_FILES: 'search:files',
   SEARCH_CONTENT: 'search:content',
-  SEARCH_CHECK_RG: 'search:checkRg',
 
   // Hapi Remote Sharing
   HAPI_CHECK_GLOBAL: 'hapi:checkGlobal',


### PR DESCRIPTION
## Summary

使用 `@vscode/ripgrep` 包内置 ripgrep 二进制文件，替代依赖系统安装的 ripgrep。

## Changes

- **新增依赖**: `@vscode/ripgrep@1.17.0` (每平台约 +2MB 二进制)
- **移除代码**:
  - `GitignoreMatcher` 类
  - `findRipgrep()` 系统检测函数
  - `searchContentFallback()` Node.js 后备方案
  - `TEXT_EXTENSIONS` 常量
  - `checkRipgrep` IPC 接口 (main/preload/shared)
  - ripgrep 安装警告 UI

## Benefits

- **开箱即用**: 用户无需手动安装系统 ripgrep
- **性能保证**: 搜索始终使用 ripgrep 级别性能
- **代码精简**: SearchService.ts 从 650 行减少到 280 行 (**-370 行**)
- **体验提升**: 移除"请安装 ripgrep"警告提示

## Size Impact

| 平台 | ripgrep 二进制大小 |
|------|-------------------|
| macOS arm64 | ~1.8 MB |
| macOS x64 | ~1.9 MB |
| Windows x64 | ~2.0 MB |
| Linux x64 | ~2.3 MB |

对于 Electron 应用（通常 100MB+）来说，增量可以接受。