### PR TITLE
fix(terminal): 修复终端页面不支持 Shift+Enter 换行输入

### DIFF
--- a/src/renderer/components/terminal/ShellTerminal.tsx
+++ b/src/renderer/components/terminal/ShellTerminal.tsx
@@ -30,6 +30,17 @@ export function ShellTerminal({
 }: ShellTerminalProps) {
   const { t } = useI18n();
 
+  // Handle Shift+Enter for newline (send LF character)
+  const handleCustomKey = useCallback((event: KeyboardEvent, ptyId: string) => {
+    if (event.key === 'Enter' && event.shiftKey) {
+      if (event.type === 'keydown') {
+        window.electronAPI.terminal.write(ptyId, '\x0a');
+      }
+      return false; // Prevent default Enter behavior
+    }
+    return true;
+  }, []);
+
   const {
     containerRef,
     isLoading,
@@ -49,6 +60,7 @@ export function ShellTerminal({
     onSplit,
     onMerge,
     canMerge,
+    onCustomKey: handleCustomKey,
   });
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchBarRef = useRef<TerminalSearchBarRef>(null);


### PR DESCRIPTION
## Summary
- 修复终端页面的 ShellTerminal 组件不支持 Shift+Enter 换行输入的问题
- Agent 页面的终端已支持此功能，但终端页面缺少 `onCustomKey` 回调处理
- 添加 `handleCustomKey` 函数拦截 Shift+Enter 并发送换行符（`\x0a`）到 PTY

## Test plan
- [ ] 打开终端页面，启动一个 Shell 终端
- [ ] 按下 Shift+Enter，确认可以换行输入而不会触发命令提交
- [ ] 确认 Agent 页面的终端 Shift+Enter 功能仍正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)