### PR TITLE
fix(security): 加固 Markdown 预览与 local-file 访问边界

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { electronApp, optimizer } from '@electron-toolkit/utils';
 import { type Locale, normalizeLocale } from '@shared/i18n';
 import { IPC_CHANNELS } from '@shared/types';
@@ -11,13 +12,14 @@ import {
   registerIpcHandlers,
 } from './ipc';
 import { initClaudeProviderWatcher } from './ipc/claudeProvider';
+import { registerWindowHandlers } from './ipc/window';
 import { registerClaudeBridgeIpcHandlers } from './services/claude/ClaudeIdeBridge';
 import { unwatchClaudeSettings } from './services/claude/ClaudeProviderManager';
+import { isAllowedLocalFilePath } from './services/files/LocalFileAccess';
 import { checkGitInstalled } from './services/git/checkGit';
 import { setCurrentLocale } from './services/i18n';
 import { buildAppMenu } from './services/MenuBuilder';
 import { createMainWindow } from './windows/MainWindow';
-import { registerWindowHandlers } from './ipc/window';
 
 let mainWindow: BrowserWindow | null = null;
 let pendingOpenPath: string | null = null;
@@ -185,8 +187,18 @@ app.whenReady().then(async () => {
 
   // Register protocol to handle local file:// URLs for markdown images
   protocol.handle('local-file', (request) => {
-    const filePath = decodeURIComponent(request.url.slice('local-file://'.length));
-    return net.fetch(`file://${filePath}`);
+    try {
+      const fileUrl = new URL(request.url.replace(/^local-file:/, 'file:'));
+      const filePath = fileURLToPath(fileUrl);
+
+      if (!isAllowedLocalFilePath(filePath)) {
+        return new Response('Forbidden', { status: 403 });
+      }
+
+      return net.fetch(fileUrl.toString());
+    } catch {
+      return new Response('Bad Request', { status: 400 });
+    }
   });
 
   // Default open or close DevTools by F12 in development

--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -6,6 +6,7 @@ import iconv from 'iconv-lite';
 import jschardet from 'jschardet';
 import simpleGit from 'simple-git';
 import { FileWatcher } from '../services/files/FileWatcher';
+import { registerAllowedLocalFileRoot } from '../services/files/LocalFileAccess';
 
 /**
  * Normalize encoding name to a consistent format
@@ -139,6 +140,10 @@ export function registerFileHandlers(): void {
   ipcMain.handle(
     IPC_CHANNELS.FILE_LIST,
     async (_, dirPath: string, gitRoot?: string): Promise<FileEntry[]> => {
+      if (gitRoot) {
+        registerAllowedLocalFileRoot(gitRoot);
+      }
+
       const entries = await readdir(dirPath);
       const result: FileEntry[] = [];
 

--- a/src/main/services/files/LocalFileAccess.ts
+++ b/src/main/services/files/LocalFileAccess.ts
@@ -1,0 +1,31 @@
+import path from 'node:path';
+
+const allowedRoots = new Set<string>();
+
+function normalizePathForComparison(inputPath: string): string {
+  let resolved = path.resolve(inputPath);
+  resolved = resolved.replace(/[\\/]+$/, '');
+
+  if (process.platform === 'win32' || process.platform === 'darwin') {
+    resolved = resolved.toLowerCase();
+  }
+
+  return resolved;
+}
+
+export function registerAllowedLocalFileRoot(rootPath: string): void {
+  allowedRoots.add(normalizePathForComparison(rootPath));
+}
+
+export function isAllowedLocalFilePath(filePath: string): boolean {
+  if (allowedRoots.size === 0) return false;
+
+  const normalizedFilePath = normalizePathForComparison(filePath);
+
+  for (const root of allowedRoots) {
+    if (normalizedFilePath === root) return true;
+    if (normalizedFilePath.startsWith(`${root}${path.sep}`)) return true;
+  }
+
+  return false;
+}

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -907,7 +907,8 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
                 >
                   <MarkdownPreview
                     content={activeTab.content}
-                    basePath={activeTab.path.substring(0, activeTab.path.lastIndexOf('/'))}
+                    filePath={activeTab.path}
+                    rootPath={rootPath}
                   />
                 </div>
               </>


### PR DESCRIPTION
- 移除 Markdown 预览的 `rehype-raw`，避免渲染原始 HTML 带来的 XSS 风险
- 图片 src 解析：仅允许 http(s)/data/blob；本地图片仅允许 worktree 根目录内的相对路径，阻止跳出 root
- 主进程 `local-file` 协议增加 allowlist：只允许读取已通过文件树 `FILE_LIST(gitRoot)` 注册过的根目录下文件

验证：
- `pnpm typecheck`