### PR TITLE
fix(linux): 修复 Ubuntu 24.04 系统通知无法显示的问题

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -113,6 +113,7 @@ linux:
       arch: [x64]
     - target: deb
       arch: [x64]
+  executableName: enso-ai
   maintainer: EnsoAI Team <crolin-zhang@users.noreply.github.com>
   category: Development
   # Register enso:// URL scheme


### PR DESCRIPTION
## Summary
- 在 electron-builder.yml 添加 `executableName: ensoai` 确保可执行文件名一致
- 在主进程添加 `app.setDesktopName()` 调用，使 Electron 能正确关联 `.desktop` 文件

## 原因分析
Ubuntu 24.04 使用 libnotify 发送系统通知，需要应用有正确的 `.desktop` 文件且 Electron 能找到它。之前配置缺少 `executableName` 和 `app.setDesktopName()` 导致通知无法显示。

Closes #156