### PR TITLE
fix(terminal): 修复 macOS 终端路径大小写问题

### DIFF
--- a/src/renderer/App/storage.ts
+++ b/src/renderer/App/storage.ts
@@ -150,6 +150,12 @@ export const normalizePath = (path: string): string => {
   return normalized;
 };
 
+// Clean path for storage (only removes trailing slashes, preserves case)
+// Use this when you need to store the original path but want consistent formatting
+export const cleanPath = (path: string): string => {
+  return path.replace(/[\\/]+$/, '');
+};
+
 // Check if two paths are equal (considering OS-specific rules)
 export const pathsEqual = (path1: string, path2: string): boolean => {
   return normalizePath(path1) === normalizePath(path2);


### PR DESCRIPTION
在 macOS 上，通过鼠标新建终端 Tab 时路径会变成小写（/users 而非 /Users）， 导致权限问题。

根因：normalizePath 函数将路径转为小写用于比较，但该小写路径被错误地
用作 worktreeStates 的 key 并传递给子组件。

修复：
- 新增 cleanPath 函数，只移除尾部斜杠但保留原始大小写
- 在 GroupState 中添加 originalPath 字段存储正确大小写的路径
- 传递给 TerminalGroup 时使用 originalPath 而非 normalized key