### PR TITLE
feat(ui): 为 Agent 和终端面板添加内边距并同步背景色

### DIFF
--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -11,6 +11,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { useI18n } from '@/i18n';
+import { defaultDarkTheme, getXtermTheme } from '@/lib/ghosttyTheme';
 import { matchesKeybinding } from '@/lib/keybinding';
 import { useAgentSessionsStore } from '@/stores/agentSessions';
 import { initAgentStatusListener } from '@/stores/agentStatus';
@@ -118,7 +119,11 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
     hapiSettings,
     autoCreateSessionOnActivate,
     claudeCodeIntegration,
+    terminalTheme,
   } = useSettingsStore();
+  const terminalBgColor = useMemo(() => {
+    return getXtermTheme(terminalTheme)?.background ?? defaultDarkTheme.background;
+  }, [terminalTheme]);
   const statusLineEnabled = claudeCodeIntegration.statusLineEnabled;
   const defaultAgentId = useMemo(() => getDefaultAgentId(agentSettings), [agentSettings]);
   const { setAgentCount, registerAgentCloseHandler } = useWorktreeActivityStore();
@@ -1020,7 +1025,7 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
   const currentGroupPositions = getGroupPositions(currentGroupState);
 
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-full w-full" style={{ backgroundColor: terminalBgColor }}>
       {/* Empty state overlay - shown when current worktree has no sessions */}
       {/* IMPORTANT: Don't use early return here - terminals must stay mounted to prevent PTY destruction */}
       {showEmptyState && (
@@ -1126,7 +1131,7 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
       {/* This container is NOT inside any worktree-specific wrapper, ensuring stable mounting */}
       {/* All sessions across ALL repos are rendered here to keep them mounted */}
       {/* bottom is dynamically set based on StatusLine height */}
-      <div className="absolute top-0 left-0 right-0 z-0" style={{ bottom: statusLineHeight }}>
+      <div className="absolute top-2 left-2 right-2 z-0" style={{ bottom: statusLineHeight + 8 }}>
         {Array.from(globalSessionIds).map((sessionId) => {
           const session = allSessions.find((s) => s.id === sessionId);
           if (!session) return null;

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -10,6 +10,7 @@ import {
   EmptyTitle,
 } from '@/components/ui/empty';
 import { useI18n } from '@/i18n';
+import { defaultDarkTheme, getXtermTheme } from '@/lib/ghosttyTheme';
 import { matchesKeybinding } from '@/lib/keybinding';
 import { useInitScriptStore } from '@/stores/initScript';
 import { useSettingsStore } from '@/stores/settings';
@@ -57,6 +58,10 @@ export function TerminalPanel({ cwd, isActive = false }: TerminalPanelProps) {
   const autoCreateSessionOnActivate = useSettingsStore(
     (state) => state.autoCreateSessionOnActivate
   );
+  const terminalTheme = useSettingsStore((state) => state.terminalTheme);
+  const terminalBgColor = useMemo(() => {
+    return getXtermTheme(terminalTheme)?.background ?? defaultDarkTheme.background;
+  }, [terminalTheme]);
   const { setTerminalCount, registerTerminalCloseHandler } = useWorktreeActivityStore();
   const syncTerminalSessions = useTerminalStore((s) => s.syncSessions);
   const { pendingScript, clearPendingScript } = useInitScriptStore();
@@ -798,7 +803,7 @@ export function TerminalPanel({ cwd, isActive = false }: TerminalPanelProps) {
   };
 
   return (
-    <div className="relative h-full w-full">
+    <div className="relative h-full w-full" style={{ backgroundColor: terminalBgColor }}>
       {/* Empty state overlay - shown when current worktree has no terminals */}
       {/* IMPORTANT: Don't use early return here - terminals must stay mounted to prevent PTY destruction */}
       {showEmptyState && (
@@ -869,7 +874,7 @@ export function TerminalPanel({ cwd, isActive = false }: TerminalPanelProps) {
             })}
 
             {/* All terminals - rendered in a single container with stable keys */}
-            <div className="absolute left-0 right-0 bottom-0 z-0" style={{ top: 36 }}>
+            <div className="absolute left-2 right-2 bottom-2 z-0" style={{ top: 44 }}>
               {Array.from(globalTerminalIds).map((tabId) => {
                 const info = findTabInfo(tabId);
                 if (!info) return null;


### PR DESCRIPTION
## Summary

- 为 AgentPanel 和 TerminalPanel 的终端视图容器添加 8px 内边距
- 父容器背景色自动同步终端主题背景色，当用户切换终端主题时实时更新

## 解决的问题

**痛点**：Agent 视图和终端视图的显示区域与父容器完全重叠，当终端绘制边框线条时会与容器边缘重叠，视觉效果不佳。

**解决方案**：
1. 在终端视图容器外增加 8px 内边距，让终端内容与容器边缘保持适当间距
2. 父容器背景色同步终端主题的背景色，确保间距区域颜色与终端内容协调统一

## 修改文件

| 文件 | 修改内容 |
|------|----------|
| `src/renderer/components/chat/AgentPanel.tsx` | 添加 terminalBgColor 计算，父容器应用背景色，终端容器添加 8px 间距 |
| `src/renderer/components/terminal/TerminalPanel.tsx` | 添加 terminalBgColor 计算，父容器应用背景色，终端容器添加 8px 间距 |

## Test plan

- [ ] 启动应用，打开 Agent 面板，确认终端视图与容器边缘有 8px 间距
- [ ] 启动应用，打开终端面板，确认终端视图与容器边缘有 8px 间距
- [ ] 切换终端主题（设置 → 外观 → 终端 → 配色方案），确认间距区域背景色同步更新
- [ ] 测试分屏功能正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)