### PR TITLE
feat(sidebar): 支持拖放文件夹到侧边栏添加仓库

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { AnimatePresence, motion } from 'framer-motion';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { consumeClaudeProviderSwitch, isClaudeProviderMatch } from '@/lib/claudeProvider';
 import { normalizeHexColor } from '@/lib/colors';
+import { cn } from '@/lib/utils';
 import {
   ALL_GROUP_ID,
   DEFAULT_GROUP_COLOR,
@@ -158,6 +159,66 @@ export default function App() {
     }
   }, [settingsCategory]);
 
+  // Global drag-and-drop for repository sidebar
+  const [isFileDragOver, setIsFileDragOver] = useState(false);
+  const repositorySidebarRef = useRef<HTMLDivElement>(null);
+  const isFileDragOverRef = useRef(false);
+
+  // Keep ref in sync with state for use in event handlers
+  useEffect(() => {
+    isFileDragOverRef.current = isFileDragOver;
+  }, [isFileDragOver]);
+
+  useEffect(() => {
+    const handleDragOver = (e: DragEvent) => {
+      if (!e.dataTransfer?.types.includes('Files')) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'copy';
+
+      // Check if over sidebar
+      const el = repositorySidebarRef.current;
+      if (el) {
+        const rect = el.getBoundingClientRect();
+        const over =
+          e.clientX >= rect.left &&
+          e.clientX <= rect.right &&
+          e.clientY >= rect.top &&
+          e.clientY <= rect.bottom;
+        setIsFileDragOver(over);
+      }
+    };
+
+    const handleDragLeave = (e: DragEvent) => {
+      if (e.clientX <= 0 || e.clientY <= 0) {
+        setIsFileDragOver(false);
+      }
+    };
+
+    const handleDrop = (e: DragEvent) => {
+      e.preventDefault();
+      const wasOver = isFileDragOverRef.current;
+      setIsFileDragOver(false);
+
+      if (wasOver && e.dataTransfer?.files.length) {
+        const file = e.dataTransfer.files[0];
+        const path = window.electronAPI.utils.getPathForFile(file);
+        if (path) {
+          setInitialLocalPath(path);
+          setAddRepoDialogOpen(true);
+        }
+      }
+    };
+
+    document.addEventListener('dragover', handleDragOver);
+    document.addEventListener('dragleave', handleDragLeave);
+    document.addEventListener('drop', handleDrop);
+    return () => {
+      document.removeEventListener('dragover', handleDragOver);
+      document.removeEventListener('dragleave', handleDragLeave);
+      document.removeEventListener('drop', handleDrop);
+    };
+  }, []);
+
   // 创建回调函数
   const handleSettingsCategoryChange = useCallback((category: SettingsCategory) => {
     setSettingsCategory(category);
@@ -165,6 +226,7 @@ export default function App() {
 
   // Add Repository dialog state
   const [addRepoDialogOpen, setAddRepoDialogOpen] = useState(false);
+  const [initialLocalPath, setInitialLocalPath] = useState<string | null>(null);
 
   // Action panel state
   const [actionPanelOpen, setActionPanelOpen] = useState(false);
@@ -1238,6 +1300,7 @@ export default function App() {
           <AnimatePresence initial={false}>
             {!repositoryCollapsed && (
               <motion.div
+                ref={repositorySidebarRef}
                 key="tree-sidebar"
                 initial={{ width: 0, opacity: 0 }}
                 animate={{ width: treeSidebarWidth, opacity: 1 }}
@@ -1283,6 +1346,7 @@ export default function App() {
                   toggleSelectedRepoExpandedRef={toggleSelectedRepoExpandedRef}
                   isSettingsActive={activeTab === 'settings'}
                   onToggleSettings={toggleSettings}
+                  isFileDragOver={isFileDragOver}
                 />
                 {/* Resize handle */}
                 <div
@@ -1299,6 +1363,7 @@ export default function App() {
             <AnimatePresence initial={false}>
               {!repositoryCollapsed && (
                 <motion.div
+                  ref={repositorySidebarRef}
                   key="repository"
                   initial={{ width: 0, opacity: 0 }}
                   animate={{ width: repositoryWidth, opacity: 1 }}
@@ -1327,6 +1392,7 @@ export default function App() {
                     onSwitchWorktreeByPath={handleSwitchWorktreePath}
                     isSettingsActive={activeTab === 'settings'}
                     onToggleSettings={toggleSettings}
+                    isFileDragOver={isFileDragOver}
                   />
                   {/* Resize handle */}
                   <div
@@ -1421,6 +1487,8 @@ export default function App() {
           onAddLocal={handleAddLocalRepository}
           onCloneComplete={handleCloneRepository}
           onCreateGroup={handleCreateGroup}
+          initialLocalPath={initialLocalPath ?? undefined}
+          onClearInitialLocalPath={() => setInitialLocalPath(null)}
         />
 
         {/* Action Panel */}

--- a/src/renderer/components/git/AddRepositoryDialog.tsx
+++ b/src/renderer/components/git/AddRepositoryDialog.tsx
@@ -39,6 +39,10 @@ interface AddRepositoryDialogProps {
   onAddLocal: (path: string, groupId: string | null) => void;
   onCloneComplete: (path: string, groupId: string | null) => void;
   onCreateGroup: (name: string, emoji: string, color: string) => RepositoryGroup;
+  /** Pre-filled local path (e.g., from drag-and-drop) */
+  initialLocalPath?: string;
+  /** Callback to clear the initial local path after it's been used */
+  onClearInitialLocalPath?: () => void;
 }
 
 export function AddRepositoryDialog({
@@ -49,6 +53,8 @@ export function AddRepositoryDialog({
   onAddLocal,
   onCloneComplete,
   onCreateGroup,
+  initialLocalPath,
+  onClearInitialLocalPath,
 }: AddRepositoryDialogProps) {
   const { t } = useI18n();
 
@@ -88,6 +94,15 @@ export function AddRepositoryDialog({
     prevOpenRef.current = open;
     prevDefaultGroupIdRef.current = defaultGroupId;
   }, [open, defaultGroupId, selectedGroupId]);
+
+  // Handle initial local path from drag-and-drop
+  React.useEffect(() => {
+    if (open && initialLocalPath) {
+      setMode('local');
+      setLocalPath(initialLocalPath);
+      onClearInitialLocalPath?.();
+    }
+  }, [open, initialLocalPath, onClearInitialLocalPath]);
 
   // Local mode state
   const [localPath, setLocalPath] = React.useState('');

--- a/src/renderer/components/layout/RepositorySidebar.tsx
+++ b/src/renderer/components/layout/RepositorySidebar.tsx
@@ -61,6 +61,8 @@ interface RepositorySidebarProps {
   onMoveToGroup?: (repoPath: string, groupId: string | null) => void;
   onSwitchTab?: (tab: TabId) => void;
   onSwitchWorktreeByPath?: (path: string) => Promise<void> | void;
+  /** Whether a file is being dragged over the sidebar (from App.tsx global handler) */
+  isFileDragOver?: boolean;
 }
 
 export function RepositorySidebar({
@@ -84,6 +86,7 @@ export function RepositorySidebar({
   onMoveToGroup,
   onSwitchTab,
   onSwitchWorktreeByPath,
+  isFileDragOver,
 }: RepositorySidebarProps) {
   const { t, tNode } = useI18n();
   const _settingsDisplayMode = useSettingsStore((s) => s.settingsDisplayMode);
@@ -206,7 +209,12 @@ export function RepositorySidebar({
   }, [repositories, activeGroupId, searchQuery]);
 
   return (
-    <aside className="flex h-full w-full flex-col border-r bg-background">
+    <aside
+      className={cn(
+        'flex h-full w-full flex-col border-r bg-background transition-colors',
+        isFileDragOver && 'bg-primary/10'
+      )}
+    >
       {/* Header */}
       <div className="flex h-12 items-center justify-end gap-1 border-b px-3 drag-region">
         {onSwitchWorktreeByPath && (

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -101,6 +101,8 @@ interface TreeSidebarProps {
   onSwitchWorktreeByPath?: (path: string) => Promise<void> | void;
   /** Ref callback to expose toggleSelectedRepoExpanded function */
   toggleSelectedRepoExpandedRef?: React.MutableRefObject<(() => void) | null>;
+  /** Whether a file is being dragged over the sidebar (from App.tsx global handler) */
+  isFileDragOver?: boolean;
 }
 
 export function TreeSidebar({
@@ -138,6 +140,7 @@ export function TreeSidebar({
   onSwitchTab,
   onSwitchWorktreeByPath,
   toggleSelectedRepoExpandedRef,
+  isFileDragOver,
 }: TreeSidebarProps) {
   const { t, tNode } = useI18n();
   const _settingsDisplayMode = useSettingsStore((s) => s.settingsDisplayMode);
@@ -465,7 +468,12 @@ export function TreeSidebar({
   );
 
   return (
-    <aside className="flex h-full w-full flex-col border-r bg-background">
+    <aside
+      className={cn(
+        'flex h-full w-full flex-col border-r bg-background transition-colors',
+        isFileDragOver && 'bg-primary/10'
+      )}
+    >
       {/* Header */}
       <div className="flex h-12 items-center justify-end gap-1 border-b px-3 drag-region">
         <div className="flex items-center gap-1">


### PR DESCRIPTION
## 📋 变更描述

支持从 Finder/文件管理器拖放文件夹到仓库侧边栏，自动打开添加仓库对话框并预填路径。

## ✨ 新功能

- 🎯 拖放文件夹到侧边栏时显示高亮背景提示
- 📂 释放后自动打开"添加仓库"对话框
- 📝 自动预填拖放的文件夹路径
- 🔒 使用 Electron `webUtils.getPathForFile` API 安全获取路径

## 📁 变更文件

| 文件 | 变更说明 |
|------|---------|
| `src/renderer/App.tsx` | 添加全局拖放事件处理 |
| `src/renderer/components/git/AddRepositoryDialog.tsx` | 支持预填路径 |
| `src/renderer/components/layout/RepositorySidebar.tsx` | 添加拖放高亮样式 |
| `src/renderer/components/layout/TreeSidebar.tsx` | 添加拖放高亮样式 |

## 🧪 测试

- [x] 从 Finder 拖放文件夹到侧边栏
- [x] 高亮效果正常显示
- [x] 对话框正确打开并预填路径
- [x] Tree 布局和 Columns 布局均正常工作

## 📸 效果预览

拖放文件夹时侧边栏显示 `bg-primary/10` 高亮背景，释放后自动打开添加仓库对话框。