### PR TITLE
fix(ui): 优化 Worktree 面板激活状态下的对比度

### DIFF
--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -627,8 +627,9 @@ export function TreeSidebar({
                           <span className="shrink-0 w-5 h-5 flex items-center justify-center">
                             <ChevronRight
                               className={cn(
-                                'h-3.5 w-3.5 text-muted-foreground transition-transform duration-200',
-                                isExpanded && 'rotate-90'
+                                'h-3.5 w-3.5 transition-transform duration-200',
+                                isExpanded && 'rotate-90',
+                                isSelected ? 'text-accent-foreground/70' : 'text-muted-foreground'
                               )}
                             />
                           </span>
@@ -679,7 +680,14 @@ export function TreeSidebar({
                                 }}
                                 title={t('New Worktree')}
                               >
-                                <Plus className="h-3.5 w-3.5 text-muted-foreground" />
+                                <Plus
+                                  className={cn(
+                                    'h-3.5 w-3.5',
+                                    isSelected
+                                      ? 'text-accent-foreground/70'
+                                      : 'text-muted-foreground'
+                                  )}
+                                />
                               </button>
                             }
                           />
@@ -695,13 +703,21 @@ export function TreeSidebar({
                             }}
                             title={t('Repository Settings')}
                           >
-                            <Settings2 className="h-3.5 w-3.5 text-muted-foreground" />
+                            <Settings2
+                              className={cn(
+                                'h-3.5 w-3.5',
+                                isSelected ? 'text-accent-foreground/70' : 'text-muted-foreground'
+                              )}
+                            />
                           </button>
                         </div>
 
                         {/* Row 3: Path */}
                         <span
-                          className="relative z-10 pl-6 overflow-hidden whitespace-nowrap text-ellipsis text-xs text-muted-foreground [direction:rtl] [text-align:left]"
+                          className={cn(
+                            'relative z-10 pl-6 overflow-hidden whitespace-nowrap text-ellipsis text-xs [direction:rtl] [text-align:left]',
+                            isSelected ? 'text-accent-foreground/60' : 'text-muted-foreground'
+                          )}
                           title={repo.path}
                         >
                           {repo.path}
@@ -1308,7 +1324,12 @@ function WorktreeTreeItem({
         )}
         {/* Activity counts and diff stats */}
         {hasActivity && (
-          <div className="relative z-10 flex items-center gap-1.5 shrink-0 text-[10px] text-muted-foreground">
+          <div
+            className={cn(
+              'relative z-10 flex items-center gap-1.5 shrink-0 text-[10px]',
+              isActive ? 'text-accent-foreground/70' : 'text-muted-foreground'
+            )}
+          >
             {activity.agentCount > 0 && (
               <span className="flex items-center gap-0.5">
                 <Sparkles className="h-3 w-3" />


### PR DESCRIPTION
## 问题描述

左侧 Worktree 面板在激活/选中状态下，灰色的字体和图标对比度不足，难以辨认。

## 解决方案

为以下元素添加条件样式，在选中/激活状态下使用更高对比度的颜色：

### 仓库行（Repository Row）
- **ChevronRight 图标**：选中时使用 `text-accent-foreground/70`
- **Plus 图标**（新建 Worktree 按钮）：选中时使用 `text-accent-foreground/70`
- **Settings2 图标**：选中时使用 `text-accent-foreground/70`
- **仓库路径文本**：选中时使用 `text-accent-foreground/60`

### Worktree 项（WorktreeTreeItem）
- **活动计数**（Agent/Terminal 数量）：激活时使用 `text-accent-foreground/70`

## 测试

- [x] 构建通过
- [x] 视觉验证：选中/激活状态下图标和文字清晰可见