### PR TITLE
feat(file-tree): 添加发送到会话功能

### DIFF
--- a/src/renderer/components/files/FileTree.tsx
+++ b/src/renderer/components/files/FileTree.tsx
@@ -7,6 +7,7 @@ import {
   FilePlus,
   FolderPlus,
   Loader2,
+  MessageSquarePlus,
   PanelLeftClose,
   Pencil,
   RefreshCw,
@@ -63,6 +64,7 @@ interface FileTreeProps {
   onFileDeleted?: (path: string) => void;
   isCollapsed?: boolean;
   onToggleCollapse?: () => void;
+  onSendToSession?: (path: string) => void;
 }
 
 export function FileTree({
@@ -85,6 +87,7 @@ export function FileTree({
   onFileDeleted,
   isCollapsed: _isCollapsed,
   onToggleCollapse,
+  onSendToSession,
 }: FileTreeProps) {
   const { t } = useI18n();
   const [editingPath, setEditingPath] = useState<string | null>(null);
@@ -1206,6 +1209,7 @@ export function FileTree({
             onCopy={handleCopy}
             onCut={handleCut}
             onPaste={handlePaste}
+            onSendToSession={onSendToSession}
           />
         ))}
       </div>
@@ -1252,6 +1256,7 @@ export function FileTree({
       {/* Root directory context menu */}
       <Menu open={rootMenuOpen} onOpenChange={setRootMenuOpen}>
         <MenuPopup
+          className="min-w-48"
           style={{
             position: 'fixed',
             left: rootMenuPosition.x,
@@ -1373,6 +1378,7 @@ interface FileTreeNodeComponentProps {
   onCopy?: (path: string, name: string, isDirectory: boolean) => void;
   onCut?: (path: string, name: string, isDirectory: boolean) => void;
   onPaste?: (targetPath: string, targetIsDirectory: boolean) => void;
+  onSendToSession?: (path: string) => void;
 }
 
 // 压缩链中的节点信息
@@ -1434,6 +1440,7 @@ function FileTreeNodeComponent({
   onCopy,
   onCut,
   onPaste,
+  onSendToSession,
 }: FileTreeNodeComponentProps) {
   const { t } = useI18n();
   const inputRef = useRef<HTMLInputElement>(null);
@@ -1730,6 +1737,7 @@ function FileTreeNodeComponent({
       {/* Context Menu */}
       <Menu open={menuOpen} onOpenChange={setMenuOpen}>
         <MenuPopup
+          className="min-w-48"
           style={{
             position: 'fixed',
             left: menuPosition.x,
@@ -1808,6 +1816,12 @@ function FileTreeNodeComponent({
                 : t('Reveal in Explorer')}
             </MenuItem>
           )}
+          {onSendToSession && (
+            <MenuItem onClick={() => onSendToSession(actualNode.path)}>
+              <MessageSquarePlus className="h-4 w-4" />
+              {t('Send to Session')}
+            </MenuItem>
+          )}
           <MenuSeparator />
           <MenuItem variant="destructive" onClick={() => onDelete(actualNode.path)}>
             <Trash2 className="h-4 w-4" />
@@ -1857,6 +1871,7 @@ function FileTreeNodeComponent({
                 onCopy={onCopy}
                 onCut={onCut}
                 onPaste={onPaste}
+                onSendToSession={onSendToSession}
               />
             ))}
           </motion.div>

--- a/src/renderer/components/ui/menu.tsx
+++ b/src/renderer/components/ui/menu.tsx
@@ -79,7 +79,7 @@ function MenuItem({
   return (
     <MenuPrimitive.Item
       className={cn(
-        "[&_svg]:-mx-0.5 flex min-h-8 cursor-default select-none items-center gap-2 rounded-sm px-2 py-1 text-base outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive data-highlighted:text-accent-foreground data-highlighted:data-[variant=destructive]:bg-destructive/10 data-highlighted:data-[variant=destructive]:text-destructive data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+        "[&_svg]:-mx-0.5 flex min-h-8 cursor-default select-none items-center gap-2 whitespace-nowrap rounded-sm px-2 py-1 text-base outline-none data-disabled:pointer-events-none data-highlighted:bg-accent data-inset:ps-8 data-[variant=destructive]:text-destructive data-highlighted:text-accent-foreground data-highlighted:data-[variant=destructive]:bg-destructive/10 data-highlighted:data-[variant=destructive]:text-destructive data-disabled:opacity-64 sm:min-h-7 sm:text-sm [&_svg:not([class*='opacity-'])]:opacity-80 [&_svg:not([class*='size-'])]:size-4.5 sm:[&_svg:not([class*='size-'])]:size-4 [&_svg]:pointer-events-none [&_svg]:shrink-0",
         className
       )}
       data-inset={inset}

--- a/src/renderer/components/ui/toast.tsx
+++ b/src/renderer/components/ui/toast.tsx
@@ -7,6 +7,7 @@ import {
   InfoIcon,
   LoaderCircleIcon,
   TriangleAlertIcon,
+  XIcon,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
 
@@ -167,6 +168,14 @@ function Toasts({ position = 'bottom-right' }: { position: ToastPosition }) {
                     {toast.actionProps.children}
                   </Toast.Action>
                 )}
+
+                <Toast.Close
+                  aria-label="Close notification"
+                  className="shrink-0 rounded p-0.5 text-muted-foreground hover:bg-muted hover:text-foreground"
+                  data-slot="toast-close"
+                >
+                  <XIcon className="h-4 w-4" />
+                </Toast.Close>
               </Toast.Content>
             </Toast.Root>
           );

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -303,6 +303,8 @@ export const zhTranslations: Record<string, string> = {
   'Select a Worktree to view changes': '选择一个 Worktree 以查看更改',
   'Select a file to view changes': '选择一个文件以查看更改',
   'Select file to view diff': '从左侧选择文件以查看更改',
+  'Send to Session': '发送到会话',
+  'Sent to session': '已发送到会话',
   Settings: '设置',
   'Settings...': '设置...',
   Shell: 'Shell',


### PR DESCRIPTION
## 功能描述

文件树右键菜单新增"发送到会话"选项，允许用户快速将文件路径发送到当前终端会话。

## 主要更改

- 文件树右键菜单新增"发送到会话"选项
- 将文件路径以 `@path` 格式发送到当前终端会话
- 自动转换为相对路径（如果在项目目录内）
- 发送成功后显示 toast 通知（2秒自动消失）
- Toast 组件全局添加关闭按钮

## 修改的文件

- `src/renderer/components/files/FilePanel.tsx` - 添加发送处理逻辑
- `src/renderer/components/files/FileTree.tsx` - 添加菜单项
- `src/renderer/components/ui/toast.tsx` - 添加关闭按钮
- `src/shared/i18n.ts` - 添加国际化文本

## 截图

N/A（功能性更改）

## 测试

- [x] 构建通过
- [x] 代码审查通过