### PR TITLE
fix(worktree): 修复合并对话框下拉框被遮挡问题

### DIFF
--- a/src/renderer/components/worktree/MergeWorktreeDialog.tsx
+++ b/src/renderer/components/worktree/MergeWorktreeDialog.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/components/ui/select';
 import { addToast } from '@/components/ui/toast';
 import { useI18n } from '@/i18n';
+import { Z_INDEX } from '@/lib/z-index';
 
 interface MergeWorktreeDialogProps {
   open: boolean;
@@ -183,7 +184,7 @@ export function MergeWorktreeDialog({
                 <SelectTrigger>
                   <SelectValue>{targetBranch || t('Choose target branch...')}</SelectValue>
                 </SelectTrigger>
-                <SelectPopup>
+                <SelectPopup zIndex={Z_INDEX.DROPDOWN_IN_MODAL}>
                   {availableBranches.map((branch) => (
                     <SelectItem key={branch.name} value={branch.name}>
                       <GitBranch className="mr-2 h-4 w-4" />
@@ -210,7 +211,7 @@ export function MergeWorktreeDialog({
                     {strategyOptions.find((s) => s.value === strategy)?.label}
                   </SelectValue>
                 </SelectTrigger>
-                <SelectPopup>
+                <SelectPopup zIndex={Z_INDEX.DROPDOWN_IN_MODAL}>
                   {strategyOptions.map((opt) => (
                     <SelectItem key={opt.value} value={opt.value}>
                       <div className="flex flex-col">


### PR DESCRIPTION
## Summary
- 为 MergeWorktreeDialog 中的两个 SelectPopup 组件添加 `zIndex={Z_INDEX.DROPDOWN_IN_MODAL}`
- 修复下拉列表被 Modal 内容遮挡的问题

## 问题原因
SelectPopup 默认 zIndex 为 40（DROPDOWN），低于 Modal 内容的 51（MODAL_CONTENT），导致下拉列表无法正常显示。

## Test plan
- [ ] 打开合并对话框
- [ ] 点击"目标分支"下拉框，确认能看到所有分支
- [ ] 点击"合并策略"下拉框，确认能看到所有选项