### PR TITLE
fix(shortcuts): 修复 Cmd+, 快捷键无法切换设置页面的问题

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -213,7 +213,7 @@ export default function App() {
     const cleanup = window.electronAPI.menu.onAction((action) => {
       switch (action) {
         case 'open-settings':
-          setSettingsOpen(true);
+          setSettingsOpen((prev) => !prev);
           break;
         case 'open-action-panel':
           setActionPanelOpen(true);


### PR DESCRIPTION
将 setSettingsOpen(true) 改为 setSettingsOpen(prev => !prev)， 使设置页面可以通过快捷键切换显示/隐藏状态。
以前只能让他显示出来,再按不会隐藏.
现在连续按就可以切换显示和隐藏了.