### PR TITLE
fix(theme): 优化同步终端模式下的 accent 颜色

### DIFF
--- a/src/renderer/lib/ghosttyTheme.ts
+++ b/src/renderer/lib/ghosttyTheme.ts
@@ -280,11 +280,12 @@ export function applyTerminalThemeToApp(themeName: string, syncDarkMode = true):
   root.style.setProperty('--muted', mutedBg);
   root.style.setProperty('--muted-foreground', mutedFg);
 
-  // Accent - use blue (more neutral than cyan)
+  // Accent - use blue mixed with background for softer appearance
   const accentColor = isDark ? theme.brightBlue : theme.blue;
-  const isAccentDark = getLuminance(accentColor) < 0.5;
-  root.style.setProperty('--accent', accentColor);
-  root.style.setProperty('--accent-foreground', isAccentDark ? '#ffffff' : '#000000');
+  const softAccent = mixColors(theme.background, accentColor, 0.3);
+  const isSoftAccentDark = getLuminance(softAccent) < 0.5;
+  root.style.setProperty('--accent', softAccent);
+  root.style.setProperty('--accent-foreground', isSoftAccentDark ? '#ffffff' : '#000000');
 
   // Semantic colors
   root.style.setProperty('--destructive', theme.red);


### PR DESCRIPTION
## 问题描述

在"同步终端"主题模式下，accent 颜色直接使用终端主题的蓝色，导致选中效果过于刺眼，在暗色和亮色模式下都不舒服。

## 解决方案

将 accent 颜色与背景色混合（70% 背景 + 30% 蓝色），使选中效果更柔和。

```typescript
// 修改前
const accentColor = isDark ? theme.brightBlue : theme.blue;
root.style.setProperty('--accent', accentColor);

// 修改后
const softAccent = mixColors(theme.background, accentColor, 0.3);
root.style.setProperty('--accent', softAccent);
```