### PR TITLE
feat(files): 添加图片预览功能

### DIFF
--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -34,6 +34,8 @@ import { useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 import { CommentForm, useEditorLineComment } from './EditorLineComment';
 import { EditorTabs } from './EditorTabs';
+import { isImageFile } from './fileIcons';
+import { ImagePreview } from './ImagePreview';
 import { MarkdownPreview } from './MarkdownPreview';
 import { CUSTOM_THEME_NAME, defineMonacoTheme } from './monacoTheme';
 // Import for side effects (Monaco setup)
@@ -111,6 +113,7 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
 
   // Markdown preview state
   const isMarkdown = isMarkdownFile(activeTabPath);
+  const isImage = isImageFile(activeTabPath);
   const [showPreview, setShowPreview] = useState(true);
   const [editorReady, setEditorReady] = useState(false);
   const [previewWidth, setPreviewWidth] = useState(50); // percentage
@@ -836,59 +839,66 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
               className="relative h-full overflow-hidden"
               style={{ width: isMarkdown && showPreview ? `${100 - previewWidth}%` : '100%' }}
             >
-              <Editor
-                key={activeTab.path}
-                width="100%"
-                height="100%"
-                path={activeTab.path}
-                value={activeTab.content}
-                theme={monacoTheme}
-                onChange={handleEditorChange}
-                onMount={handleEditorMount}
-                options={{
-                  // Display
-                  minimap: {
-                    enabled: isMarkdown && showPreview ? false : editorSettings.minimapEnabled,
-                    side: 'right',
-                    showSlider: 'mouseover',
-                    renderCharacters: false,
-                    maxColumn: 80,
-                  },
-                  lineNumbers: editorSettings.lineNumbers,
-                  wordWrap: editorSettings.wordWrap,
-                  renderWhitespace: editorSettings.renderWhitespace,
-                  renderLineHighlight: editorSettings.renderLineHighlight,
-                  folding: editorSettings.folding,
-                  links: editorSettings.links,
-                  smoothScrolling: editorSettings.smoothScrolling,
-                  // Font
-                  fontSize: editorSettings.fontSize,
-                  fontFamily: editorSettings.fontFamily,
-                  fontLigatures: editorSettings.fontLigatures,
-                  lineHeight: editorSettings.lineHeight,
-                  // Indentation
-                  tabSize: editorSettings.tabSize,
-                  insertSpaces: editorSettings.insertSpaces,
-                  // Cursor
-                  cursorStyle: editorSettings.cursorStyle,
-                  cursorBlinking: editorSettings.cursorBlinking,
-                  // Brackets
-                  bracketPairColorization: { enabled: editorSettings.bracketPairColorization },
-                  matchBrackets: editorSettings.matchBrackets,
-                  guides: {
-                    bracketPairs: editorSettings.bracketPairGuides,
-                    indentation: editorSettings.indentationGuides,
-                  },
-                  // Editing
-                  autoClosingBrackets: editorSettings.autoClosingBrackets,
-                  autoClosingQuotes: editorSettings.autoClosingQuotes,
-                  // Fixed options
-                  padding: { top: editorSettings.paddingTop, bottom: editorSettings.paddingBottom },
-                  scrollBeyondLastLine: false,
-                  automaticLayout: true,
-                  fixedOverflowWidgets: true,
-                }}
-              />
+              {isImage ? (
+                <ImagePreview path={activeTab.path} sessionId={sessionId ?? undefined} />
+              ) : (
+                <Editor
+                  key={activeTab.path}
+                  width="100%"
+                  height="100%"
+                  path={activeTab.path}
+                  value={activeTab.content}
+                  theme={monacoTheme}
+                  onChange={handleEditorChange}
+                  onMount={handleEditorMount}
+                  options={{
+                    // Display
+                    minimap: {
+                      enabled: isMarkdown && showPreview ? false : editorSettings.minimapEnabled,
+                      side: 'right',
+                      showSlider: 'mouseover',
+                      renderCharacters: false,
+                      maxColumn: 80,
+                    },
+                    lineNumbers: editorSettings.lineNumbers,
+                    wordWrap: editorSettings.wordWrap,
+                    renderWhitespace: editorSettings.renderWhitespace,
+                    renderLineHighlight: editorSettings.renderLineHighlight,
+                    folding: editorSettings.folding,
+                    links: editorSettings.links,
+                    smoothScrolling: editorSettings.smoothScrolling,
+                    // Font
+                    fontSize: editorSettings.fontSize,
+                    fontFamily: editorSettings.fontFamily,
+                    fontLigatures: editorSettings.fontLigatures,
+                    lineHeight: editorSettings.lineHeight,
+                    // Indentation
+                    tabSize: editorSettings.tabSize,
+                    insertSpaces: editorSettings.insertSpaces,
+                    // Cursor
+                    cursorStyle: editorSettings.cursorStyle,
+                    cursorBlinking: editorSettings.cursorBlinking,
+                    // Brackets
+                    bracketPairColorization: { enabled: editorSettings.bracketPairColorization },
+                    matchBrackets: editorSettings.matchBrackets,
+                    guides: {
+                      bracketPairs: editorSettings.bracketPairGuides,
+                      indentation: editorSettings.indentationGuides,
+                    },
+                    // Editing
+                    autoClosingBrackets: editorSettings.autoClosingBrackets,
+                    autoClosingQuotes: editorSettings.autoClosingQuotes,
+                    // Fixed options
+                    padding: {
+                      top: editorSettings.paddingTop,
+                      bottom: editorSettings.paddingBottom,
+                    },
+                    scrollBeyondLastLine: false,
+                    automaticLayout: true,
+                    fixedOverflowWidgets: true,
+                  }}
+                />
+              )}
             </div>
 
             {/* Resize Divider & Preview Panel (only for markdown with preview enabled) */}

--- a/src/renderer/components/files/ImagePreview.tsx
+++ b/src/renderer/components/files/ImagePreview.tsx
@@ -1,0 +1,135 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+interface ImagePreviewProps {
+  path: string;
+  sessionId?: string;
+}
+
+function normalizeForUrlPath(path: string): string {
+  let normalized = path.replace(/\\/g, '/');
+
+  // Windows drive path (C:/...) needs a leading slash in URL pathname (/C:/...)
+  if (/^[a-zA-Z]:\//.test(normalized)) {
+    normalized = `/${normalized}`;
+  } else if (!normalized.startsWith('/')) {
+    normalized = `/${normalized}`;
+  }
+
+  return normalized;
+}
+
+export function ImagePreview({ path }: ImagePreviewProps) {
+  const [scale, setScale] = useState(1);
+  const [imageDimensions, setImageDimensions] = useState<{ width: number; height: number } | null>(
+    null
+  );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const imageRef = useRef<HTMLImageElement>(null);
+
+  // Convert file path to local-file:// URL (Electron custom protocol)
+  const imageUrl = useMemo(() => {
+    const url = new URL('local-file://');
+    url.pathname = normalizeForUrlPath(path);
+    return url.toString();
+  }, [path]);
+
+  // Reset scale when image changes
+  // biome-ignore lint/correctness/useExhaustiveDependencies: path change should reset scale
+  useEffect(() => {
+    setScale(1);
+    setImageDimensions(null);
+  }, [path]);
+
+  // Handle wheel event for zooming
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    let rafId: number | null = null;
+
+    const handleWheel = (e: WheelEvent) => {
+      // Only zoom when Ctrl/Cmd is pressed
+      if (!e.ctrlKey && !e.metaKey) return;
+
+      e.preventDefault();
+
+      // Cancel previous animation frame
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+
+      // Use requestAnimationFrame to throttle updates
+      rafId = requestAnimationFrame(() => {
+        setScale((prevScale) => {
+          const delta = e.deltaY > 0 ? 0.9 : 1.1;
+          const newScale = prevScale * delta;
+          // Limit scale between 10% and 500%
+          return Math.min(Math.max(newScale, 0.1), 5);
+        });
+        rafId = null;
+      });
+    };
+
+    container.addEventListener('wheel', handleWheel, { passive: false });
+    return () => {
+      container.removeEventListener('wheel', handleWheel);
+      if (rafId !== null) {
+        cancelAnimationFrame(rafId);
+      }
+    };
+  }, []);
+
+  // Handle double click to reset scale
+  const handleDoubleClick = () => {
+    setScale(1);
+  };
+
+  // Handle image load to get dimensions
+  const handleImageLoad = (e: React.SyntheticEvent<HTMLImageElement>) => {
+    const img = e.currentTarget;
+    setImageDimensions({
+      width: img.naturalWidth,
+      height: img.naturalHeight,
+    });
+  };
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative flex h-full w-full flex-col items-center justify-center overflow-auto bg-[length:20px_20px]"
+      style={{
+        backgroundImage: `
+          linear-gradient(45deg, hsl(var(--muted)) 25%, transparent 25%),
+          linear-gradient(-45deg, hsl(var(--muted)) 25%, transparent 25%),
+          linear-gradient(45deg, transparent 75%, hsl(var(--muted)) 75%),
+          linear-gradient(-45deg, transparent 75%, hsl(var(--muted)) 75%)
+        `,
+        backgroundSize: '20px 20px',
+        backgroundPosition: '0 0, 0 10px, 10px -10px, -10px 0px',
+      }}
+      onDoubleClick={handleDoubleClick}
+    >
+      {/* Image */}
+      <img
+        ref={imageRef}
+        src={imageUrl}
+        alt={path.split('/').pop() || 'Preview'}
+        className="max-h-full max-w-full object-contain"
+        style={{
+          transform: `scale(${scale})`,
+          willChange: 'transform',
+          imageRendering: scale > 1 ? 'auto' : 'crisp-edges',
+        }}
+        onLoad={handleImageLoad}
+        draggable={false}
+      />
+
+      {/* Info bar */}
+      {imageDimensions && (
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded bg-background/80 px-3 py-1 text-xs text-muted-foreground backdrop-blur-sm">
+          {imageDimensions.width}×{imageDimensions.height} • {Math.round(scale * 100)}%
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/files/fileIcons.tsx
+++ b/src/renderer/components/files/fileIcons.tsx
@@ -15,6 +15,9 @@ import {
   Terminal,
 } from 'lucide-react';
 
+// Image file extensions for preview
+const imageExtensions = ['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico'];
+
 const fileIconMap: Record<string, LucideIcon> = {
   // JavaScript/TypeScript
   ts: FileCode,
@@ -40,6 +43,7 @@ const fileIconMap: Record<string, LucideIcon> = {
   gif: FileImage,
   svg: FileImage,
   webp: FileImage,
+  bmp: FileImage,
   ico: FileImage,
   // Documents
   md: FileText,
@@ -125,4 +129,10 @@ export function getFileIconColor(name: string, isDirectory: boolean): string {
     default:
       return 'text-muted-foreground';
   }
+}
+
+export function isImageFile(path: string | null | undefined): boolean {
+  if (!path) return false;
+  const ext = path.split('.').pop()?.toLowerCase() || '';
+  return imageExtensions.includes(ext);
 }


### PR DESCRIPTION
- 支持在编辑器中预览 PNG、JPG、GIF、WebP、SVG、BMP、ICO 等图片格式
- Ctrl/Cmd + 滚轮缩放图片 (10%-500%)
- 双击重置缩放
- 显示图片尺寸和缩放比例
- 使用 local-file:// 协议加载本地图片