### PR TITLE
fix: 修复 agent 状态在重启和热更新后不刷新的问题

### DIFF
--- a/src/renderer/stores/agentSessions.ts
+++ b/src/renderer/stores/agentSessions.ts
@@ -6,7 +6,7 @@ import type { AgentGroupState } from '@/components/chat/types';
 import { createInitialGroupState } from '@/components/chat/types';
 
 // Global storage key for all sessions across all repos
-const SESSIONS_STORAGE_KEY = 'enso-agent-sessions';
+export const SESSIONS_STORAGE_KEY = 'enso-agent-sessions';
 
 // Runtime output state for each session (not persisted)
 export type OutputState = 'idle' | 'outputting' | 'unread';


### PR DESCRIPTION
## 问题背景

Agent 状态在以下场景无法正确刷新：
- 应用重启后
- 热更新（HMR）后

状态丢失导致的问题：
- 通知点击无法正确激活对应 session
- 侧边栏 activity 状态不正确
- `waiting_input` / `completed` 状态被覆盖

## 解决方案

### 1. Hook 通知路由优化
- 支持 `cwd` 优先匹配 workspaceFolders 投递
- 目标不可达时回退到其他实例
- 兼容 `session.id` 与 `session.sessionId` 双键匹配

### 2. 状态覆盖保护
- `waiting_input` / `completed` 状态不再被轮询回写覆盖
- 仅 `idle` / `running` 状态可被更新为 `running`

### 3. HMR 场景兜底
- 使用 `getState()` 获取最新 store 数据
- 增加持久化数据快照作为 fallback
- 消除重复的 storage key 定义

### 4. 响应体 drain
- 消费 HTTP 响应体避免潜在 socket 泄漏

## 变更文件

| 文件 | 修改内容 |
|------|----------|
| `ClaudeHookManager.ts` | Hook 路由匹配、响应体 drain、postAgentHook |
| `AgentPanel.tsx` | 会话 ID 双键匹配、handleSelectSession 修复 |
| `AgentTerminal.tsx` | 状态覆盖保护、移除 sessionWorktree 注册 |
| `agentSessions.ts` | 导出 SESSIONS_STORAGE_KEY |
| `worktreeActivity.ts` | HMR 兜底、findWorktreePath 持久化 fallback |

## 验证

```bash
pnpm -s biome check src/main/services/claude/ClaudeHookManager.ts \
  src/renderer/components/chat/AgentPanel.tsx \
  src/renderer/components/chat/AgentTerminal.tsx \
  src/renderer/stores/agentSessions.ts \
  src/renderer/stores/worktreeActivity.ts
```