### PR TITLE
fix(editor): 修复切换标签页后文件保存失败的问题

### DIFF
--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -33,7 +33,9 @@ export function useEditor() {
 
   const saveFile = useMutation({
     mutationFn: async (path: string) => {
-      const file = tabs.find((f) => f.path === path);
+      // Get latest tabs from store to avoid stale closure issue
+      const currentTabs = useEditorStore.getState().tabs;
+      const file = currentTabs.find((f) => f.path === path);
       if (!file) throw new Error('File not found');
       await window.electronAPI.file.write(path, file.content, file.encoding);
       markFileSaved(path);


### PR DESCRIPTION
## Summary
- 修复 `useEditor` hook 中 `saveFile` mutation 的闭包陷阱（stale closure）问题
- 原代码使用闭包捕获的 `tabs` 变量，在切换到版本管理等标签页后可能获取到过时的状态
- 修改为使用 `useEditorStore.getState().tabs` 获取最新状态

## Test plan
- [ ] 打开一个文件并编辑
- [ ] 切换到版本管理标签页
- [ ] 切换回文件标签页
- [ ] 尝试保存文件（Cmd+S），确认保存成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)