### PR TITLE
feat(keybindings): 添加工作区面板快捷键

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -109,6 +109,9 @@ export default function App() {
     getStoredBoolean(STORAGE_KEYS.WORKTREE_COLLAPSED, false)
   );
 
+  // Ref to toggle selected repo expanded in tree layout
+  const toggleSelectedRepoExpandedRef = useRef<(() => void) | null>(null);
+
   // Settings dialog state
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [settingsCategory, setSettingsCategory] = useState<
@@ -172,6 +175,15 @@ export default function App() {
     activeWorktreePath: activeWorktree?.path,
     onTabSwitch: handleTabChange,
     onActionPanelToggle: useCallback(() => setActionPanelOpen((prev) => !prev), []),
+    onToggleWorktree: useCallback(() => {
+      // In tree layout, toggle selected repo expanded; in columns layout, toggle worktree panel
+      if (layoutMode === 'tree') {
+        toggleSelectedRepoExpandedRef.current?.();
+      } else {
+        setWorktreeCollapsed((prev) => !prev);
+      }
+    }, [layoutMode]),
+    onToggleRepository: useCallback(() => setRepositoryCollapsed((prev) => !prev), []),
   });
 
   // Handle terminal file link navigation
@@ -1066,6 +1078,7 @@ export default function App() {
                   onMoveToGroup={handleMoveToGroup}
                   onSwitchTab={setActiveTab}
                   onSwitchWorktreeByPath={handleSwitchWorktreePath}
+                  toggleSelectedRepoExpandedRef={toggleSelectedRepoExpandedRef}
                 />
                 {/* Resize handle */}
                 <div

--- a/src/renderer/App/useAppKeyboardShortcuts.ts
+++ b/src/renderer/App/useAppKeyboardShortcuts.ts
@@ -7,12 +7,16 @@ interface UseAppKeyboardShortcutsOptions {
   activeWorktreePath: string | undefined;
   onTabSwitch: (tab: TabId) => void;
   onActionPanelToggle: () => void;
+  onToggleWorktree: () => void;
+  onToggleRepository: () => void;
 }
 
 export function useAppKeyboardShortcuts({
   activeWorktreePath: _activeWorktreePath,
   onTabSwitch,
   onActionPanelToggle,
+  onToggleWorktree,
+  onToggleRepository,
 }: UseAppKeyboardShortcutsOptions) {
   // Listen for Action Panel keyboard shortcut (Shift+Cmd+P)
   useEffect(() => {
@@ -53,4 +57,26 @@ export function useAppKeyboardShortcuts({
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [onTabSwitch]);
+
+  // Listen for workspace panel toggle shortcuts
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const bindings = useSettingsStore.getState().workspaceKeybindings;
+
+      if (matchesKeybinding(e, bindings.toggleWorktree)) {
+        e.preventDefault();
+        onToggleWorktree();
+        return;
+      }
+
+      if (matchesKeybinding(e, bindings.toggleRepository)) {
+        e.preventDefault();
+        onToggleRepository();
+        return;
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [onToggleWorktree, onToggleRepository]);
 }

--- a/src/renderer/components/layout/ActionPanel.tsx
+++ b/src/renderer/components/layout/ActionPanel.tsx
@@ -25,7 +25,18 @@ import { toastManager } from '@/components/ui/toast';
 import { useDetectedApps, useOpenWith } from '@/hooks/useAppDetector';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
-import { useSettingsStore } from '@/stores/settings';
+import { type TerminalKeybinding, useSettingsStore } from '@/stores/settings';
+
+// Format keybinding for display in ActionPanel
+function formatKeybindingDisplay(binding: TerminalKeybinding): string {
+  const parts: string[] = [];
+  if (binding.meta) parts.push('⌘');
+  if (binding.ctrl) parts.push('⌃');
+  if (binding.alt) parts.push('⌥');
+  if (binding.shift) parts.push('⇧');
+  parts.push(binding.key.toUpperCase());
+  return parts.join('');
+}
 
 function useCliInstallStatus() {
   return useQuery({
@@ -187,6 +198,9 @@ export function ActionPanel({
   const { data: detectedApps = [] } = useDetectedApps();
   const openWith = useOpenWith();
 
+  // Workspace keybindings for shortcut display
+  const workspaceKeybindings = useSettingsStore((s) => s.workspaceKeybindings);
+
   // CLI install status
   const { data: cliStatus } = useCliInstallStatus();
   const cliInstall = useCliInstall();
@@ -255,12 +269,14 @@ export function ActionPanel({
             id: 'toggle-repository',
             label: repositoryCollapsed ? t('Expand Repository') : t('Collapse Repository'),
             icon: repositoryCollapsed ? FolderOpen : PanelLeftClose,
+            shortcut: formatKeybindingDisplay(workspaceKeybindings.toggleRepository),
             action: onToggleRepository,
           },
           {
             id: 'toggle-worktree',
             label: worktreeCollapsed ? t('Expand Worktree') : t('Collapse Worktree'),
             icon: worktreeCollapsed ? GitBranch : PanelLeftOpen,
+            shortcut: formatKeybindingDisplay(workspaceKeybindings.toggleWorktree),
             action: onToggleWorktree,
           },
         ],
@@ -391,6 +407,7 @@ export function ActionPanel({
     detectedApps,
     cliStatus,
     recentIds,
+    workspaceKeybindings,
     onToggleRepository,
     onToggleWorktree,
     onOpenSettings,

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -94,6 +94,8 @@ interface TreeSidebarProps {
   onMoveToGroup?: (repoPath: string, groupId: string | null) => void;
   onSwitchTab?: (tab: TabId) => void;
   onSwitchWorktreeByPath?: (path: string) => Promise<void> | void;
+  /** Ref callback to expose toggleSelectedRepoExpanded function */
+  toggleSelectedRepoExpandedRef?: React.MutableRefObject<(() => void) | null>;
 }
 
 export function TreeSidebar({
@@ -128,6 +130,7 @@ export function TreeSidebar({
   onMoveToGroup,
   onSwitchTab,
   onSwitchWorktreeByPath,
+  toggleSelectedRepoExpandedRef,
 }: TreeSidebarProps) {
   const { t, tNode } = useI18n();
   const [searchQuery, setSearchQuery] = useState('');
@@ -261,6 +264,20 @@ export function TreeSidebar({
       return [...prev, repoPath];
     });
   }, []);
+
+  // Expose toggle function for selected repo via ref
+  useEffect(() => {
+    if (toggleSelectedRepoExpandedRef) {
+      toggleSelectedRepoExpandedRef.current = selectedRepo
+        ? () => toggleRepoExpanded(selectedRepo)
+        : null;
+    }
+    return () => {
+      if (toggleSelectedRepoExpandedRef) {
+        toggleSelectedRepoExpandedRef.current = null;
+      }
+    };
+  }, [toggleSelectedRepoExpandedRef, selectedRepo, toggleRepoExpanded]);
 
   // Repository drag handlers
   const handleRepoDragStart = useCallback((e: React.DragEvent, index: number, repo: Repository) => {

--- a/src/renderer/components/settings/KeybindingsSettings.tsx
+++ b/src/renderer/components/settings/KeybindingsSettings.tsx
@@ -103,6 +103,8 @@ export function KeybindingsSettings() {
     setSearchKeybindings,
     globalKeybindings,
     setGlobalKeybindings,
+    workspaceKeybindings,
+    setWorkspaceKeybindings,
   } = useSettingsStore();
   const { t } = useI18n();
 
@@ -121,6 +123,38 @@ export function KeybindingsSettings() {
                 setGlobalKeybindings({
                   ...globalKeybindings,
                   runningProjects: binding,
+                });
+              }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Workspace */}
+      <div className="border-t pt-6">
+        <h3 className="text-lg font-medium">{t('Workspace')}</h3>
+        <p className="text-sm text-muted-foreground mb-4">{t('Workspace panel shortcuts')}</p>
+        <div className="space-y-3">
+          <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+            <span className="text-sm">{t('Toggle Repository')}</span>
+            <KeybindingInput
+              value={workspaceKeybindings.toggleRepository}
+              onChange={(binding) => {
+                setWorkspaceKeybindings({
+                  ...workspaceKeybindings,
+                  toggleRepository: binding,
+                });
+              }}
+            />
+          </div>
+          <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+            <span className="text-sm">{t('Toggle Worktree')}</span>
+            <KeybindingInput
+              value={workspaceKeybindings.toggleWorktree}
+              onChange={(binding) => {
+                setWorkspaceKeybindings({
+                  ...workspaceKeybindings,
+                  toggleWorktree: binding,
                 });
               }}
             />

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -181,6 +181,12 @@ export interface GlobalKeybindings {
   runningProjects: TerminalKeybinding;
 }
 
+// Workspace panel keybindings
+export interface WorkspaceKeybindings {
+  toggleWorktree: TerminalKeybinding;
+  toggleRepository: TerminalKeybinding;
+}
+
 // Unified xterm keybindings (for Terminal, Agent, and all xterm-based components)
 export interface XtermKeybindings {
   newTab: TerminalKeybinding;
@@ -461,6 +467,11 @@ export const defaultGlobalKeybindings: GlobalKeybindings = {
   runningProjects: { key: 'l', meta: true },
 };
 
+export const defaultWorkspaceKeybindings: WorkspaceKeybindings = {
+  toggleWorktree: { key: 'w', meta: true, shift: true },
+  toggleRepository: { key: 'r', meta: true, shift: true },
+};
+
 interface SettingsState {
   theme: Theme;
   layoutMode: LayoutMode;
@@ -479,6 +490,7 @@ interface SettingsState {
   sourceControlKeybindings: SourceControlKeybindings;
   searchKeybindings: SearchKeybindings;
   globalKeybindings: GlobalKeybindings;
+  workspaceKeybindings: WorkspaceKeybindings;
   editorSettings: EditorSettings;
   agentSettings: AgentSettings;
   agentDetectionStatus: AgentDetectionStatus;
@@ -520,6 +532,7 @@ interface SettingsState {
   setSourceControlKeybindings: (keybindings: SourceControlKeybindings) => void;
   setSearchKeybindings: (keybindings: SearchKeybindings) => void;
   setGlobalKeybindings: (keybindings: GlobalKeybindings) => void;
+  setWorkspaceKeybindings: (keybindings: WorkspaceKeybindings) => void;
   setEditorSettings: (settings: Partial<EditorSettings>) => void;
   setAgentEnabled: (agentId: string, enabled: boolean) => void;
   setAgentDefault: (agentId: string) => void;
@@ -599,6 +612,7 @@ export const useSettingsStore = create<SettingsState>()(
       sourceControlKeybindings: defaultSourceControlKeybindings,
       searchKeybindings: defaultSearchKeybindings,
       globalKeybindings: defaultGlobalKeybindings,
+      workspaceKeybindings: defaultWorkspaceKeybindings,
       editorSettings: defaultEditorSettings,
       agentSettings: defaultAgentSettings,
       agentDetectionStatus: defaultAgentDetectionStatus,
@@ -668,6 +682,7 @@ export const useSettingsStore = create<SettingsState>()(
       setSourceControlKeybindings: (sourceControlKeybindings) => set({ sourceControlKeybindings }),
       setSearchKeybindings: (searchKeybindings) => set({ searchKeybindings }),
       setGlobalKeybindings: (globalKeybindings) => set({ globalKeybindings }),
+      setWorkspaceKeybindings: (workspaceKeybindings) => set({ workspaceKeybindings }),
       setEditorSettings: (settings) =>
         set((state) => ({
           editorSettings: { ...state.editorSettings, ...settings },
@@ -952,6 +967,10 @@ export const useSettingsStore = create<SettingsState>()(
           globalKeybindings: {
             ...currentState.globalKeybindings,
             ...persisted.globalKeybindings,
+          },
+          workspaceKeybindings: {
+            ...currentState.workspaceKeybindings,
+            ...persisted.workspaceKeybindings,
           },
           editorSettings: {
             ...currentState.editorSettings,

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -344,6 +344,7 @@ export const zhTranslations: Record<string, string> = {
   Workspace: '工作区',
   'Workspace clean': '工作区干净',
   'Workspace is not a Git repository': '当前目录还不是 Git 仓库，初始化后即可使用 Git 功能',
+  'Workspace panel shortcuts': '工作区面板快捷键',
   Worktrees: 'Worktree',
   'Worktree created': '创建 Worktree',
   'Worktree delete description prunable': '该目录已被删除，将清理 git 记录。',
@@ -355,6 +356,8 @@ export const zhTranslations: Record<string, string> = {
   'Worktree path already exists. Choose a different path or branch name.':
     '目录已存在，请选择其他路径或分支名',
   'Worktree search placeholder': '搜索 worktree...',
+  'Toggle Worktree': '折叠/展开 Worktree',
+  'Toggle Repository': '折叠/展开 Repository',
   'Yes, remove': '移除',
   'You have {{count}} changed files': '{{count}} 个文件已更改',
   'You have no worktrees yet': '暂无 Worktree',


### PR DESCRIPTION
## Summary

新增两个快捷键用于折叠/展开工作区面板，提升键盘操作效率。

### 新增快捷键

| 快捷键 | 功能 | 默认按键 |
|--------|------|----------|
| 折叠/展开 Worktree | 切换 Worktree 面板显示状态 | Cmd/Ctrl+Shift+W |
| 折叠/展开 Repository | 切换 Repository 面板显示状态 | Cmd/Ctrl+Shift+R |

### 功能特性

- **设置界面**：在「设置 → 快捷键」中新建「工作区」分组，位于「全局」分组下方
- **Action Panel 显示**：在 Cmd+Shift+P 弹出的操作面板中显示对应快捷键（如 ⌘⇧W）
- **树状布局适配**：
  - Cmd+Shift+W 触发选中仓库的 worktree 列表展开/折叠（小箭头）
  - Cmd+Shift+R 折叠/展开整个 TreeSidebar 面板
- **三栏布局**：
  - Cmd+Shift+W 切换 Worktree 面板折叠状态
  - Cmd+Shift+R 切换 Repository 面板折叠状态
- **国际化**：支持中英双语

### 修改文件

- `src/renderer/stores/settings.ts` - 添加 WorkspaceKeybindings 接口和默认值
- `src/renderer/components/settings/KeybindingsSettings.tsx` - 添加「工作区」分组 UI
- `src/renderer/App/useAppKeyboardShortcuts.ts` - 添加快捷键监听
- `src/renderer/App.tsx` - 根据布局模式切换快捷键行为
- `src/renderer/components/layout/ActionPanel.tsx` - 显示快捷键
- `src/renderer/components/layout/TreeSidebar.tsx` - 暴露选中仓库展开/折叠功能
- `src/shared/i18n.ts` - 添加中文翻译

## Test plan

- [ ] 三栏布局下按 Cmd+Shift+W 验证 Worktree 面板折叠/展开
- [ ] 三栏布局下按 Cmd+Shift+R 验证 Repository 面板折叠/展开
- [ ] 树状布局下按 Cmd+Shift+W 验证选中仓库的 worktree 列表展开/折叠
- [ ] 树状布局下按 Cmd+Shift+R 验证 TreeSidebar 面板折叠/展开
- [ ] 打开设置 → 快捷键，确认「工作区」分组在「全局」下方
- [ ] 按 Cmd+Shift+P 打开 Action Panel，确认快捷键显示在操作项右侧
- [ ] 切换语言验证中英文显示正确

🤖 Generated with [Claude Code](https://claude.ai/claude-code)