### PR TITLE
fix: 修复 Windows 打包版 Agent CLI （ClaudeCode/Codex）检测误报未安装

### DIFF
--- a/src/main/services/cli/CliDetector.ts
+++ b/src/main/services/cli/CliDetector.ts
@@ -1,7 +1,17 @@
-import type { AgentCliInfo, BuiltinAgentId, CustomAgent } from '@shared/types';
-import { execInPty } from '../../utils/shell';
+import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import {
+  type AgentCliInfo,
+  type BuiltinAgentId,
+  type CliDetectDebugLog,
+  type CustomAgent,
+  IPC_CHANNELS,
+} from '@shared/types';
+import { app, BrowserWindow } from 'electron';
+import { execInPty, getEnvForCommand, getShellForCommand } from '../../utils/shell';
 
 const isWindows = process.platform === 'win32';
+const CLI_DETECT_DEBUG_ENV = 'ENSO_DEBUG_CLI_DETECT';
 
 /**
  * Check if an error is a timeout error
@@ -75,15 +85,197 @@ const BUILTIN_AGENT_CONFIGS: BuiltinAgentConfig[] = [
 ];
 
 class CliDetector {
+  private hasFileLogErrorNotified = false;
+
+  private isDebugEnabled(): boolean {
+    const debugValue = process.env[CLI_DETECT_DEBUG_ENV];
+    if (!debugValue) return false;
+    return debugValue === '1' || debugValue.toLowerCase() === 'true';
+  }
+
+  private getLogFilePath(): string {
+    const logBaseDir = app.isReady() ? app.getPath('userData') : process.cwd();
+    return join(logBaseDir, 'logs', 'cli-detect.log');
+  }
+
+  private emitRendererLog(payload: CliDetectDebugLog): void {
+    const windows = BrowserWindow.getAllWindows();
+    for (const window of windows) {
+      if (window.isDestroyed() || window.webContents.isDestroyed()) continue;
+      window.webContents.send(IPC_CHANNELS.CLI_DETECT_LOG, payload);
+    }
+  }
+
+  private writeLogFile(
+    level: 'debug' | 'warn',
+    message: string,
+    details?: Record<string, unknown>
+  ): void {
+    const payload: CliDetectDebugLog = {
+      level,
+      message,
+      details,
+      timestamp: new Date().toISOString(),
+    };
+    if (this.isDebugEnabled()) {
+      this.emitRendererLog(payload);
+    }
+
+    try {
+      const logFilePath = this.getLogFilePath();
+      const logDirPath = dirname(logFilePath);
+      mkdirSync(logDirPath, { recursive: true });
+      const detailText = details ? ` ${JSON.stringify(details)}` : '';
+      const line = `[${payload.timestamp}] [${level}] ${message}${detailText}\n`;
+      appendFileSync(logFilePath, line, { encoding: 'utf8' });
+    } catch (error) {
+      if (!this.hasFileLogErrorNotified) {
+        this.hasFileLogErrorNotified = true;
+        console.warn('[cli-detect] failed to write cli-detect.log', this.formatError(error));
+      }
+    }
+  }
+
+  private formatError(error: unknown): string {
+    if (error instanceof Error) return error.message;
+    return String(error);
+  }
+
+  private getPathPreview(pathValue: string | undefined): string[] {
+    if (!pathValue) return [];
+    const delimiter = isWindows ? ';' : ':';
+    return pathValue
+      .split(delimiter)
+      .map((entry) => entry.trim())
+      .filter(Boolean)
+      .slice(0, 8);
+  }
+
+  private previewOutput(output: string): string {
+    const firstLine = output
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (!firstLine) return '';
+    return firstLine.length > 200 ? `${firstLine.slice(0, 200)}...` : firstLine;
+  }
+
+  private logDebug(message: string, details?: Record<string, unknown>): void {
+    if (!this.isDebugEnabled()) return;
+    this.writeLogFile('debug', message, details);
+    if (details) {
+      console.log(`[cli-detect] ${message}`, details);
+      return;
+    }
+    console.log(`[cli-detect] ${message}`);
+  }
+
+  private logDetectFailure(
+    agentId: string,
+    command: string,
+    error: unknown,
+    timeout: number,
+    phase: 'version' | 'probe'
+  ): void {
+    const { shell, args } = getShellForCommand();
+    const env = getEnvForCommand();
+
+    const details = {
+      agentId,
+      command,
+      phase,
+      timeout,
+      error: this.formatError(error),
+      shell,
+      shellArgs: args,
+      pathPreview: this.getPathPreview(env.PATH),
+      packaged: app.isPackaged,
+    };
+
+    this.writeLogFile('warn', 'command detection failed', details);
+    console.warn('[cli-detect] command detection failed', details);
+  }
+
+  private extractExecutable(command: string): string {
+    const trimmed = command.trim();
+    if (!trimmed) return '';
+
+    const firstChar = trimmed[0];
+    if (firstChar === '"' || firstChar === "'") {
+      const endIndex = trimmed.indexOf(firstChar, 1);
+      if (endIndex > 1) {
+        return trimmed.slice(1, endIndex);
+      }
+    }
+
+    const firstWhitespaceIndex = trimmed.search(/\s/);
+    return firstWhitespaceIndex === -1 ? trimmed : trimmed.slice(0, firstWhitespaceIndex);
+  }
+
+  private isPathLike(command: string): boolean {
+    return (
+      command.includes('/') ||
+      command.includes('\\') ||
+      /^[a-zA-Z]:/.test(command) ||
+      command.startsWith('.')
+    );
+  }
+
+  private async isCommandAvailable(command: string, timeout: number): Promise<boolean> {
+    const executable = this.extractExecutable(command);
+    if (!executable) return false;
+
+    if (this.isPathLike(executable)) {
+      const exists = existsSync(executable);
+      this.logDebug('Path-like command probe result', { command, executable, exists });
+      return exists;
+    }
+
+    const probeCommand = isWindows ? `where.exe ${executable}` : `command -v ${executable}`;
+    this.logDebug('Start command availability probe', {
+      command,
+      executable,
+      probeCommand,
+      timeout,
+    });
+    try {
+      const stdout = await execInPty(probeCommand, { timeout: Math.min(timeout, 10000) });
+      const available = stdout.trim().length > 0;
+      this.logDebug('Command availability probe success', {
+        command,
+        executable,
+        available,
+        outputPreview: this.previewOutput(stdout),
+      });
+      return available;
+    } catch (error) {
+      this.logDetectFailure(executable, probeCommand, error, Math.min(timeout, 10000), 'probe');
+      return false;
+    }
+  }
+
   private async detectBuiltin(
     config: BuiltinAgentConfig,
     customPath?: string
   ): Promise<AgentCliInfo> {
+    // Use customPath if provided, otherwise use default command
+    const effectiveCommand = customPath || config.command;
+    // Windows: use 60s timeout due to slower shell initialization (PowerShell, WSL)
+    const timeout = isWindows ? 60000 : 15000;
+    const { shell, args } = getShellForCommand();
+    const env = getEnvForCommand();
+
+    this.logDebug('Start builtin CLI detection', {
+      agentId: config.id,
+      effectiveCommand,
+      timeout,
+      shell,
+      shellArgs: args,
+      pathPreview: this.getPathPreview(env.PATH),
+      packaged: process.env.NODE_ENV === 'production',
+    });
+
     try {
-      // Use customPath if provided, otherwise use default command
-      const effectiveCommand = customPath || config.command;
-      // Windows: use 60s timeout due to slower shell initialization (PowerShell, WSL)
-      const timeout = isWindows ? 60000 : 15000;
       const stdout = await execInPty(`${effectiveCommand} ${config.versionFlag}`, { timeout });
 
       let version: string | undefined;
@@ -91,6 +283,13 @@ class CliDetector {
         const match = stdout.match(config.versionRegex);
         version = match ? match[1] : undefined;
       }
+
+      this.logDebug('Builtin CLI version command success', {
+        agentId: config.id,
+        effectiveCommand,
+        version,
+        outputPreview: this.previewOutput(stdout),
+      });
 
       return {
         id: config.id,
@@ -102,6 +301,31 @@ class CliDetector {
         environment: 'native',
       };
     } catch (error) {
+      this.logDetectFailure(
+        config.id,
+        `${effectiveCommand} ${config.versionFlag}`,
+        error,
+        timeout,
+        'version'
+      );
+      const commandAvailable = await this.isCommandAvailable(effectiveCommand, timeout);
+      this.logDebug('Builtin CLI fallback probe result', {
+        agentId: config.id,
+        effectiveCommand,
+        commandAvailable,
+      });
+
+      if (commandAvailable) {
+        return {
+          id: config.id,
+          name: config.name,
+          command: config.command,
+          installed: true,
+          isBuiltin: true,
+          environment: 'native',
+        };
+      }
+
       return {
         id: config.id,
         name: config.name,
@@ -114,13 +338,33 @@ class CliDetector {
   }
 
   private async detectCustom(agent: CustomAgent): Promise<AgentCliInfo> {
+    // Windows: use 60s timeout due to slower shell initialization (PowerShell, WSL)
+    const timeout = isWindows ? 60000 : 15000;
+    const { shell, args } = getShellForCommand();
+    const env = getEnvForCommand();
+
+    this.logDebug('Start custom CLI detection', {
+      agentId: agent.id,
+      command: agent.command,
+      timeout,
+      shell,
+      shellArgs: args,
+      pathPreview: this.getPathPreview(env.PATH),
+      packaged: process.env.NODE_ENV === 'production',
+    });
+
     try {
-      // Windows: use 60s timeout due to slower shell initialization (PowerShell, WSL)
-      const timeout = isWindows ? 60000 : 15000;
       const stdout = await execInPty(`${agent.command} --version`, { timeout });
 
       const match = stdout.match(/(\d+\.\d+\.\d+)/);
       const version = match ? match[1] : undefined;
+
+      this.logDebug('Custom CLI version command success', {
+        agentId: agent.id,
+        command: agent.command,
+        version,
+        outputPreview: this.previewOutput(stdout),
+      });
 
       return {
         id: agent.id,
@@ -132,6 +376,25 @@ class CliDetector {
         environment: 'native',
       };
     } catch (error) {
+      this.logDetectFailure(agent.id, `${agent.command} --version`, error, timeout, 'version');
+      const commandAvailable = await this.isCommandAvailable(agent.command, timeout);
+      this.logDebug('Custom CLI fallback probe result', {
+        agentId: agent.id,
+        command: agent.command,
+        commandAvailable,
+      });
+
+      if (commandAvailable) {
+        return {
+          id: agent.id,
+          name: agent.name,
+          command: agent.command,
+          installed: true,
+          isBuiltin: false,
+          environment: 'native',
+        };
+      }
+
       return {
         id: agent.id,
         name: agent.name,
@@ -148,6 +411,13 @@ class CliDetector {
     customAgent?: CustomAgent,
     customPath?: string
   ): Promise<AgentCliInfo> {
+    this.logDebug('Detect one CLI request received', {
+      agentId,
+      hasCustomAgent: Boolean(customAgent),
+      hasCustomPath: Boolean(customPath),
+      customPath: customPath || '',
+    });
+
     const builtinConfig = BUILTIN_AGENT_CONFIGS.find((c) => c.id === agentId);
     if (builtinConfig) {
       return await this.detectBuiltin(builtinConfig, customPath);

--- a/src/main/services/terminal/PtyManager.ts
+++ b/src/main/services/terminal/PtyManager.ts
@@ -105,6 +105,15 @@ function expandWindowsEnvVars(str: string): string {
         return value;
       }
     }
+
+    const processValue =
+      process.env[varName] ||
+      process.env[varName.toUpperCase()] ||
+      process.env[varName.toLowerCase()];
+    if (processValue) {
+      return processValue;
+    }
+
     // Keep original if not found
     return match;
   });
@@ -152,7 +161,13 @@ function getWindowsRegistryPath(): string {
     // Expand environment variables like %NVM_SYMLINK%, %USERPROFILE%, etc.
     combinedPath = expandWindowsEnvVars(combinedPath);
 
-    cachedWindowsPath = combinedPath || process.env.PATH || '';
+    const processPath = process.env.PATH || '';
+    const allPaths = [
+      ...new Set([...combinedPath.split(delimiter), ...processPath.split(delimiter)]),
+    ]
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+    cachedWindowsPath = allPaths.join(delimiter);
     return cachedWindowsPath;
   } catch {
     // Fallback to process.env.PATH

--- a/src/shared/types/cli.ts
+++ b/src/shared/types/cli.ts
@@ -31,3 +31,10 @@ export interface CustomAgent {
 export interface AgentCliStatus {
   agents: AgentCliInfo[];
 }
+
+export interface CliDetectDebugLog {
+  level: 'debug' | 'warn';
+  message: string;
+  details?: Record<string, unknown>;
+  timestamp: string;
+}

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -145,6 +145,7 @@ export const IPC_CHANNELS = {
   // CLI Detector
   CLI_DETECT: 'cli:detect',
   CLI_DETECT_ONE: 'cli:detectOne',
+  CLI_DETECT_LOG: 'cli:detect:log',
 
   // CLI Installer
   CLI_INSTALL_STATUS: 'cli:install:status',


### PR DESCRIPTION
  在 Windows 打包版中，设置面板的 Agent CLI 检测会将 `ClaudeCode/Codex` 误判为“未安装”，但同机终端可正常执行 agent cli。

  ## 根因
  1. Shell 解析优先选到了 `pwsh.exe`，但部分机器未安装 PowerShell 7，导致命令执行前即失败。
  2. 打包环境 PATH 来自注册表时，存在 `%SystemRoot%` 等变量未完全展开的问题。
  3. PATH 仅用注册表值时可能缺少进程环境中的路径，导致命令查找不稳定。

  ## 变更内容
  ### 1) Windows shell 解析增强
  - 文件：`src/main/services/terminal/ShellDetector.ts`
  - 变更：
    - 新增 `where.exe` 探测，解析 shell 命令到真实可执行路径。
    - 自定义 shell 配置增加可用性校验，不可用时回退到 `powershell.exe`。
    - Windows 默认回退路径改为“探测到的 powershell 绝对路径”优先。

  ### 2) PATH 构建增强
  - 文件：`src/main/services/terminal/PtyManager.ts`
  - 变更：
    - 扩展 `%VAR%` 展开逻辑，增加 `process.env` 兜底。
    - 合并“注册表 PATH + 进程 PATH”并去重，降低打包环境下漏路径概率。

  ### 3) CLI 检测调试与容错（含开关）
  - 文件：`src/main/services/cli/CliDetector.ts`
  - 变更：
    - 保留检测失败告警日志（含 shell、PATH 预览、阶段信息）。
    - 增加 `ENSO_DEBUG_CLI_DETECT=1` 调试开关：
      - 开启时输出详细调试日志；
      - 开启时才镜像 main 日志到 renderer DevTools。
    - 失败日志中的 `packaged` 标识改为 `app.isPackaged`，避免误判。

  ### 4) 调试事件类型/通道（用于 DevTools 镜像）
  - 文件：
    - `src/shared/types/ipc.ts`
    - `src/shared/types/cli.ts`
  - 变更：
    - 新增 CLI 检测日志事件通道与类型定义。

  ## 验证
  - Windows 打包版中复现路径下，`ClaudeCode/Codex` 检测恢复正常。
  - 本机日志显示 shell 不可用场景可正确回退。
  - 相关改动已通过针对性 `biome check`。

  ## 影响范围
  - 仅影响 Windows shell/CLI 检测链路与调试日志通道。
  - 默认运行时无额外 DevTools 日志噪音（需显式设置 `ENSO_DEBUG_CLI_DETECT=1` 才镜像）。