### PR TITLE
fix(git): 修复 auto-fetch 后 worktree 列表不刷新的问题

### DIFF
--- a/src/renderer/hooks/useGit.ts
+++ b/src/renderer/hooks/useGit.ts
@@ -195,6 +195,7 @@ export function useAutoFetchListener() {
       queryClient.invalidateQueries({ queryKey: ['git', 'status'] });
       queryClient.invalidateQueries({ queryKey: ['git', 'branches'] });
       queryClient.invalidateQueries({ queryKey: ['worktree', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['worktree', 'listMultiple'] });
     });
 
     return cleanup;


### PR DESCRIPTION
## 问题

在终端中手动切换分支后，TreeSidebar 中的 worktree 列表不会自动更新显示最新的分支信息。

## 原因

`useAutoFetchListener` hook 在 auto-fetch 完成后会刷新 `['worktree', 'list']` 缓存，但 TreeSidebar 使用的是 `useWorktreeListMultiple` hook，其 queryKey 为 `['worktree', 'listMultiple', repoPath]`。

由于 queryKey 前缀不匹配，导致 TreeSidebar 的 worktree 列表缓存没有被刷新。

## 解决方案

在 `useAutoFetchListener` 中添加刷新 `['worktree', 'listMultiple']` 缓存的调用，利用 React Query 的前缀匹配机制，确保所有 `listMultiple` 查询都会被刷新。

## 变更

- `src/renderer/hooks/useGit.ts`: 添加 1 行代码刷新 `['worktree', 'listMultiple']` 缓存