### PR TITLE
fix(source-control): 修复子模块文件变更显示和暂存操作问题

### DIFF
--- a/src/renderer/components/source-control/BranchSwitcher.tsx
+++ b/src/renderer/components/source-control/BranchSwitcher.tsx
@@ -84,7 +84,7 @@ export function BranchSwitcher({
           'border-0 bg-transparent shadow-none ring-0 ring-transparent before:shadow-none before:!shadow-none transition-colors dark:bg-transparent shrink-0',
           'focus-visible:ring-0 focus-visible:border-0 hover:ring-0 hover:shadow-none hover:before:shadow-none',
           size === 'xs' &&
-            'h-auto min-h-0 min-w-0 w-auto max-w-20 gap-0 p-0 text-xs text-muted-foreground hover:text-foreground',
+            'h-auto min-h-0 min-w-0 w-auto max-w-20 gap-0 p-0 text-xs text-muted-foreground hover:text-foreground sm:!min-h-0 sm:!h-auto',
           size === 'sm' && 'h-6 min-h-6 min-w-0 w-auto max-w-32 gap-1 px-1.5 text-xs',
           size === 'md' && 'h-7 min-h-7 min-w-0 w-auto max-w-40 gap-1.5 px-2 text-sm'
         )}

--- a/src/renderer/hooks/useSubmodules.ts
+++ b/src/renderer/hooks/useSubmodules.ts
@@ -138,6 +138,9 @@ export function useStageSubmodule() {
       queryClient.invalidateQueries({
         queryKey: ['git', 'submodule', 'changes', workdir, submodulePath],
       });
+      queryClient.invalidateQueries({
+        queryKey: ['git', 'submodule', 'diff', workdir, submodulePath],
+      });
       queryClient.invalidateQueries({ queryKey: ['git', 'submodules', workdir] });
     },
   });
@@ -161,6 +164,9 @@ export function useUnstageSubmodule() {
     onSuccess: (_, { workdir, submodulePath }) => {
       queryClient.invalidateQueries({
         queryKey: ['git', 'submodule', 'changes', workdir, submodulePath],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['git', 'submodule', 'diff', workdir, submodulePath],
       });
       queryClient.invalidateQueries({ queryKey: ['git', 'submodules', workdir] });
     },


### PR DESCRIPTION
## 问题描述

1. 子模块分支后面不显示文件变更数字
2. 子模块"全部暂存/全部不暂存"操作后 UI 不刷新，像卡死一样

## 修复内容

### 1. 修复子模块文件变更数字不显示

**原因**：`changesCount` 被硬编码为 `0`

**修复**：使用 `(sub.stagedCount ?? 0) + (sub.unstagedCount ?? 0)`

### 2. 修复子模块暂存操作后 UI 不刷新

**原因**：子模块操作使用了主仓库的 `useGitStage/useGitUnstage`，这些 hook 的 `onSuccess` 只刷新主仓库相关的 query，不刷新子模块的 `useSubmoduleChanges`

**修复**：子模块场景改用专门的 `useStageSubmodule/useUnstageSubmodule`，正确 invalidate 子模块相关的 queryKey