### PR TITLE
feat(editor): Support quick global search for selected text

### DIFF
--- a/src/renderer/components/search/GlobalSearchDialog.tsx
+++ b/src/renderer/components/search/GlobalSearchDialog.tsx
@@ -58,11 +58,17 @@ export function GlobalSearchDialog({
   useEffect(() => {
     if (open) {
       setMode(initialMode);
+      // Get pending search query from window (set by FilePanel when opening search)
+      const pendingQuery = window._pendingSearchQuery;
+      if (pendingQuery) {
+        setQuery(pendingQuery);
+        window._pendingSearchQuery = undefined; // Clear after use
+      }
       setTimeout(() => inputRef.current?.focus(), 50);
     } else {
       reset();
     }
-  }, [open, initialMode, setMode, reset]);
+  }, [open, initialMode, setMode, setQuery, reset]);
 
   // Handle keyboard navigation
   const handleKeyDown = useCallback(


### PR DESCRIPTION
  ## Summary

  - 编辑器内选中文本后，可通过快捷键 `Cmd+Shift+F` 或文件树的搜索按钮快速打开全局搜索
  - 搜索框自动填充当前选中的文本内容

  ---
  变更文件：
  - src/renderer/components/files/EditorArea.tsx - 添加 EditorAreaRef 接口、Cmd+Shift+F 快捷键
  - src/renderer/components/files/FilePanel.tsx - 集成编辑器引用，传递选中内容
  - src/renderer/components/search/GlobalSearchDialog.tsx - 支持自动填充选中文本