### PR TITLE
fix: 修复 fish/nushell 等非 POSIX shell 的 CLI 检测失败问题

### DIFF
--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -75,7 +75,8 @@ export async function execInPty(command: string, options: ExecInPtyOptions = {})
     const { shell, args } = getShellForCommand();
     const shellName = shell.toLowerCase();
 
-    // Construct shell args with command (same logic as AgentTerminal)
+    // Construct shell args with command
+    // Shell will naturally exit with the command's exit code
     let shellArgs: string[];
     if (shellName.includes('wsl')) {
       // WSL: wsl.exe doesn't load user's shell environment by default.
@@ -83,12 +84,8 @@ export async function execInPty(command: string, options: ExecInPtyOptions = {})
       // to ensure PATH and other environment variables are properly initialized.
       const escapedCommand = command.replace(/"/g, '\\"');
       shellArgs = ['-e', 'sh', '-lc', `exec "$SHELL" -ilc "${escapedCommand}"`];
-    } else if (shellName.includes('powershell') || shellName.includes('pwsh')) {
-      shellArgs = [...args, `& { ${command}; exit $LASTEXITCODE }`];
-    } else if (shellName.includes('cmd')) {
-      shellArgs = [...args, `${command} & exit %ERRORLEVEL%`];
     } else {
-      shellArgs = [...args, `${command}; exit $?`];
+      shellArgs = [...args, command];
     }
 
     let output = '';


### PR DESCRIPTION
## Summary
- 移除 `execInPty` 中冗余的 `exit $?` 处理
- 修复 fish shell 使用 `$status`、nushell 使用 `$env.LAST_EXIT_CODE` 等语法差异导致的 exit code 127 错误
- shell 执行完命令后会自然以该命令的退出码退出，无需手动处理

## Test plan
- [ ] 使用 fish shell 测试 CLI 检测功能
- [ ] 使用 zsh/bash 测试 CLI 检测功能确保无回归