### PR TITLE
fix(git): 为gh CLI和claude review命以及生成commit命令添加代理环境变量

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { type FileChangeStatus, IPC_CHANNELS } from '@shared/types';
 import { ipcMain } from 'electron';
 import { GitService } from '../services/git/GitService';
+import { getProxyEnvVars } from '../services/proxy/ProxyConfig';
 import { getEnvForCommand, getShellForCommand, killProcessTree } from '../utils/shell';
 
 const gitServices = new Map<string, GitService>();
@@ -254,7 +255,7 @@ ${truncatedDiff}`;
 
         const proc = spawn(shell, [...shellArgs, command], {
           cwd: resolved,
-          env: getEnvForCommand(),
+          env: { ...getEnvForCommand(), ...getProxyEnvVars() },
         });
 
         // Handle stdin errors to prevent EPIPE crashes
@@ -442,7 +443,7 @@ ${gitLog || '(No commit history available)'}`;
 
       const proc = spawn(shell, [...shellArgs, claudeCommand], {
         cwd: resolved,
-        env: getEnvForCommand(),
+        env: { ...getEnvForCommand(), ...getProxyEnvVars() },
       });
 
       activeCodeReviews.set(reviewId, proc);

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -465,7 +465,7 @@ export class GitService {
       // Check if gh is authenticated
       await execAsync('gh auth status', {
         cwd: this.workdir,
-        env: { ...process.env, PATH: getEnhancedPath() },
+        env: { ...process.env, ...getProxyEnvVars(), PATH: getEnhancedPath() },
       });
       return { installed: true, authenticated: true };
     } catch {
@@ -479,7 +479,7 @@ export class GitService {
         'gh pr list --state open --json number,title,headRefName,state,author,updatedAt,isDraft --limit 50',
         {
           cwd: this.workdir,
-          env: { ...process.env, PATH: getEnhancedPath() },
+          env: { ...process.env, ...getProxyEnvVars(), PATH: getEnhancedPath() },
         }
       );
 


### PR DESCRIPTION
## Summary

为 gh CLI、claude review命令以及生成 commit 命令添加代理环境变量支持

## Changes

| 文件 | 更改内容 |
|------|----------|
| `src/main/ipc/git.ts` | 为 Git Code Review 命令和生成 commit 命令添加 `getProxyEnvVars()` |
| `src/main/services/git/GitService.ts` | 为 `gh auth status` 和 `gh pr list` 命令添加 `getProxyEnvVars()` |

## Test plan

- [ ] 验证配置代理后 `gh` CLI 能正常认证
- [ ] 验证代理环境下能正常列出 PR 列表
- [ ] 验证代理环境下 Code Review 功能正常工作
- [ ] 验证代理环境下 commit message 生成功能正常工作