### PR TITLE
fix(source-control): 修复放弃更改弹窗关闭时闪现删除文件弹窗

### DIFF
--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -220,7 +220,8 @@ export function SourceControlPanel({
     handleDeleteUntracked,
     handleCommit,
     confirmAction,
-    setConfirmAction,
+    dialogOpen,
+    handleDialogOpenChange,
     handleConfirmAction,
     isCommitting,
   } = useSourceControlActions({ rootPath, stagedCount: staged.length });
@@ -592,7 +593,7 @@ export function SourceControlPanel({
       </div>
 
       {/* Discard/Delete Confirmation Dialog */}
-      <AlertDialog open={!!confirmAction} onOpenChange={(open) => !open && setConfirmAction(null)}>
+      <AlertDialog open={dialogOpen} onOpenChange={handleDialogOpenChange}>
         <AlertDialogPopup>
           <AlertDialogHeader>
             <AlertDialogTitle>


### PR DESCRIPTION
问题原因：AlertDialog 内容根据 confirmAction.type 动态渲染，
当弹窗关闭时 confirmAction 立即被设置为 null，但弹窗仍在
执行关闭动画，导致条件判断进入"删除文件"分支。

修复方案：使用单独的 dialogOpen 状态控制弹窗可见性，
只在弹窗完全关闭后才清除 confirmAction 的值。

Closes #144