### PR TITLE
fix(worktree): 修复点击非选中仓库新建 worktree 时使用错误分支列表的问题

### DIFF
--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -667,29 +667,49 @@ export function TreeSidebar({
                           )}
 
                           {/* Create Worktree Button */}
-                          <CreateWorktreeDialog
-                            branches={branches}
-                            projectName={repo.name}
-                            workdir={workdir}
-                            isLoading={isCreating}
-                            onSubmit={async (options) => {
-                              await onCreateWorktree(options);
-                              refetchExpandedWorktrees();
-                            }}
-                            trigger={
-                              <button
-                                type="button"
-                                className="shrink-0 p-1 rounded hover:bg-muted"
-                                onClick={(e) => {
-                                  e.stopPropagation();
-                                  e.currentTarget.blur();
-                                }}
-                                title={t('New Worktree')}
-                              >
-                                <Plus className="h-3.5 w-3.5 text-muted-foreground" />
-                              </button>
-                            }
-                          />
+                          {isSelected ? (
+                            // Selected repo: open dialog directly with current branches
+                            <CreateWorktreeDialog
+                              branches={branches}
+                              projectName={repo.name}
+                              workdir={workdir}
+                              isLoading={isCreating}
+                              onSubmit={async (options) => {
+                                await onCreateWorktree(options);
+                                refetchExpandedWorktrees();
+                              }}
+                              trigger={
+                                <button
+                                  type="button"
+                                  className="shrink-0 p-1 rounded hover:bg-muted"
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    e.currentTarget.blur();
+                                  }}
+                                  title={t('New Worktree')}
+                                >
+                                  <Plus className="h-3.5 w-3.5 text-muted-foreground" />
+                                </button>
+                              }
+                            />
+                          ) : (
+                            // Non-selected repo: switch to repo first, then open dialog
+                            <button
+                              type="button"
+                              className="shrink-0 p-1 rounded hover:bg-muted"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                e.currentTarget.blur();
+                                // Switch to this repo and trigger dialog open after branches load
+                                setRepoMenuTarget(repo);
+                                onSelectRepo(repo.path);
+                                setPendingCreateWorktree(true);
+                              }}
+                              title={t('New Worktree')}
+                            >
+                              <Plus className="h-3.5 w-3.5 text-muted-foreground" />
+                            </button>
+                          )}
 
                           {/* Repository Settings Button */}
                           <button


### PR DESCRIPTION
## 问题描述

点击仓库新建 worktree 时，没有记住点击的是哪个仓库，总是新建到最后一个（当前选中的）仓库下。

## 原因分析

在 `TreeSidebar.tsx` 中，每个仓库行的 "+" 按钮直接使用了父组件传入的 `branches` 属性，而这个属性是基于 `selectedRepo`（当前选中的仓库）获取的分支列表，而不是被点击的仓库的分支列表。

## 解决方案

修改 "+" 按钮的行为：
- **如果点击的是当前选中的仓库**：直接打开对话框，使用当前的分支列表
- **如果点击的是非选中的仓库**：先切换到该仓库，等待分支列表刷新后再打开对话框

这与右键菜单中 "New Worktree" 的行为保持一致。

## 改动文件

- `src/renderer/components/layout/TreeSidebar.tsx`