### PR TITLE
feat(ai): 添加 Cursor CLI 支持，用于代码审查与继续对话

### DIFF
--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -222,15 +222,20 @@ export function AgentTerminal({
     // Use custom path if provided, otherwise use agentCommand
     const effectiveCommand = customPath || agentCommand;
 
-    const supportsSession = agentCommand?.startsWith('claude') ?? false;
-    const supportIde = agentCommand?.startsWith('claude') ?? false;
+    const supportsSession = agentCommand?.startsWith('claude') || agentCommand === 'cursor-agent';
+    // Only Claude CLI supports --ide; Cursor CLI does not (errors with "unknown option '--ide'")
+    const supportIde = agentCommand?.startsWith('claude');
     const effectiveSessionId = resumeSessionId;
-    const agentArgs =
-      supportsSession && effectiveSessionId
-        ? initialized
-          ? ['--resume', effectiveSessionId]
-          : ['--session-id', effectiveSessionId]
-        : [];
+
+    // Build agent args: cursor-agent and initialized claude use --resume; otherwise --session-id
+    let agentArgs: string[] = [];
+    if (supportsSession && effectiveSessionId) {
+      if (agentCommand === 'cursor-agent' || initialized) {
+        agentArgs = ['--resume', effectiveSessionId];
+      } else {
+        agentArgs = ['--session-id', effectiveSessionId];
+      }
+    }
 
     if (supportIde) {
       agentArgs.push('--ide');

--- a/src/renderer/components/settings/AISettings.tsx
+++ b/src/renderer/components/settings/AISettings.tsx
@@ -21,6 +21,7 @@ import {
 const PROVIDERS: { value: AIProvider; label: string }[] = [
   { value: 'claude-code', label: 'Claude Code' },
   { value: 'codex-cli', label: 'Codex CLI' },
+  { value: 'cursor-cli', label: 'Cursor CLI' },
   { value: 'gemini-cli', label: 'Gemini CLI' },
 ];
 
@@ -34,6 +35,13 @@ const MODELS_BY_PROVIDER: Record<AIProvider, { value: string; label: string }[]>
   'codex-cli': [
     { value: 'gpt-5.2', label: 'GPT-5.2' },
     { value: 'gpt-5.2-codex', label: 'GPT-5.2 Codex' },
+  ],
+  'cursor-cli': [
+    { value: 'auto', label: 'Auto' },
+    { value: 'composer-1', label: 'Composer 1' },
+    { value: 'gpt-5.2', label: 'GPT-5.2' },
+    { value: 'sonnet-4.5', label: 'Sonnet 4.5' },
+    { value: 'opus-4.6', label: 'Opus 4.6' },
   ],
   'gemini-cli': [
     { value: 'gemini-3-pro-preview', label: 'Gemini 3 Pro Preview' },

--- a/src/renderer/components/source-control/CodeReviewModal.tsx
+++ b/src/renderer/components/source-control/CodeReviewModal.tsx
@@ -263,10 +263,10 @@ export function CodeReviewModal({ open, onOpenChange, repoPath, sessionId }: Cod
 
   const handleContinueConversation = useCallback(() => {
     if (reviewSessionId) {
-      requestContinue(reviewSessionId);
+      requestContinue(reviewSessionId, codeReviewSettings.provider ?? undefined);
       onOpenChange(false);
     }
-  }, [reviewSessionId, requestContinue, onOpenChange]);
+  }, [reviewSessionId, codeReviewSettings.provider, requestContinue, onOpenChange]);
 
   const handleSendToCurrentSession = useCallback(() => {
     if (!sessionId || !hasWriter || !content) return;
@@ -381,12 +381,15 @@ export function CodeReviewModal({ open, onOpenChange, repoPath, sessionId }: Cod
                 {t('Minimize')}
               </Button>
             )}
-            {codeReviewSettings.provider === 'claude-code' && status === 'complete' && content && (
-              <Button variant="outline" onClick={handleContinueConversation}>
-                <MessageSquare className="h-4 w-4 mr-2" />
-                {t('Continue Conversation')}
-              </Button>
-            )}
+            {(codeReviewSettings.provider === 'claude-code' ||
+              codeReviewSettings.provider === 'cursor-cli') &&
+              status === 'complete' &&
+              content && (
+                <Button variant="outline" onClick={handleContinueConversation}>
+                  <MessageSquare className="h-4 w-4 mr-2" />
+                  {t('Continue Conversation')}
+                </Button>
+              )}
             {content && sessionId && (
               <Button variant="outline" onClick={handleSendToCurrentSession} disabled={!hasWriter}>
                 <Send className="h-4 w-4 mr-2" />

--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -1,9 +1,10 @@
-export type AIProvider = 'claude-code' | 'codex-cli' | 'gemini-cli';
+export type AIProvider = 'claude-code' | 'codex-cli' | 'cursor-cli' | 'gemini-cli';
 
 export type ClaudeModelId = 'haiku' | 'sonnet' | 'opus';
 export type CodexModelId = 'gpt-5.2' | 'gpt-5.2-codex';
+export type CursorModelId = 'auto' | 'composer-1' | 'gpt-5.2' | 'sonnet-4.5' | 'opus-4.6';
 export type GeminiModelId = 'gemini-3-pro-preview' | 'gemini-3-flash-preview';
 
-export type ModelId = ClaudeModelId | CodexModelId | GeminiModelId;
+export type ModelId = ClaudeModelId | CodexModelId | CursorModelId | GeminiModelId;
 
 export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';


### PR DESCRIPTION
- 新增 cursor-cli 提供方与 CursorModelId 类型
- providers: buildCursorArgs、parseCursorOutput，spawn/parse 分支
- code-review: cursor-cli 使用 stream-json 与 claude 解析逻辑
- 设置页与 CodeReviewModal：可选 Cursor CLI，继续对话按钮对 cursor-cli 可见
- codeReviewContinue store 记录 provider，AgentPanel 按 provider 映射到对应 agent