### PR TITLE
feat(terminal): 支持点击 @path 格式和绝对路径打开文件

### DIFF
--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -12,10 +12,10 @@ import { useSettingsStore } from '@/stores/settings';
 import '@xterm/xterm/css/xterm.css';
 
 // Regex to match file paths with optional line:column
-// Matches: path/to/file.ts:42 or path/to/file.ts:42:10 or ./file.ts:10
-// Note: longer extensions must come before shorter ones (tsx before ts, jsx before js, etc.)
+// Matches: path/to/file.ts:42 or path/to/file.ts:42:10 or ./file.ts:10 or @src/file.ts:42
+// Note: longer extensions must come before shorter ones (tsx before ts, jsx before js, json before js, etc.)
 const FILE_PATH_REGEX =
-  /(?:^|[\s'"({[])((?:\.{1,2}\/|\/)?(?:[\w.-]+\/)*[\w.-]+\.(?:tsx|ts|jsx|js|mjs|cjs|json|scss|css|less|html|vue|svelte|md|yaml|yml|toml|py|go|rs|java|cpp|hpp|c|h|rb|php|bash|zsh|sh))(?::(\d+))?(?::(\d+))?/g;
+  /(?:^|[\s'"({[@])((?:\.{1,2}\/|\/)?(?:[\w.-]+\/)*[\w.-]+\.(?:tsx|ts|jsx|json|mjs|cjs|js|scss|css|less|html|vue|svelte|md|yaml|yml|toml|py|go|rs|java|cpp|hpp|c|h|rb|php|bash|zsh|sh))(?::(\d+))?(?::(\d+))?/g;
 
 // Check if data contains visible characters (not just ANSI control sequences)
 // biome-ignore lint/suspicious/noControlCharactersInRegex: ANSI escape sequences require ESC character


### PR DESCRIPTION
## 变更说明

在终端中支持点击文件路径直接在编辑器中打开，增强了路径格式的兼容性。

## 主要改动

- **添加 `@` 前缀支持**：兼容拖拽文件到终端生成的 `@src/file.ts` 格式
- **修复 `.json` 文件匹配问题**：调整扩展名优先级，避免 `.json` 被错误匹配为 `.js`
- **更新注释**：补充支持的路径格式示例

## 支持的路径格式

- 相对路径：`./file.ts:10`、`src/file.ts:42:10`
- 绝对路径：`/Volumes/path/to/file.json`
- @ 别名路径：`@src/file.ts:42`

## 测试

已验证以下场景均可正确匹配并点击打开：
- `@src/file.ts`
- `text @src/file.ts`
- `(@src/file.ts)`
- `/Volumes/ext/workspace/learn/EnsoAI/tsconfig.json`