### PR TITLE
fix(worktree): 修复合并后删除 worktree 时分支未删除且左侧目录未刷新的问题

### DIFF
--- a/src/renderer/components/worktree/MergeWorktreeDialog.tsx
+++ b/src/renderer/components/worktree/MergeWorktreeDialog.tsx
@@ -243,7 +243,14 @@ export function MergeWorktreeDialog({
               <label className="flex items-center gap-2 text-sm">
                 <Checkbox
                   checked={deleteWorktree}
-                  onCheckedChange={(checked) => setDeleteWorktree(checked === true)}
+                  onCheckedChange={(checked) => {
+                    const isChecked = checked === true;
+                    setDeleteWorktree(isChecked);
+                    // Auto-enable deleteBranch when deleteWorktree is checked
+                    if (isChecked) {
+                      setDeleteBranch(true);
+                    }
+                  }}
                 />
                 {t('Delete worktree')}
               </label>

--- a/src/renderer/hooks/useWorktree.ts
+++ b/src/renderer/hooks/useWorktree.ts
@@ -111,6 +111,7 @@ export function useWorktreeCreate() {
     },
     onSuccess: (_, { workdir }) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', 'list', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['worktree', 'listMultiple', workdir] });
     },
   });
 }
@@ -130,6 +131,7 @@ export function useWorktreeRemove() {
     },
     onSuccess: (_, { workdir }) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', 'list', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['worktree', 'listMultiple', workdir] });
     },
   });
 }
@@ -150,6 +152,7 @@ export function useWorktreeMerge() {
     },
     onSuccess: (_, { workdir }) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', 'list', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['worktree', 'listMultiple', workdir] });
       queryClient.invalidateQueries({ queryKey: ['worktree', 'mergeState', workdir] });
       queryClient.invalidateQueries({ queryKey: ['git', 'branches', workdir] });
     },
@@ -240,6 +243,7 @@ export function useWorktreeMergeContinue() {
     },
     onSuccess: (_, { workdir }) => {
       queryClient.invalidateQueries({ queryKey: ['worktree', 'list', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['worktree', 'listMultiple', workdir] });
       queryClient.invalidateQueries({ queryKey: ['worktree', 'mergeState', workdir] });
       queryClient.invalidateQueries({ queryKey: ['worktree', 'conflicts', workdir] });
       queryClient.invalidateQueries({ queryKey: ['git', 'branches', workdir] });


### PR DESCRIPTION
## Summary
- 修复勾选"删除 worktree"时分支未自动删除的问题：当用户勾选 deleteWorktree 时，自动将 deleteBranch 设为 true
- 修复合并/删除 worktree 后左侧目录树未刷新的问题：在 worktree 相关 hooks 的 onSuccess 中添加 invalidate `listMultiple` 查询

## 问题原因

### 问题 1: 分支未删除
`MergeWorktreeDialog.tsx` 中 UI 显示 "Included with worktree deletion"，但实际上 `deleteBranch` 状态没有自动设为 `true`，导致传给后端的 `deleteBranchAfterMerge` 为 `false`

### 问题 2: 左侧目录未刷新
- `App.tsx` 使用 `useWorktreeList`，queryKey 是 `['worktree', 'list', workdir]`
- `TreeSidebar` 使用 `useWorktreeListMultiple`，queryKey 是 `['worktree', 'listMultiple', repoPath]`
- 合并成功后只 invalidate 了 `['worktree', 'list', ...]`，没有 invalidate `['worktree', 'listMultiple', ...]`

## Test plan
- [ ] 创建一个新的 worktree 并进行一些更改
- [ ] 合并 worktree 时勾选"删除 worktree"
- [ ] 验证 worktree 目录被删除
- [ ] 验证分支被删除
- [ ] 验证左侧目录树正确刷新，不再显示已删除的 worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)