### PR TITLE
feat(agent): 在 SessionBar 添加 Claude Provider 标签

### DIFF
--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -890,6 +890,8 @@ export const zhTranslations: Record<string, string> = {
   'Opus Model': 'Opus 模型',
   'Haiku Model': 'Haiku 模型',
   'Provider switched': '已切换 Provider',
+  'Select Provider': '选择 Claude Provider',
+  'Switch failed': '切换失败',
   'New provider detected': '检测到新配置',
   'Click to save this config': '点击保存此配置',
   'Open Settings': '打开设置',


### PR DESCRIPTION
- 在浮动工具栏右侧添加 Provider Tag
- 显示当前激活的 Provider 名称（最多 15 字符）
- 支持点击弹出 Provider 选择菜单
- 支持快速切换 Provider
- 添加切换成功/失败的 Toast 通知
- 吸附状态下自动隐藏 Tag
- 修复靠近右侧边缘时内容被挤压的问题
- 添加国际化翻译（选择 Claude Provider、切换失败）