### PR TITLE
fix(sidebar): 修复添加仓库里按钮嵌套导致的 hydration 错误

### DIFF
--- a/src/renderer/components/layout/RepositorySidebar.tsx
+++ b/src/renderer/components/layout/RepositorySidebar.tsx
@@ -338,18 +338,27 @@ export function RepositorySidebar({
                           )}
                         />
                         <span className="truncate font-medium flex-1">{repo.name}</span>
-                        <button
-                          type="button"
-                          className="shrink-0 p-1 rounded hover:bg-muted"
+                        <div
+                          role="button"
+                          tabIndex={0}
+                          className="shrink-0 p-1 rounded hover:bg-muted cursor-pointer"
                           onClick={(e) => {
                             e.stopPropagation();
                             setRepoSettingsTarget(repo);
                             setRepoSettingsOpen(true);
                           }}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              e.stopPropagation();
+                              setRepoSettingsTarget(repo);
+                              setRepoSettingsOpen(true);
+                            }
+                          }}
                           title={t('Repository Settings')}
                         >
                           <Settings2 className="h-3.5 w-3.5 text-muted-foreground" />
-                        </button>
+                        </div>
                       </div>
 
                       {/* Tags (Group) */}


### PR DESCRIPTION
前端在添加仓库页面,点击添加按钮时有一个报错.不允许在button 里嵌套button.
修复方式:
将仓库项内的设置按钮从 <button> 改为 <div role="button">，
避免 HTML 规范不允许的 button 嵌套问题，同时保持键盘可访问性。

视觉和功能上无任何影响.