### PR TITLE
feat: 添加仓库分组选择显示颜色并支持新建

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1194,6 +1194,7 @@ export default function App() {
           defaultGroupId={activeGroupId === ALL_GROUP_ID ? null : activeGroupId}
           onAddLocal={handleAddLocalRepository}
           onCloneComplete={handleCloneRepository}
+          onCreateGroup={handleCreateGroup}
         />
 
         {/* Action Panel */}

--- a/src/renderer/components/group/MoveToGroupSubmenu.tsx
+++ b/src/renderer/components/group/MoveToGroupSubmenu.tsx
@@ -57,8 +57,13 @@ export function MoveToGroupSubmenu({
             <span className="w-4 h-4 flex items-center justify-center">
               {currentGroupId === group.id && <Check className="h-3.5 w-3.5" />}
             </span>
-            {group.emoji && <span>{group.emoji}</span>}
-            <span className="truncate">{group.name}</span>
+            {group.emoji && <span className="shrink-0 text-base">{group.emoji}</span>}
+            <span
+              className="h-2.5 w-2.5 shrink-0 rounded-full border"
+              style={{ backgroundColor: group.color }}
+              aria-hidden="true"
+            />
+            <span className="min-w-0 flex-1 truncate text-left">{group.name}</span>
           </button>
         ))}
       </div>


### PR DESCRIPTION
## 背景
添加仓库/移动到分组时，下拉列表缺少颜色标识，难以与左侧分组列表对应。

## 改动
- 添加仓库弹窗：分组 Select 下拉项/选中态显示颜色圆点 + 名称（可选 emoji），并新增 `+` 按钮快速新建分组（创建后自动选中）。
- 右键菜单“移动到分组”：分组列表项显示颜色圆点，文本左对齐。

<img width="1002" height="680" alt="image" src="https://github.com/user-attachments/assets/bfab984a-82f7-484f-8993-b9242f651fce" />
<img width="1014" height="830" alt="image" src="https://github.com/user-attachments/assets/a719653c-1700-456b-9b84-15ab185508a6" />
