### PR TITLE
feat(sidebar): 侧边栏仓库分组折叠显示与代码质量改进

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,

--- a/src/main/ipc/tempWorkspace.ts
+++ b/src/main/ipc/tempWorkspace.ts
@@ -38,11 +38,12 @@ function formatTimestamp(date = new Date()): string {
 function mapError(err: unknown, fallbackCode = 'UNKNOWN'): { code: string; message: string } {
   if (err && typeof err === 'object' && 'code' in err) {
     const code = String((err as { code?: string }).code || fallbackCode);
+    const rawMessage = (err as { message?: unknown }).message;
     const message =
       err instanceof Error
         ? err.message
-        : typeof (err as { message?: unknown }).message === 'string'
-          ? (err as { message: string }).message
+        : typeof rawMessage === 'string'
+          ? rawMessage
           : String(err);
     return { code, message };
   }

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -1114,7 +1114,10 @@ export class GitService {
    * 智能 Push（公共逻辑）
    * 如果 non-fast-forward，自动先 pull 再重试
    */
-  private async smartPush(pushFn: () => Promise<void>, pullFn: () => Promise<void>): Promise<void> {
+  private async smartPush(
+    pushFn: () => Promise<unknown>,
+    pullFn: () => Promise<void>
+  ): Promise<void> {
     try {
       await pushFn();
     } catch (error) {

--- a/src/main/services/webInspector/WebInspectorServer.ts
+++ b/src/main/services/webInspector/WebInspectorServer.ts
@@ -133,7 +133,7 @@ export class WebInspectorServer {
   }
 
   isRunning(): boolean {
-    return this.server?.listening;
+    return this.server?.listening ?? false;
   }
 
   getStatus(): { running: boolean; port: number } {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -581,7 +581,7 @@ export default function App() {
         });
       } else {
         // New unsaved config detected
-        providerToastRef.current = toastManager.add({
+        providerToastRef.current = addToast({
           type: 'info',
           title: t('New provider detected'),
           description: t('Click to save this config'),

--- a/src/renderer/App/constants.ts
+++ b/src/renderer/App/constants.ts
@@ -19,6 +19,9 @@ export const DEFAULT_TAB_ORDER: TabId[] = ['chat', 'file', 'terminal', 'source-c
 /** 全部分组 ID（特殊值） */
 export const ALL_GROUP_ID = '__all__';
 
+/** Virtual section ID for ungrouped repositories */
+export const UNGROUPED_SECTION_ID = '__ungrouped__';
+
 /** 分组 Emoji 预设 */
 export const GROUP_EMOJI_PRESETS = ['🏠', '💼', '🧪', '📦', '🎮', '📚', '🔧', '🌟', '🎯', '🚀'];
 

--- a/src/renderer/App/storage.ts
+++ b/src/renderer/App/storage.ts
@@ -24,6 +24,7 @@ export const STORAGE_KEYS = {
   REPOSITORY_SETTINGS: 'enso-repository-settings', // per-repo settings (init script, etc.)
   REPOSITORY_GROUPS: 'enso-repository-groups',
   ACTIVE_GROUP: 'enso-active-group',
+  GROUP_COLLAPSED_STATE: 'enso-group-collapsed-state',
 } as const;
 
 // Helper to get initial value from localStorage
@@ -252,4 +253,20 @@ export const migrateRepositoryGroups = (): void => {
   if (localStorage.getItem(STORAGE_KEYS.ACTIVE_GROUP) === null) {
     localStorage.setItem(STORAGE_KEYS.ACTIVE_GROUP, ALL_GROUP_ID);
   }
+};
+
+export const getStoredGroupCollapsedState = (): Record<string, boolean> => {
+  const saved = localStorage.getItem(STORAGE_KEYS.GROUP_COLLAPSED_STATE);
+  if (saved) {
+    try {
+      return JSON.parse(saved) as Record<string, boolean>;
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+export const saveGroupCollapsedState = (state: Record<string, boolean>): void => {
+  localStorage.setItem(STORAGE_KEYS.GROUP_COLLAPSED_STATE, JSON.stringify(state));
 };

--- a/src/renderer/components/files/FilePanel.tsx
+++ b/src/renderer/components/files/FilePanel.tsx
@@ -166,7 +166,7 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
       // Convert to relative path if within rootPath, otherwise use full path
       let displayPath = path;
       const normalizedRoot = rootPath ? normalizePath(rootPath) : '';
-      if (normalizedRoot && path.startsWith(normalizedRoot + '/')) {
+      if (normalizedRoot && path.startsWith(`${normalizedRoot}/`)) {
         displayPath = path.slice(normalizedRoot.length + 1);
       }
       terminalWrite(sessionId, `@${displayPath} `);

--- a/src/renderer/components/git/AddRepositoryDialog.tsx
+++ b/src/renderer/components/git/AddRepositoryDialog.tsx
@@ -229,7 +229,7 @@ export function AddRepositoryDialog({
   const formatPathDisplay = React.useCallback((fullPath: string) => {
     const home = window.electronAPI.env.HOME;
     if (home && fullPath.startsWith(home)) {
-      return '~' + fullPath.slice(home.length);
+      return `~${fullPath.slice(home.length)}`;
     }
     return fullPath;
   }, []);

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -245,7 +245,7 @@ export function GeneralSettings() {
   const isCustomShell = shellConfig.shellType === 'custom';
 
   const [customArgsText, setCustomArgsText] = React.useState(() =>
-    stringifyShellArgs(shellConfig.customShellArgs || []),
+    stringifyShellArgs(shellConfig.customShellArgs || [])
   );
 
   React.useEffect(() => {
@@ -261,7 +261,9 @@ export function GeneralSettings() {
 
   const isWindows = window.electronAPI?.env.platform === 'win32';
   const shellPathPlaceholder = isWindows ? 'cmd.exe' : '/bin/bash';
-  const shellArgsPlaceholder = isWindows ? '/k "C:\\Program Files\\init.bat"' : "-l -c '/usr/local/bin/app'";
+  const shellArgsPlaceholder = isWindows
+    ? '/k "C:\\Program Files\\init.bat"'
+    : "-l -c '/usr/local/bin/app'";
 
   return (
     <div className="space-y-6">
@@ -476,7 +478,7 @@ export function GeneralSettings() {
             >
               <SelectTrigger className="w-64">
                 <SelectValue>
-                  {isCustomShell ? t('Custom') : (currentShell?.name || shellConfig.shellType)}
+                  {isCustomShell ? t('Custom') : currentShell?.name || shellConfig.shellType}
                 </SelectValue>
               </SelectTrigger>
               <SelectPopup>
@@ -817,12 +819,10 @@ export function GeneralSettings() {
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogClose asChild>
-              <Button variant="outline">{t('Cancel')}</Button>
-            </AlertDialogClose>
-            <AlertDialogClose asChild>
-              <Button onClick={handleSelectTempPath}>{t('Choose directory')}</Button>
-            </AlertDialogClose>
+            <AlertDialogClose render={<Button variant="outline">{t('Cancel')}</Button>} />
+            <AlertDialogClose
+              render={<Button onClick={handleSelectTempPath}>{t('Choose directory')}</Button>}
+            />
           </AlertDialogFooter>
         </AlertDialogPopup>
       </AlertDialog>

--- a/src/renderer/components/source-control/CodeReviewModal.tsx
+++ b/src/renderer/components/source-control/CodeReviewModal.tsx
@@ -30,7 +30,6 @@ import { Button } from '@/components/ui/button';
 import { CodeBlock } from '@/components/ui/code-block';
 import {
   Dialog,
-  DialogClose,
   DialogDescription,
   DialogFooter,
   DialogHeader,

--- a/src/renderer/components/source-control/DiffReviewModal.tsx
+++ b/src/renderer/components/source-control/DiffReviewModal.tsx
@@ -922,7 +922,6 @@ export function DiffReviewModal({
         viewZoneIdsRef.current = [];
       }
     };
-    // biome-ignore lint/correctness/useExhaustiveDependencies: using ref for handleDeleteComment
   }, [editorReady, open, selectedFile, currentFileComments, t]);
 
   // Cleanup on unmount

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -52,7 +52,7 @@ import { CommitHistoryList } from './CommitHistoryList';
 import { panelTransition } from './constants';
 import { DiffViewer } from './DiffViewer';
 import { RepositoryList } from './RepositoryList';
-import type { Repository, SelectedFile } from './types';
+import type { Repository } from './types';
 import { usePanelResize } from './usePanelResize';
 
 interface SourceControlPanelProps {
@@ -95,7 +95,7 @@ export function SourceControlPanel({
   const [expandedCommitHash, setExpandedCommitHash] = useState<string | null>(null);
 
   // Submodule commit history state
-  const [selectedSubmoduleCommit, setSelectedSubmoduleCommit] = useState<{
+  const [selectedSubmoduleCommit, _setSelectedSubmoduleCommit] = useState<{
     hash: string;
     filePath: string | null;
     submodulePath: string;
@@ -456,7 +456,7 @@ export function SourceControlPanel({
   );
 
   // Submodule commit diff
-  const { data: submoduleCommitDiff, isLoading: submoduleCommitDiffLoading } = useCommitDiff(
+  const { data: _submoduleCommitDiff, isLoading: _submoduleCommitDiffLoading } = useCommitDiff(
     rootPath ?? null,
     selectedSubmoduleCommit?.hash ?? null,
     selectedSubmoduleCommit?.filePath ?? null,

--- a/src/renderer/components/temp-workspace/TempWorkspaceDialogs.tsx
+++ b/src/renderer/components/temp-workspace/TempWorkspaceDialogs.tsx
@@ -98,9 +98,7 @@ export function TempWorkspaceDialogs({
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
-            <AlertDialogClose asChild>
-              <Button variant="outline">{t('Cancel')}</Button>
-            </AlertDialogClose>
+            <AlertDialogClose render={<Button variant="outline">{t('Cancel')}</Button>} />
             <Button
               variant="destructive"
               onClick={async () => {

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -634,7 +634,10 @@ export function useXterm({
       }
       // Remove copy-on-selection listener before disposing terminal
       if (copyOnSelectionHandlerRef.current) {
-        terminalRef.current?.element?.removeEventListener('mouseup', copyOnSelectionHandlerRef.current);
+        terminalRef.current?.element?.removeEventListener(
+          'mouseup',
+          copyOnSelectionHandlerRef.current
+        );
         copyOnSelectionHandlerRef.current = null;
       }
       // Dispose addons before terminal to prevent async callback errors

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -233,6 +233,7 @@ export const zhTranslations: Record<string, string> = {
   'No files': '没有文件',
   'No commits yet': '暂无提交记录',
   'No Group': '无分组',
+  Ungrouped: '未分组',
   'No file changes in this commit': '此提交没有文件更改',
   'No staged changes': '没有暂存的更改',
   'No matching actions found': '没有找到匹配的操作',


### PR DESCRIPTION
## 概述

侧边栏仓库列表支持按分组分区显示，可折叠/展开各分组，并修复了多项代码质量问题。

## 主要改动

### 新功能
- **侧边栏分组折叠** — `RepositorySidebar` 和 `TreeSidebar` 在"全部"视图下按分组分区显示仓库，每个分组可独立折叠/展开
- 折叠状态持久化到 `localStorage`，刷新后保持
- 未分组仓库归入"未分组"区域
- 拖拽排序限制在同一分组内，防止跨组拖拽错乱

### 重构
- **Toast 系统** — `actions` 从顶层属性迁移到 `data` 属性，修复 action 点击后 toast 关闭行为
- **AlertDialogClose** — 从 `asChild` 迁移到 `render` prop（GeneralSettings、TempWorkspaceDialogs）

### 修复
- `WebInspectorServer.isRunning()` 返回 `boolean` 而非可能的 `undefined`
- `GitService.smartPush` 类型签名修正（`Promise<void>` → `Promise<unknown>`）
- 移除未使用的导入（`DialogClose`、`SelectedFile`、`hexToRgba`）
- Biome lint 格式化修复（模板字符串、行宽、尾逗号等）

### 国际化
- 新增 `Ungrouped` / `未分组` 翻译条目

## 影响范围

- `src/renderer/components/layout/RepositorySidebar.tsx`
- `src/renderer/components/layout/TreeSidebar.tsx`
- `src/renderer/components/ui/toast.tsx`
- `src/renderer/App/constants.ts` / `storage.ts`
- 其他 13 个文件（小幅修复）