### PR TITLE
fix(view-menu): 移除 globalShortcut 改用 before-input-event 修复 Cmd+- 缩放

### DIFF
--- a/src/main/services/MenuBuilder.ts
+++ b/src/main/services/MenuBuilder.ts
@@ -1,11 +1,6 @@
 import { translate } from '@shared/i18n';
-import { app, type BrowserWindow, globalShortcut, Menu, shell } from 'electron';
+import { app, type BrowserWindow, Menu, shell } from 'electron';
 import { getCurrentLocale } from './i18n';
-
-function handleZoomOut(window: BrowserWindow): void {
-  const currentZoom = window.webContents.getZoomLevel();
-  window.webContents.setZoomLevel(currentZoom - 0.5);
-}
 
 export type MenuAction = 'open-settings' | 'toggle-devtools' | 'open-action-panel';
 
@@ -122,8 +117,11 @@ export function buildAppMenu(mainWindow: BrowserWindow, options: MenuOptions = {
         },
         {
           label: t('Zoom Out'),
-          accelerator: 'CommandOrControl+Minus',
-          click: () => handleZoomOut(mainWindow),
+          accelerator: 'CommandOrControl+-',
+          click: () => {
+            const currentZoom = mainWindow.webContents.getZoomLevel();
+            mainWindow.webContents.setZoomLevel(currentZoom - 0.5);
+          },
         },
         { type: 'separator' as const },
         { role: 'togglefullscreen' as const },
@@ -159,14 +157,5 @@ export function buildAppMenu(mainWindow: BrowserWindow, options: MenuOptions = {
     },
   ];
 
-  const menu = Menu.buildFromTemplate(template);
-
-  // Register global shortcut for Zoom Out to bypass renderer process interception
-  // Unregister first to avoid conflicts
-  globalShortcut.unregister('CommandOrControl+-');
-  globalShortcut.register('CommandOrControl+-', () => {
-    handleZoomOut(mainWindow);
-  });
-
-  return menu;
+  return Menu.buildFromTemplate(template);
 }


### PR DESCRIPTION
问题描述：
之前为修复 Cmd+- 被渲染进程（Monaco Editor）拦截的问题，使用了
globalShortcut.register 方案。但这导致了严重 bug：
- 即使 EnsoAI 在后台，其他应用的 Cmd+- 也会被拦截
- 窗口引用过期风险：闭包中的 mainWindow 可能指向已关闭的窗口
- 多窗口场景失效：只有最后一个窗口能正常缩放

根本原因：
globalShortcut 是操作系统级别的全局快捷键，会拦截所有应用的键盘事件，
不适合用于应用内的菜单快捷键。

修复方案：
1. 移除 globalShortcut，改用 webContents.on before-input-event
2. 将监听器放在 app.on browser-window-created 中，确保所有窗口都生效
3. 使用闭包中的 window 参数而非全局 mainWindow，避免类型安全问题