### PR TITLE
feat(worktree): add AI-powered branch name generator

### DIFF
--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -102,6 +102,11 @@ const electronAPI = {
       options: { maxDiffLines: number; timeout: number; model: string }
     ): Promise<{ success: boolean; message?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG, workdir, options),
+    generateBranchName: (
+      workdir: string,
+      options: { prompt: string; model: string }
+    ): Promise<{ success: boolean; branchName?: string; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_BRANCH_NAME, workdir, options),
     startCodeReview: (
       workdir: string,
       options: {

--- a/src/renderer/components/settings/IntegrationSettings.tsx
+++ b/src/renderer/components/settings/IntegrationSettings.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { useI18n } from '@/i18n';
-import { useSettingsStore } from '@/stores/settings';
+import { defaultBranchNameGeneratorSettings, useSettingsStore } from '@/stores/settings';
 import { ProviderList } from './claude-provider';
 import { KeybindingInput } from './KeybindingsSettings';
 import { McpSection } from './mcp';
@@ -25,6 +25,8 @@ export function IntegrationSettings() {
     setCommitMessageGenerator,
     codeReview,
     setCodeReview,
+    branchNameGenerator,
+    setBranchNameGenerator,
   } = useSettingsStore();
   const [bridgePort, setBridgePort] = React.useState<number | null>(null);
 
@@ -533,6 +535,102 @@ export function IntegrationSettings() {
                 checked={codeReview.continueConversation ?? true}
                 onCheckedChange={(checked) => setCodeReview({ continueConversation: checked })}
               />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="mt-6 border-t pt-6">
+        <div>
+          <h3 className="text-lg font-medium">{t('Branch Name Generator')}</h3>
+          <p className="text-sm text-muted-foreground">
+            {t('Auto-generate branch names using Claude')}
+          </p>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <div className="space-y-0.5">
+            <span className="text-sm font-medium">{t('Enable Generator')}</span>
+            <p className="text-xs text-muted-foreground">
+              {t('Generate branch names with AI assistance')}
+            </p>
+          </div>
+          <Switch
+            checked={branchNameGenerator.enabled}
+            onCheckedChange={(checked) => setBranchNameGenerator({ enabled: checked })}
+          />
+        </div>
+
+        {branchNameGenerator.enabled && (
+          <div className="mt-4 space-y-4 border-t pt-4">
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Model')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={branchNameGenerator.model ?? 'haiku'}
+                  onValueChange={(v) =>
+                    setBranchNameGenerator({
+                      model: v as 'default' | 'opus' | 'sonnet' | 'haiku',
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue>
+                      {(branchNameGenerator.model ?? 'haiku') === 'default'
+                        ? t('Default')
+                        : (branchNameGenerator.model ?? 'haiku').charAt(0).toUpperCase() +
+                          (branchNameGenerator.model ?? 'haiku').slice(1)}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    <SelectItem value="haiku">Haiku</SelectItem>
+                    <SelectItem value="sonnet">Sonnet</SelectItem>
+                    <SelectItem value="opus">Opus</SelectItem>
+                    <SelectItem value="default">{t('Default')}</SelectItem>
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {t('Claude model for generating branch names')}
+                </p>
+              </div>
+            </div>
+
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium">{t('Prompt')}</span>
+              <div className="space-y-1.5">
+                <textarea
+                  value={branchNameGenerator.prompt}
+                  onChange={(e) => setBranchNameGenerator({ prompt: e.target.value })}
+                  className="w-full h-40 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder={t(
+                    'Enter a prompt template, and the AI will generate branch names according to your rules.\nAvailable variables:\n• {description} - Feature description\n• {current_date} - Current date\n• {current_time} - Current time'
+                  )}
+                />
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    {t('Customize the AI prompt for generating branch names')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (
+                        window.confirm(
+                          t(
+                            'This will restore the default AI prompt for generating branch names. Your custom prompt will be lost.'
+                          )
+                        )
+                      ) {
+                        setBranchNameGenerator({
+                          prompt: defaultBranchNameGeneratorSettings.prompt,
+                        });
+                      }
+                    }}
+                    className="text-xs text-muted-foreground hover:text-primary underline"
+                  >
+                    {t('Restore default prompt')}
+                  </button>
+                </div>
+              </div>
             </div>
           </div>
         )}

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -275,6 +275,21 @@ export const defaultCodeReviewSettings: CodeReviewSettings = {
   continueConversation: true,
 };
 
+export type BranchNameModel = 'default' | 'opus' | 'sonnet' | 'haiku';
+
+export interface BranchNameGeneratorSettings {
+  enabled: boolean;
+  model: BranchNameModel;
+  prompt: string;
+}
+
+export const defaultBranchNameGeneratorSettings: BranchNameGeneratorSettings = {
+  enabled: false,
+  model: 'haiku',
+  prompt:
+    '你是 Git 分支命名助手（不可用工具）。输入含 desc 可含 date/branch_style。任务：从 desc 判定 type、提取 ticket、生成 slug，按模板渲染分支名。只输出一行分支名，无解释无标点。\n\n约束：仅允许 a-z0-9-/.；全小写；词用 -；禁空格/中文/下划线/其他符号。渲染后：-// 连续压缩为 1；去掉首尾 - / .；空变量不产生多余分隔符。\n\nticket：识别 ABC-123/#456/issue 789 等 → 小写，去 #；若存在则置于 slug 最前（形成 ticket-slug）。\n\nslug：取核心关键词 3–8 词，过滤泛词（如：一下/相关/进行/支持/增加/优化/问题/功能/页面/接口/调整/更新/修改等）；必要时将中文概念转换为常见英文词（如 login/order/pay），无法转换则丢弃。\n\ntype 枚举：feat fix hotfix perf refactor docs test chore ci build 判定优先级：hotfix(紧急/回滚/prod) > perf(性能) > fix(bug/修复) > feat(新增) > refactor(结构不变) > docs > test > ci > build > chore(兜底)。\n\ndate: 格式为 yyyyMMdd\n\n输出格式：{type}-{date}-{slug}\n\ndate: {current_date}\ntime: {current_time}\ndesc：{description}',
+};
+
 // Hapi remote sharing settings
 export type TunnelMode = 'quick' | 'auth';
 
@@ -461,6 +476,8 @@ interface SettingsState {
   // MCP, Prompts management
   mcpServers: McpServer[];
   promptPresets: PromptPreset[];
+  // Branch name generator
+  branchNameGenerator: BranchNameGeneratorSettings;
 
   setTheme: (theme: Theme) => void;
   setLayoutMode: (mode: LayoutMode) => void;
@@ -518,6 +535,8 @@ interface SettingsState {
   updatePromptPreset: (id: string, updates: Partial<PromptPreset>) => void;
   removePromptPreset: (id: string) => void;
   setPromptPresetEnabled: (id: string) => void;
+  // Branch name generator
+  setBranchNameGenerator: (settings: Partial<BranchNameGeneratorSettings>) => void;
 }
 
 const defaultAgentSettings: AgentSettings = {
@@ -575,6 +594,7 @@ export const useSettingsStore = create<SettingsState>()(
       // MCP, Prompts defaults
       mcpServers: [],
       promptPresets: [],
+      branchNameGenerator: defaultBranchNameGeneratorSettings,
 
       setTheme: (theme) => {
         const terminalTheme = get().terminalTheme;
@@ -802,6 +822,10 @@ export const useSettingsStore = create<SettingsState>()(
             enabled: p.id === id,
           })),
         })),
+      setBranchNameGenerator: (settings) =>
+        set((state) => ({
+          branchNameGenerator: { ...state.branchNameGenerator, ...settings },
+        })),
     }),
     {
       name: 'enso-settings',
@@ -911,6 +935,10 @@ export const useSettingsStore = create<SettingsState>()(
           codeReview: {
             ...currentState.codeReview,
             ...persisted.codeReview,
+          },
+          branchNameGenerator: {
+            ...currentState.branchNameGenerator,
+            ...persisted.branchNameGenerator,
           },
           hapiSettings: {
             ...currentState.hapiSettings,

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -620,6 +620,22 @@ export const zhTranslations: Record<string, string> = {
   'Review content copied to clipboard': '审查内容已复制到剪贴板',
   'Copy failed': '复制失败',
   'Failed to copy content': '复制内容失败',
+  'Branch Name Generator': '分支名称生成器',
+  'Auto-generate branch names using Claude': '使用 Claude 自动生成分支名称',
+  // 'Enable Generator': '启用生成器',
+  'Generate branch names with AI assistance': '使用 AI 辅助生成分支名称',
+  'Claude model for generating branch names': '用于生成分支名称的 Claude 模型',
+  Prompt: '提示词',
+  'Customize the AI prompt for generating branch names': '自定义生成分支名称的 AI 提示词',
+  'Enter a prompt template, and the AI will generate branch names according to your rules.\nAvailable variables:\n• {description} - Feature description\n• {current_date} - Current date\n• {current_time} - Current time':
+    '输入提示词模板，AI 将根据您的规则生成分支名称。\n可用变量：\n• ⁠{description} - 功能描述\n• ⁠{current_date} - 当前日期\n• ⁠{current_time} - 当前时间',
+  'Generate branch name': '生成分支名称',
+  'Failed to generate branch name': '生成分支名称失败',
+  'Generating branch name...': '正在生成分支名称...',
+  'Restore Default': '恢复默认',
+  'Restore default prompt': '恢复默认提示词',
+  'This will restore the default AI prompt for generating branch names. Your custom prompt will be lost.':
+    '这将恢复生成分支名称的默认 AI 提示词。您的自定义提示词将丢失。',
   // Auto Save section
   'Auto Save': '自动保存',
   'Auto save settings': '自动保存设置',

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -21,6 +21,7 @@ export const IPC_CHANNELS = {
   GIT_COMMIT_DIFF: 'git:commit:diff',
   GIT_DIFF_STATS: 'git:diff:stats',
   GIT_GENERATE_COMMIT_MSG: 'git:generate-commit-msg',
+  GIT_GENERATE_BRANCH_NAME: 'git:generate-branch-name',
   GIT_CODE_REVIEW_START: 'git:code-review:start',
   GIT_CODE_REVIEW_STOP: 'git:code-review:stop',
   GIT_CODE_REVIEW_DATA: 'git:code-review:data',


### PR DESCRIPTION
## Summary
  - ✨ 新增 AI 分支名称生成器功能，支持使用 Claude 根据功能描述自动生成规范的分支名称
  - 🎨 在创建 Worktree 对话框中添加"魔法棒"按钮，一键生成分支名
  - ⚙️ 在集成设置中新增"分支名称生成器"配置项

  ## Features

  ### 核心功能
  - 新增 `GIT_GENERATE_BRANCH_NAME` IPC 通道，集成 Claude API 进行分支名生成
  - 支持自定义提示词模板，可使用变量：
    - `{description}` - 功能描述
    - `{current_date}` - 当前日期（yyyyMMdd）
    - `{current_time}` - 当前时间
  - 内置智能提示词，自动识别类型（feat/fix/hotfix 等）、提取 ticket 号、生成 slug

  ### 配置项
  - **启用/禁用开关**：控制是否显示生成按钮
  - **模型选择**：支持 Haiku/Sonnet/Opus/Default
  - **自定义提示词**：支持恢复默认模板

  ### UI 优化
  - 在分支名称输入框右侧添加 Sparkles 图标按钮
  - 生成过程中显示加载动画
  - 超时保护（60 秒）