### PR TITLE
feat(ai): 支持自定义 AI Commit 提示词

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -209,6 +209,7 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> => {
       const resolved = validateWorkdir(workdir);
@@ -219,6 +220,7 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        prompt: options.prompt,
       });
     }
   );

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -107,6 +107,7 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG, workdir, options),

--- a/src/renderer/components/settings/AISettings.tsx
+++ b/src/renderer/components/settings/AISettings.tsx
@@ -11,6 +11,8 @@ import { useI18n } from '@/i18n';
 import {
   type AIProvider,
   defaultBranchNameGeneratorSettings,
+  defaultCommitPromptEn,
+  defaultCommitPromptZh,
   type ReasoningEffort,
   useSettingsStore,
 } from '@/stores/settings';
@@ -56,7 +58,7 @@ function getDefaultModel(provider: AIProvider): string {
 }
 
 export function AISettings() {
-  const { t } = useI18n();
+  const { t, locale } = useI18n();
   const {
     commitMessageGenerator,
     setCommitMessageGenerator,
@@ -251,6 +253,46 @@ export function AISettings() {
                   </SelectPopup>
                 </Select>
                 <p className="text-xs text-muted-foreground">{t('Timeout in seconds')}</p>
+              </div>
+            </div>
+
+            {/* Commit Prompt */}
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium">{t('Commit Prompt')}</span>
+              <div className="space-y-1.5">
+                <textarea
+                  value={commitMessageGenerator.prompt}
+                  onChange={(e) => setCommitMessageGenerator({ prompt: e.target.value })}
+                  maxLength={4000}
+                  className="w-full h-40 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder={t(
+                    'Enter a prompt template for generating commit messages.\nAvailable variables:\n• {recent_commits} - Recent commit messages\n• {staged_stat} - Staged changes statistics\n• {staged_diff} - Staged changes diff'
+                  )}
+                />
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    {t('Customize the AI prompt for generating commit messages')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (
+                        window.confirm(
+                          t(
+                            'This will restore the default AI prompt for generating commit messages. Your custom prompt will be lost.'
+                          )
+                        )
+                      ) {
+                        setCommitMessageGenerator({
+                          prompt: locale === 'zh' ? defaultCommitPromptZh : defaultCommitPromptEn,
+                        });
+                      }
+                    }}
+                    className="text-xs text-muted-foreground hover:text-primary underline"
+                  >
+                    {t('Restore default prompt')}
+                  </button>
+                </div>
               </div>
             </div>
           </div>

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -50,6 +50,7 @@ export function CommitBox({
         provider: commitMessageGenerator.provider,
         model: commitMessageGenerator.model,
         reasoningEffort: commitMessageGenerator.reasoningEffort,
+        prompt: commitMessageGenerator.prompt,
       });
 
       if (result.success && result.message) {

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -279,7 +279,51 @@ export interface CommitMessageGeneratorSettings {
   provider: AIProvider;
   model: string; // Dynamic based on provider
   reasoningEffort?: ReasoningEffort; // For Codex CLI
+  prompt: string; // Custom prompt template
 }
+
+// Default prompts for different languages
+export const defaultCommitPromptZh = `你是一个 Git commit message 生成助手。请根据以下信息生成规范的 commit message。
+
+要求：
+1. 遵循 Conventional Commits 规范
+2. 格式：<type>(<scope>): <description>
+3. type 包括：feat, fix, docs, style, refactor, perf, test, chore, ci, build
+4. scope 可选，表示影响范围
+5. description 使用中文，简洁明了
+6. 如果变更较复杂，可以添加正文说明
+
+参考最近的提交风格：
+{recent_commits}
+
+变更摘要：
+{staged_stat}
+
+变更详情：
+{staged_diff}
+
+请直接输出 commit message，无需解释。`;
+
+export const defaultCommitPromptEn = `You are a Git commit message generator. Generate a commit message based on the following information.
+
+Requirements:
+1. Follow Conventional Commits specification
+2. Format: <type>(<scope>): <description>
+3. Types: feat, fix, docs, style, refactor, perf, test, chore, ci, build
+4. Scope is optional, indicates the affected area
+5. Description should be concise and clear
+6. Add body for complex changes
+
+Reference recent commit style:
+{recent_commits}
+
+Changes summary:
+{staged_stat}
+
+Changes detail:
+{staged_diff}
+
+Output the commit message directly, no explanation needed.`;
 
 export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettings = {
   enabled: true,
@@ -287,6 +331,7 @@ export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettin
   timeout: 120,
   provider: 'claude-code',
   model: 'haiku',
+  prompt: defaultCommitPromptZh,
 };
 
 export interface CodeReviewSettings {

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -742,6 +742,13 @@ export const zhTranslations: Record<string, string> = {
   'Restore default prompt': '恢复默认提示词',
   'This will restore the default AI prompt for generating branch names. Your custom prompt will be lost.':
     '这将恢复生成分支名称的默认 AI 提示词。您的自定义提示词将丢失。',
+  // Commit Prompt section
+  'Commit Prompt': '提交提示词',
+  'Customize the AI prompt for generating commit messages': '自定义生成提交信息的 AI 提示词',
+  'Enter a prompt template for generating commit messages.\nAvailable variables:\n• {recent_commits} - Recent commit messages\n• {staged_stat} - Staged changes statistics\n• {staged_diff} - Staged changes diff':
+    '输入提示词模板，AI 将根据您的规则生成提交信息。\n可用变量：\n• {recent_commits} - 最近的提交信息\n• {staged_stat} - 暂存区变更统计\n• {staged_diff} - 暂存区变更详情',
+  'This will restore the default AI prompt for generating commit messages. Your custom prompt will be lost.':
+    '这将恢复生成提交信息的默认 AI 提示词。您的自定义提示词将丢失。',
   // Auto Save section
   'Auto Save': '自动保存',
   'Auto save settings': '自动保存设置',


### PR DESCRIPTION
## 概述

支持用户自定义 AI Commit 提示词，解决 #235 和 #210 中提出的需求。

## 变更内容

### 新功能
- 添加 **Commit Prompt** 设置项，支持用户自定义提示词模板
- 支持中英文双语默认提示词，根据语言设置自动切换
- 提供"恢复默认提示词"按钮

### 技术改进
- 使用安全的正则单次替换，避免模板注入风险
- 添加输入长度限制 (maxLength=4000)
- 完善国际化翻译

## 可用变量

| 变量 | 说明 |
|------|------|
| `{recent_commits}` | 最近的提交信息 |
| `{staged_stat}` | 暂存区变更统计 |
| `{staged_diff}` | 暂存区变更详情 |

## 关联 Issue

Closes #235
Closes #210