### PR TITLE
feat(terminal): 支持自定义终端程序配置

### DIFF
--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -3,6 +3,18 @@ import type { ShellInfo } from '@shared/types';
 import { Columns3, FolderOpen, RefreshCw, TreePine } from 'lucide-react';
 import * as React from 'react';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectItem,
+  SelectPopup,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useI18n } from '@/i18n';
+import { cn } from '@/lib/utils';
+import { type LayoutMode, type TerminalRenderer, useSettingsStore } from '@/stores/settings';
 
 // Parse shell arguments string, supporting single/double quotes for paths with spaces
 function parseShellArgs(input: string): string[] {
@@ -35,18 +47,6 @@ function stringifyShellArgs(args: string[]): string {
     })
     .join(' ');
 }
-import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectItem,
-  SelectPopup,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { Switch } from '@/components/ui/switch';
-import { useI18n } from '@/i18n';
-import { cn } from '@/lib/utils';
-import { type LayoutMode, type TerminalRenderer, useSettingsStore } from '@/stores/settings';
 
 interface UpdateStatus {
   status: 'checking' | 'available' | 'not-available' | 'downloading' | 'downloaded' | 'error';
@@ -149,7 +149,6 @@ export function GeneralSettings() {
 
   const [shells, setShells] = React.useState<ShellInfo[]>([]);
   const [loadingShells, setLoadingShells] = React.useState(true);
-  const _isWindows = window.electronAPI?.env.platform === 'win32';
   const appVersion = window.electronAPI?.env.appVersion || '0.0.0';
 
   // Update status state
@@ -229,9 +228,9 @@ export function GeneralSettings() {
     });
   }, [customArgsText, shellConfig, setShellConfig]);
 
-  const isWin = window.electronAPI?.env.platform === 'win32';
-  const shellPathPlaceholder = isWin ? 'cmd.exe' : '/bin/bash';
-  const shellArgsPlaceholder = isWin ? '/k "C:\\Program Files\\init.bat"' : "-l -c '/usr/local/bin/app'";
+  const isWindows = window.electronAPI?.env.platform === 'win32';
+  const shellPathPlaceholder = isWindows ? 'cmd.exe' : '/bin/bash';
+  const shellArgsPlaceholder = isWindows ? '/k "C:\\Program Files\\init.bat"' : "-l -c '/usr/local/bin/app'";
 
   return (
     <div className="space-y-6">


### PR DESCRIPTION
## Summary
- 在终端设置中新增「自定义」Shell 选项，允许用户指定任意 Shell 程序路径和启动参数
- 参数输入支持单/双引号包裹含空格的路径（如 `/k "C:\Program Files\init.bat"`）
- 根据当前平台（Windows/Unix）显示对应的 placeholder 示例
- 支持 Enter 键和失焦两种方式提交参数

## Test plan
- [ ] 设置页面选择「自定义」后，Shell 路径和参数输入框正常显示
- [ ] 输入带空格路径的参数（用引号包裹），新建终端验证参数解析正确
- [ ] 切换回预定义 Shell 后，自定义输入框隐藏
- [ ] 在 Windows/macOS/Linux 上验证 placeholder 显示对应平台示例