### PR TITLE
fix(source-control): 切换分支或标签页时立即刷新数据

### DIFF
--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query';
 import { AnimatePresence, motion } from 'framer-motion';
 import {
   ArrowDown,
@@ -64,6 +65,7 @@ export function SourceControlPanel({
   sessionId,
 }: SourceControlPanelProps) {
   const { t, tNode } = useI18n();
+  const queryClient = useQueryClient();
 
   // Accordion state - collapsible sections
   const [changesExpanded, setChangesExpanded] = useState(true);
@@ -125,11 +127,14 @@ export function SourceControlPanel({
   // Refetch immediately when tab becomes active
   useEffect(() => {
     if (isActive && rootPath) {
-      refetch();
-      refetchCommits();
-      refetchStatus();
+      // Invalidate all git-related queries to refresh data
+      queryClient.invalidateQueries({ queryKey: ['git', 'status', rootPath] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', rootPath] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'log-infinite', rootPath] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'submodules', rootPath] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'changes', rootPath] });
     }
-  }, [isActive, rootPath, refetch, refetchCommits, refetchStatus]);
+  }, [isActive, rootPath, queryClient]);
 
   // Sync handler: pull first (if behind), then push (if ahead)
   const handleSync = useCallback(async () => {

--- a/src/renderer/hooks/useGit.ts
+++ b/src/renderer/hooks/useGit.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useEffect } from 'react';
 import { useRepositoryStore } from '@/stores/repository';
 import { useShouldPoll } from './useWindowFocus';
 
@@ -16,9 +15,9 @@ export function useGitStatus(workdir: string | null, isActive = true) {
       return status;
     },
     enabled: !!workdir,
-    refetchInterval: (query) => {
+    refetchInterval: (q) => {
       if (!isActive || !shouldPoll) return false;
-      return query.state.data?.truncated ? 60000 : 5000;
+      return q.state.data?.truncated ? 60000 : 5000;
     },
     refetchIntervalInBackground: false,
   });
@@ -84,8 +83,14 @@ export function useGitCheckout() {
       await window.electronAPI.git.checkout(workdir, branch);
     },
     onSuccess: (_, { workdir }) => {
+      // Invalidate all git-related queries after branch switch
       queryClient.invalidateQueries({ queryKey: ['git', 'status', workdir] });
       queryClient.invalidateQueries({ queryKey: ['git', 'branches', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'file-diff', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'log', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'log-infinite', workdir] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'submodules', workdir] });
     },
   });
 }

--- a/src/renderer/hooks/useSourceControl.ts
+++ b/src/renderer/hooks/useSourceControl.ts
@@ -15,12 +15,12 @@ export function useFileChanges(workdir: string | null, isActive = true) {
       return window.electronAPI.git.getFileChanges(workdir);
     },
     enabled: !!workdir,
-    refetchInterval: (query) => {
+    refetchInterval: (q) => {
       if (!isActive || !shouldPoll) return false;
-      return query.state.data?.truncated ? 60000 : 5000;
-    }, // Only poll when tab is active and user is not idle
-    refetchIntervalInBackground: false, // Only poll when window is focused
-    staleTime: 2000, // Avoid redundant requests within 2s
+      return q.state.data?.truncated ? 60000 : 5000;
+    },
+    refetchIntervalInBackground: false,
+    staleTime: 2000,
   });
 }
 


### PR DESCRIPTION
## 问题描述

切换分支或切换到版本管理标签页时，数据没有立即刷新，导致变更没有同步显示。

## 修复内容

### useGitCheckout
切换分支后 invalidate 所有相关 query keys：
- `file-changes`
- `file-diff`
- `log`
- `log-infinite`
- `submodules`

### SourceControlPanel
切换到版本管理标签页时统一刷新所有数据：
- `status`
- `file-changes`
- `log-infinite`
- `submodules`
- `submodule/changes`

### 代码简化
移除 `useGitStatus` 和 `useFileChanges` 中重复的 `useEffect` 刷新逻辑。