### PR TITLE
feat(terminal): 添加 tmux 会话包装支持

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -24,6 +24,7 @@ import {
   destroyAllTerminalsAndWait,
   registerTerminalHandlers,
 } from './terminal';
+import { cleanupTmux, cleanupTmuxSync, registerTmuxHandlers } from './tmux';
 import { registerUpdaterHandlers } from './updater';
 import { registerWebInspectorHandlers } from './webInspector';
 import { clearAllWorktreeServices, registerWorktreeHandlers } from './worktree';
@@ -47,6 +48,7 @@ export function registerIpcHandlers(): void {
   registerClaudeConfigHandlers();
   registerWebInspectorHandlers();
   registerTempWorkspaceHandlers();
+  registerTmuxHandlers();
 }
 
 export async function cleanupAllResources(): Promise<void> {
@@ -54,6 +56,9 @@ export async function cleanupAllResources(): Promise<void> {
 
   // Stop Hapi server first (sync, fast)
   cleanupHapi();
+
+  // Kill tmux enso server (async, fast)
+  cleanupTmux().catch((err) => console.warn('Tmux cleanup warning:', err));
 
   // Stop Web Inspector server (sync, fast)
   webInspectorServer.stop();
@@ -108,6 +113,9 @@ export function cleanupAllResourcesSync(): void {
 
   // Kill Hapi/Cloudflared processes (sync)
   cleanupHapi();
+
+  // Kill tmux enso server (sync)
+  cleanupTmuxSync();
 
   // Stop Web Inspector server (sync)
   webInspectorServer.stop();

--- a/src/main/ipc/tmux.ts
+++ b/src/main/ipc/tmux.ts
@@ -1,0 +1,21 @@
+import { IPC_CHANNELS } from '@shared/types';
+import { ipcMain } from 'electron';
+import { tmuxDetector } from '../services/cli/TmuxDetector';
+
+export function registerTmuxHandlers(): void {
+  ipcMain.handle(IPC_CHANNELS.TMUX_CHECK, async (_, forceRefresh?: boolean) => {
+    return await tmuxDetector.check(forceRefresh);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.TMUX_KILL_SESSION, async (_, name: string) => {
+    return await tmuxDetector.killSession(name);
+  });
+}
+
+export async function cleanupTmux(): Promise<void> {
+  await tmuxDetector.killServer();
+}
+
+export function cleanupTmuxSync(): void {
+  tmuxDetector.killServerSync();
+}

--- a/src/main/services/cli/TmuxDetector.ts
+++ b/src/main/services/cli/TmuxDetector.ts
@@ -1,0 +1,71 @@
+import { spawnSync } from 'node:child_process';
+import { execInPty } from '../../utils/shell';
+
+const isWindows = process.platform === 'win32';
+
+export interface TmuxCheckResult {
+  installed: boolean;
+  version?: string;
+  error?: string;
+}
+
+class TmuxDetector {
+  private cache: TmuxCheckResult | null = null;
+
+  async check(forceRefresh?: boolean): Promise<TmuxCheckResult> {
+    if (isWindows) {
+      return { installed: false };
+    }
+
+    if (this.cache && !forceRefresh) {
+      return this.cache;
+    }
+
+    try {
+      const stdout = await execInPty('tmux -V', { timeout: 5000 });
+      const match = stdout.match(/tmux\s+(\d+\.\d+[a-z]?)/i);
+      const result: TmuxCheckResult = {
+        installed: true,
+        version: match ? match[1] : undefined,
+      };
+      this.cache = result;
+      return result;
+    } catch {
+      const result: TmuxCheckResult = { installed: false };
+      this.cache = result;
+      return result;
+    }
+  }
+
+  async killSession(name: string): Promise<void> {
+    if (isWindows) return;
+    try {
+      await execInPty(`tmux -L enso kill-session -t ${name}`, { timeout: 5000 });
+    } catch {
+      // Session may already be gone — ignore errors
+    }
+  }
+
+  async killServer(): Promise<void> {
+    if (isWindows) return;
+    try {
+      await execInPty('tmux -L enso kill-server', { timeout: 5000 });
+    } catch {
+      // Server may already be gone — ignore errors
+    }
+  }
+
+  killServerSync(): void {
+    if (isWindows) return;
+    try {
+      spawnSync('tmux', ['-L', 'enso', 'kill-server'], {
+        timeout: 3000,
+        stdio: 'ignore',
+      });
+    } catch {
+      // Server may already be gone — ignore errors
+    }
+  }
+}
+
+export const tmuxDetector = new TmuxDetector();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -487,6 +487,16 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.CLI_UNINSTALL),
   },
 
+  // Tmux
+  tmux: {
+    check: (
+      forceRefresh?: boolean
+    ): Promise<{ installed: boolean; version?: string; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.TMUX_CHECK, forceRefresh),
+    killSession: (name: string): Promise<void> =>
+      ipcRenderer.invoke(IPC_CHANNELS.TMUX_KILL_SESSION, name),
+  },
+
   // Settings
   settings: {
     read: (): Promise<unknown> => ipcRenderer.invoke(IPC_CHANNELS.SETTINGS_READ),

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -108,6 +108,7 @@ export function AgentTerminal({
   const pendingIdleMonitorRef = useRef(false); // Pending idle monitor; enabled after Enter.
   const dataSinceEnterRef = useRef(0); // Track output volume since last Enter.
   const currentTitleRef = useRef<string>(''); // Terminal title from OSC escape sequence.
+  const tmuxSessionNameRef = useRef<string | null>(null); // Tmux session name for cleanup.
 
   // Output state tracking for global store
   const outputStateRef = useRef<OutputState>('idle');
@@ -238,6 +239,15 @@ export function AgentTerminal({
     };
   }, [terminalSessionId, clearRuntimeState, stopActivityPolling]);
 
+  // Cleanup tmux session on unmount
+  useEffect(() => {
+    return () => {
+      if (tmuxSessionNameRef.current) {
+        window.electronAPI.tmux.killSession(tmuxSessionNameRef.current);
+      }
+    };
+  }, []);
+
   // Build command with session args
   const { command, env } = useMemo(() => {
     // Wait for shell config to be resolved
@@ -315,11 +325,29 @@ export function AgentTerminal({
     const fullCommand = `${effectiveCommand} ${agentArgs.join(' ')}`.trim();
     const shellName = resolvedShell.shell.toLowerCase();
 
+    // Determine if tmux wrapping should be applied
+    const isClaude = agentCommand?.startsWith('claude') ?? false;
+    const shouldUseTmux = claudeCodeIntegration.tmuxEnabled && isClaude && !isWindows;
+
+    // Build tmux session name from terminal session ID
+    const tmuxSessionName =
+      shouldUseTmux && terminalSessionId
+        ? `enso-${terminalSessionId}`.replace(/[^a-zA-Z0-9_-]/g, '_')
+        : null;
+    tmuxSessionNameRef.current = tmuxSessionName;
+
+    // Wrap command in tmux if enabled
+    let finalCommand = fullCommand;
+    if (tmuxSessionName) {
+      const escaped = fullCommand.replace(/'/g, "'\\''");
+      finalCommand = `env -u TMUX tmux -L enso -f /dev/null new-session -A -s ${tmuxSessionName} '${escaped}'`;
+    }
+
     // WSL: detect from shell name (wsl.exe)
     if (shellName.includes('wsl') && isWindows) {
       // Use -e to run command directly, sh -lc loads login profile
       // exec $SHELL replaces with user's shell (zsh/bash/etc.)
-      const escapedCommand = fullCommand.replace(/"/g, '\\"');
+      const escapedCommand = finalCommand.replace(/"/g, '\\"');
       return {
         command: {
           shell: 'wsl.exe',
@@ -335,7 +363,7 @@ export function AgentTerminal({
       return {
         command: {
           shell: resolvedShell.shell,
-          args: [...resolvedShell.execArgs, `& { ${fullCommand} }`],
+          args: [...resolvedShell.execArgs, `& { ${finalCommand} }`],
         },
         env: envVars,
       };
@@ -345,7 +373,7 @@ export function AgentTerminal({
     return {
       command: {
         shell: resolvedShell.shell,
-        args: [...resolvedShell.execArgs, fullCommand],
+        args: [...resolvedShell.execArgs, finalCommand],
       },
       env: envVars,
     };
@@ -359,6 +387,8 @@ export function AgentTerminal({
     hapiSettings.cliApiToken,
     hapiGlobalInstalled,
     resolvedShell,
+    claudeCodeIntegration.tmuxEnabled,
+    terminalSessionId,
   ]);
 
   // Handle exit with auto-close logic

--- a/src/renderer/components/settings/IntegrationSettings.tsx
+++ b/src/renderer/components/settings/IntegrationSettings.tsx
@@ -25,6 +25,8 @@ export function IntegrationSettings({ scrollToProvider }: IntegrationSettingsPro
   const providerRef = React.useRef<HTMLDivElement>(null);
   const { claudeCodeIntegration, setClaudeCodeIntegration } = useSettingsStore();
   const [bridgePort, setBridgePort] = React.useState<number | null>(null);
+  const [tmuxError, setTmuxError] = React.useState<string | null>(null);
+  const isWindows = window.electronAPI?.env?.platform === 'win32';
 
   const debounceOptions = React.useMemo(
     () =>
@@ -355,6 +357,36 @@ export function IntegrationSettings({ scrollToProvider }: IntegrationSettingsPro
                   {t('Version')}
                 </label>
               </div>
+            </div>
+          )}
+
+          {/* Tmux Session (non-Windows only) */}
+          {!isWindows && (
+            <div className="space-y-2">
+              <div className="flex items-center justify-between">
+                <div className="space-y-0.5">
+                  <span className="text-sm font-medium">{t('Tmux Session')}</span>
+                  <p className="text-xs text-muted-foreground">
+                    {t('Wrap Claude agent in tmux for session persistence and recovery')}
+                  </p>
+                </div>
+                <Switch
+                  checked={claudeCodeIntegration.tmuxEnabled}
+                  onCheckedChange={async (checked) => {
+                    if (checked) {
+                      setTmuxError(null);
+                      const result = await window.electronAPI.tmux.check(true);
+                      if (!result.installed) {
+                        setTmuxError(t('tmux is not installed. Please install tmux first.'));
+                        return;
+                      }
+                    }
+                    setTmuxError(null);
+                    setClaudeCodeIntegration({ tmuxEnabled: checked });
+                  }}
+                />
+              </div>
+              {tmuxError && <p className="text-xs text-destructive">{tmuxError}</p>}
             </div>
           )}
         </div>

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -254,6 +254,7 @@ export interface ClaudeCodeIntegrationSettings {
   permissionRequestHookEnabled: boolean; // Enable PermissionRequest hook for AskUserQuestion notifications
   statusLineEnabled: boolean; // Enable Status Line hook for displaying agent status
   statusLineFields: StatusLineFieldSettings; // Which fields to display in status line
+  tmuxEnabled: boolean; // Enable tmux session wrapping for persistent terminal sessions
   showProviderSwitcher: boolean; // Show provider switcher in SessionBar
   enableProviderDisableFeature: boolean; // Enable/disable the provider temporary disable feature
   providers: import('@shared/types').ClaudeProvider[];
@@ -267,6 +268,7 @@ export const defaultClaudeCodeIntegrationSettings: ClaudeCodeIntegrationSettings
   permissionRequestHookEnabled: true, // Enable PermissionRequest hook for AskUserQuestion notifications
   statusLineEnabled: false, // Disable Status Line hook by default
   statusLineFields: defaultStatusLineFieldSettings,
+  tmuxEnabled: false, // Disable tmux wrapping by default
   showProviderSwitcher: true,
   enableProviderDisableFeature: false,
   providers: [],

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -420,6 +420,10 @@ export const zhTranslations: Record<string, string> = {
   'Worktree search placeholder': '搜索 worktree...',
   'Toggle Worktree': '折叠/展开 Worktree',
   'Toggle Repository': '折叠/展开 Repository',
+  'Tmux Session': 'Tmux 会话',
+  'Wrap Claude agent in tmux for session persistence and recovery':
+    '将 Claude agent 包装在 tmux 中以实现会话持久化与恢复',
+  'tmux is not installed. Please install tmux first.': 'tmux 未安装，请先安装 tmux。',
   'Yes, remove': '移除',
   'You have {{count}} changed files': '{{count}} 个文件已更改',
   'You have no worktrees yet': '暂无 Worktree',

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -146,6 +146,10 @@ export const IPC_CHANNELS = {
   CLI_DETECT: 'cli:detect',
   CLI_DETECT_ONE: 'cli:detectOne',
 
+  // Tmux
+  TMUX_CHECK: 'tmux:check',
+  TMUX_KILL_SESSION: 'tmux:killSession',
+
   // CLI Installer
   CLI_INSTALL_STATUS: 'cli:install:status',
   CLI_INSTALL: 'cli:install',


### PR DESCRIPTION
## Summary
- 新增 tmux 会话包装功能，可在设置中启用，将 Claude agent 包装在 tmux 会话中运行，实现终端会话持久化与恢复
- 新增 `TmuxDetector` 服务检测 tmux 安装状态，并管理 enso 专用 tmux socket 的会话生命周期
- 设置界面新增 tmux 开关（仅非 Windows 平台显示），开启前自动检测 tmux 是否安装
- 应用退出时自动清理 tmux enso server，防止残留进程

## Changes
- `src/main/services/cli/TmuxDetector.ts` - 新增 tmux 检测与管理服务
- `src/main/ipc/tmux.ts` - 新增 tmux IPC 处理程序
- `src/main/ipc/index.ts` - 注册 tmux handlers 和清理逻辑
- `src/preload/index.ts` - 暴露 tmux API 到渲染进程
- `src/renderer/components/chat/AgentTerminal.tsx` - 支持 tmux 包装运行 Claude agent
- `src/renderer/components/settings/IntegrationSettings.tsx` - 设置界面增加 tmux 开关
- `src/renderer/stores/settings.ts` - 新增 `tmuxEnabled` 设置项
- `src/shared/i18n.ts` - 添加中文翻译
- `src/shared/types/ipc.ts` - 新增 tmux IPC channel 常量

## Test plan
- [ ] 在 Linux/macOS 上开启 tmux 设置，确认 Claude agent 正确运行在 tmux 会话中
- [ ] 确认关闭 tmux 设置后 agent 正常运行（不包装 tmux）
- [ ] 在未安装 tmux 的系统上开启开关，确认显示错误提示
- [ ] 确认 Windows 平台不显示 tmux 设置选项
- [ ] 确认应用退出后 tmux enso server 被正确清理