### PR TITLE
feat(sidebar): 在仓库右键菜单中添加隐藏仓库功能

### DIFF
--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -1092,6 +1092,15 @@ export function TreeSidebar({
                     hidden: true,
                   });
                   refreshRepoSettings();
+                  // If hiding the currently selected repo, switch to next visible one
+                  if (selectedRepo === repoMenuTarget.path) {
+                    const nextVisible = repositories.find(
+                      (r) => r.path !== repoMenuTarget.path && !getRepositorySettings(r.path).hidden
+                    );
+                    if (nextVisible) {
+                      onSelectRepo(nextVisible.path);
+                    }
+                  }
                   toastManager.add({
                     title: t('Repository hidden'),
                     description: t('Hidden repositories will not appear in the sidebar'),
@@ -1274,6 +1283,7 @@ export function TreeSidebar({
         open={repoManagerOpen}
         onOpenChange={setRepoManagerOpen}
         repositories={repositories}
+        selectedRepo={selectedRepo}
         onSelectRepo={onSelectRepo}
         onRemoveRepository={onRemoveRepository}
         onSettingsChange={refreshRepoSettings}

--- a/src/renderer/components/repository/RepositoryManagerDialog.tsx
+++ b/src/renderer/components/repository/RepositoryManagerDialog.tsx
@@ -32,6 +32,7 @@ interface RepositoryManagerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   repositories: Repository[];
+  selectedRepo?: string | null;
   onSelectRepo?: (repoPath: string) => void;
   onRemoveRepository?: (repoPath: string) => void;
   onSettingsChange?: () => void;
@@ -41,6 +42,7 @@ export function RepositoryManagerDialog({
   open,
   onOpenChange,
   repositories,
+  selectedRepo,
   onSelectRepo,
   onRemoveRepository,
   onSettingsChange,
@@ -67,8 +69,17 @@ export function RepositoryManagerDialog({
       saveRepositorySettings(repoPath, updated);
       setSettingsMap((prev) => ({ ...prev, [repoPath]: updated }));
       onSettingsChange?.();
+      // If hiding the currently selected repo, switch to next visible one
+      if (updated.hidden && selectedRepo === repoPath) {
+        const nextVisible = repositories.find(
+          (r) => r.path !== repoPath && !settingsMap[r.path]?.hidden
+        );
+        if (nextVisible) {
+          onSelectRepo?.(nextVisible.path);
+        }
+      }
     },
-    [settingsMap, onSettingsChange]
+    [settingsMap, onSettingsChange, selectedRepo, repositories, onSelectRepo]
   );
 
   const handleRepoClick = useCallback(


### PR DESCRIPTION
## 变更内容

在仓库右键菜单中添加「隐藏仓库」选项，用户可以快速隐藏不需要显示的仓库。

### 改动

- 在仓库右键菜单中新增「Hide Repository」按钮
- 点击后将仓库设置为隐藏并刷新侧边栏列表
- 显示 toast 提示用户操作成功

### 涉及文件

- `src/renderer/components/layout/TreeSidebar.tsx`