### PR TITLE
feat(keybindings): 添加活跃工作树焦点切换快捷键

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -78,6 +78,7 @@ import { useNavigationStore } from './stores/navigation';
 import { useSettingsStore } from './stores/settings';
 import { requestUnsavedChoice } from './stores/unsavedPrompt';
 import { useWorktreeStore } from './stores/worktree';
+import { useWorktreeActivityStore } from './stores/worktreeActivity';
 
 // Initialize global clone progress listener
 initCloneProgressListener();
@@ -111,6 +112,9 @@ export default function App() {
 
   // Ref to toggle selected repo expanded in tree layout
   const toggleSelectedRepoExpandedRef = useRef<(() => void) | null>(null);
+
+  // Ref for cross-repo worktree switching (defined later)
+  const switchWorktreePathRef = useRef<((path: string) => void) | null>(null);
 
   // Settings dialog state
   const [settingsOpen, setSettingsOpen] = useState(false);
@@ -184,6 +188,31 @@ export default function App() {
       }
     }, [layoutMode]),
     onToggleRepository: useCallback(() => setRepositoryCollapsed((prev) => !prev), []),
+    onSwitchActiveWorktree: useCallback(() => {
+      const activities = useWorktreeActivityStore.getState().activities;
+
+      // 获取所有有活跃 agent 会话的 worktree 路径（跨所有仓库）
+      const activeWorktreePaths = Object.entries(activities)
+        .filter(([, activity]) => activity.agentCount > 0)
+        .map(([path]) => path)
+        .sort(); // 确保顺序稳定
+
+      // 边界检查：少于 2 个活跃 worktree 时无需切换
+      if (activeWorktreePaths.length < 2) {
+        return;
+      }
+
+      // 找到当前 worktree 在列表中的位置
+      const currentPath = activeWorktree?.path ?? '';
+      const currentIndex = activeWorktreePaths.indexOf(currentPath);
+
+      // 计算下一个索引（循环）
+      const nextIndex = currentIndex === -1 ? 0 : (currentIndex + 1) % activeWorktreePaths.length;
+
+      // 切换到下一个 worktree（使用 ref 调用跨仓库切换函数）
+      const nextWorktreePath = activeWorktreePaths[nextIndex];
+      switchWorktreePathRef.current?.(nextWorktreePath);
+    }, [activeWorktree?.path]),
   });
 
   // Handle terminal file link navigation
@@ -803,6 +832,9 @@ export default function App() {
     },
     [worktrees, repositories, worktreeTabMap, handleSelectWorktree]
   );
+
+  // Assign to ref for use in keyboard shortcut callback
+  switchWorktreePathRef.current = handleSwitchWorktreePath;
 
   // Open add repository dialog
   const handleAddRepository = () => {

--- a/src/renderer/App/useAppKeyboardShortcuts.ts
+++ b/src/renderer/App/useAppKeyboardShortcuts.ts
@@ -9,6 +9,7 @@ interface UseAppKeyboardShortcutsOptions {
   onActionPanelToggle: () => void;
   onToggleWorktree: () => void;
   onToggleRepository: () => void;
+  onSwitchActiveWorktree: () => void;
 }
 
 export function useAppKeyboardShortcuts({
@@ -17,6 +18,7 @@ export function useAppKeyboardShortcuts({
   onActionPanelToggle,
   onToggleWorktree,
   onToggleRepository,
+  onSwitchActiveWorktree,
 }: UseAppKeyboardShortcutsOptions) {
   // Listen for Action Panel keyboard shortcut (Shift+Cmd+P)
   useEffect(() => {
@@ -80,9 +82,16 @@ export function useAppKeyboardShortcuts({
         onToggleRepository();
         return;
       }
+
+      // 新增：切换活跃 worktree 焦点
+      if (matchesKeybinding(e, bindings.switchActiveWorktree)) {
+        e.preventDefault();
+        onSwitchActiveWorktree();
+        return;
+      }
     };
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [onToggleWorktree, onToggleRepository]);
+  }, [onToggleWorktree, onToggleRepository, onSwitchActiveWorktree]);
 }

--- a/src/renderer/components/chat/SessionBar.tsx
+++ b/src/renderer/components/chat/SessionBar.tsx
@@ -120,8 +120,9 @@ function SessionTab({
         {dropTargetIndex === index && draggedTabIndex !== null && draggedTabIndex > index && (
           <div className="absolute -left-1 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-full" />
         )}
-        <button
-          type="button"
+        <div
+          role="button"
+          tabIndex={0}
           className={cn(
             'group flex items-center gap-1.5 rounded-full px-3 py-1 text-sm transition-colors cursor-pointer',
             isActive
@@ -136,6 +137,12 @@ function SessionTab({
           onDragLeave={onDragLeave}
           onDrop={onDrop}
           onClick={onSelect}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              onSelect();
+            }
+          }}
           onContextMenu={(e) => {
             e.preventDefault();
             onStartEdit();
@@ -169,7 +176,7 @@ function SessionTab({
           >
             <X className="h-3 w-3" />
           </button>
-        </button>
+        </div>
         {/* Drop indicator - right side */}
         {dropTargetIndex === index && draggedTabIndex !== null && draggedTabIndex < index && (
           <div className="absolute -right-1 top-1/2 -translate-y-1/2 w-0.5 h-5 bg-primary rounded-full" />
@@ -187,7 +194,9 @@ function SessionTab({
       )}
       <GlowCard
         state={outputState}
-        as="button"
+        as="div"
+        role="button"
+        tabIndex={0}
         className={cn(
           'group flex items-center gap-1.5 rounded-full px-3 py-1 text-sm transition-colors cursor-pointer',
           isActive
@@ -202,7 +211,13 @@ function SessionTab({
         onDragLeave={onDragLeave}
         onDrop={onDrop}
         onClick={onSelect}
-        onContextMenu={(e) => {
+        onKeyDown={(e: React.KeyboardEvent) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
+        onContextMenu={(e: React.MouseEvent) => {
           e.preventDefault();
           onStartEdit();
         }}

--- a/src/renderer/components/settings/KeybindingsSettings.tsx
+++ b/src/renderer/components/settings/KeybindingsSettings.tsx
@@ -162,6 +162,19 @@ export function KeybindingsSettings() {
               }}
             />
           </div>
+          {/* 新增：切换活跃 Worktree */}
+          <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+            <span className="text-sm">{t('Switch Active Worktree')}</span>
+            <KeybindingInput
+              value={workspaceKeybindings.switchActiveWorktree}
+              onChange={(binding) => {
+                setWorkspaceKeybindings({
+                  ...workspaceKeybindings,
+                  switchActiveWorktree: binding,
+                });
+              }}
+            />
+          </div>
         </div>
       </div>
 

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -186,6 +186,7 @@ export interface GlobalKeybindings {
 export interface WorkspaceKeybindings {
   toggleWorktree: TerminalKeybinding;
   toggleRepository: TerminalKeybinding;
+  switchActiveWorktree: TerminalKeybinding;
 }
 
 // Unified xterm keybindings (for Terminal, Agent, and all xterm-based components)
@@ -472,6 +473,7 @@ export const defaultGlobalKeybindings: GlobalKeybindings = {
 export const defaultWorkspaceKeybindings: WorkspaceKeybindings = {
   toggleWorktree: { key: 'w', meta: true, shift: true },
   toggleRepository: { key: 'r', meta: true, shift: true },
+  switchActiveWorktree: { key: 'CapsLock', ctrl: true },
 };
 
 interface SettingsState {


### PR DESCRIPTION
- 在 WorkspaceKeybindings 中新增 switchActiveWorktree 字段
- 默认快捷键设置为 Ctrl+CapsLock
- 实现在有活跃 agent 会话的 worktree 间循环切换（支持跨仓库）
- 在设置页面 Workspace 区域添加快捷键配置项