### PR TITLE
fix(add-repo): sync default group on open

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -622,7 +622,7 @@ export default function App() {
 
   // Handle adding a local repository
   const handleAddLocalRepository = useCallback(
-    (selectedPath: string) => {
+    (selectedPath: string, groupId: string | null) => {
       // Check if repo already exists
       if (repositories.some((r) => r.path === selectedPath)) {
         return;
@@ -634,6 +634,7 @@ export default function App() {
       const newRepo: Repository = {
         name,
         path: selectedPath,
+        groupId: groupId || undefined,
       };
 
       const updated = [...repositories, newRepo];
@@ -647,7 +648,7 @@ export default function App() {
 
   // Handle cloning a remote repository
   const handleCloneRepository = useCallback(
-    (clonedPath: string) => {
+    (clonedPath: string, groupId: string | null) => {
       // Check if repo already exists
       if (repositories.some((r) => r.path === clonedPath)) {
         setSelectedRepo(clonedPath);
@@ -660,6 +661,7 @@ export default function App() {
       const newRepo: Repository = {
         name,
         path: clonedPath,
+        groupId: groupId || undefined,
       };
 
       const updated = [...repositories, newRepo];
@@ -982,6 +984,8 @@ export default function App() {
       <AddRepositoryDialog
         open={addRepoDialogOpen}
         onOpenChange={setAddRepoDialogOpen}
+        groups={sortedGroups}
+        defaultGroupId={activeGroupId === ALL_GROUP_ID ? null : activeGroupId}
         onAddLocal={handleAddLocalRepository}
         onCloneComplete={handleCloneRepository}
       />

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -107,6 +107,7 @@ export const zhTranslations: Record<string, string> = {
   English: '英语',
   'Enter delay': '启动延迟',
   'Enter a new branch name:': '输入新分支名:',
+  Group: '分组',
   'Enter a name for the new file.': '输入新文件的名称。',
   'Enter a name for the new folder.': '输入新文件夹的名称。',
   'Enter commit message... (Cmd/Ctrl+Enter to commit)': '输入提交信息... (Cmd/Ctrl+Enter 提交)',


### PR DESCRIPTION
## 背景 / 问题
父组件在打开 “Add Repository” 对话框时会传入 `defaultGroupId`，期望默认选中当前分组。但对话框是受控组件，父组件将 `open` 设为 `true` 不会触发 `onOpenChange`，导致内部 `selectedGroupId` 初始仍为空，最终新增/克隆仓库的 `groupId` 总是 `null`，仓库都会被保存到“无分组”。

## 修复内容
- 在 `AddRepositoryDialog` 中将默认分组同步逻辑改为：
  - 对话框从关闭→打开时初始化 `selectedGroupId = defaultGroupId ?? ''`
  - 对话框打开期间仅当“当前选择仍等于旧默认值且用户未手动改选”时，才跟随 `defaultGroupId` 变化，避免覆盖用户明确选择“无分组/其他分组”
- `onAddLocal` / `onCloneComplete` 增加 `groupId` 参数，并在 `App.tsx` 写入 `Repository.groupId`
- 补充 i18n：新增 `Group` 文案

## 行为变化
- 打开对话框后默认会正确选中当前分组，直接新增/克隆会落到该分组
- 用户手动选择分组（包括“无分组”）后，不会因父级默认分组变化而被强制覆盖

## 影响范围
- `src/renderer/components/git/AddRepositoryDialog.tsx`
- `src/renderer/App.tsx`
- `src/shared/i18n.ts`

## 验证方式
1. 切换侧边栏当前分组 A
2. 打开 Add Repository，对话框分组下拉默认显示 A
3. 不手动更改分组，直接 Add/Clone：仓库保存到分组 A
4. 手动选择“无分组”，保持对话框打开并切换父级当前分组：对话框仍保持“无分组”不被覆盖
