### PR TITLE
feat(file-tree): 切换标签页时自动展开并选中对应文件

### DIFF
--- a/src/renderer/components/files/FilePanel.tsx
+++ b/src/renderer/components/files/FilePanel.tsx
@@ -73,6 +73,7 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
     refresh,
     handleExternalDrop,
     resolveConflictsAndContinue,
+    revealFile,
   } = useFileTree({ rootPath, enabled: !!rootPath, isActive });
 
   const {
@@ -110,6 +111,17 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
   const handleRecordOperations = useCallback((addFn: (operations: any[]) => void) => {
     addOperationsRef.current = addFn;
   }, []);
+
+  // Auto-sync file tree selection with active tab (like VSCode's "Auto Reveal")
+  useEffect(() => {
+    if (!activeTab?.path || !rootPath) return;
+
+    // Update selected file path to match active tab
+    setSelectedFilePath(activeTab.path);
+
+    // Expand parent directories to reveal the file
+    revealFile(activeTab.path);
+  }, [activeTab?.path, rootPath, revealFile]);
 
   // Handle file deleted (from undo operation)
   const handleFileDeleted = useCallback(


### PR DESCRIPTION
## 功能描述

实现类似 VSCode 的 "Auto Reveal" 功能：切换编辑器标签页时，文件树自动展开并选中对应文件。

## 改动内容

### useFileTree.ts
- 添加 `revealFile` 函数，展开文件所在的所有父目录
- 使用 refs (`treeRef`, `expandedPathsRef`) 解决 `toggleExpand` 中的闭包陈旧问题
- 同步更新 refs 确保连续展开操作正确执行

### FilePanel.tsx
- 添加 useEffect 监听 `activeTab` 变化
- 自动更新文件树选中状态
- 调用 `revealFile` 展开父目录

## 测试

- [x] 切换标签页时文件树自动定位
- [x] 深层目录路径正确展开
- [x] 文件树菜单正常工作