### PR TITLE
fix: 修复切换远程分支时的异常问题

### DIFF
--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -453,7 +453,10 @@ export class GitService {
   }
 
   async checkout(branch: string): Promise<void> {
-    await this.git.checkout(branch);
+    // Remote branch names are in the format "remotes/origin/branch-name"
+    // git checkout requires "origin/branch-name" format to properly track remote branches
+    const normalizedBranch = branch.startsWith('remotes/') ? branch.slice(8) : branch;
+    await this.git.checkout(normalizedBranch);
   }
 
   async createBranch(name: string, startPoint?: string): Promise<void> {


### PR DESCRIPTION
## Summary
- 修复切换远程分支时的异常问题
- 远程分支名称格式为 `remotes/origin/branch-name`，但 `git checkout` 需要 `origin/branch-name` 格式才能正确创建本地跟踪分支
- 修复方法是在 checkout 时去掉 `remotes/` 前缀

## Test plan
- [ ] 测试从远程分支列表切换到远程分支
- [ ] 验证切换后本地分支正确跟踪远程分支

🤖 Generated with [Claude Code](https://claude.com/claude-code)