### PR TITLE
feat(hapi): 增加 Runner 远程创建会话开关，并按 Hapi 生命周期管理

### DIFF
--- a/src/main/ipc/hapi.ts
+++ b/src/main/ipc/hapi.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { IPC_CHANNELS } from '@shared/types';
 import { app, BrowserWindow, ipcMain } from 'electron';
 import { type CloudflaredConfig, cloudflaredManager } from '../services/hapi/CloudflaredManager';
+import { hapiRunnerManager } from '../services/hapi/HapiRunnerManager';
 import { type HapiConfig, hapiServerManager } from '../services/hapi/HapiServerManager';
 
 interface StoredHapiSettings {
@@ -17,6 +18,60 @@ interface StoredHapiSettings {
   tunnelMode: 'quick' | 'auth';
   tunnelToken: string;
   useHttp2: boolean;
+  // Hapi runner settings
+  runnerEnabled?: boolean;
+}
+
+interface HapiControlConfig extends HapiConfig {
+  runnerEnabled?: boolean;
+}
+
+function waitForHapiReady(maxAttempts = 60, intervalMs = 500): Promise<boolean> {
+  return new Promise((resolve) => {
+    let attempts = 0;
+
+    const checkReady = () => {
+      attempts++;
+      const status = hapiServerManager.getStatus();
+      if (status.ready) {
+        resolve(true);
+        return;
+      }
+
+      if (!status.running || attempts >= maxAttempts) {
+        resolve(false);
+        return;
+      }
+
+      setTimeout(checkReady, intervalMs);
+    };
+
+    checkReady();
+  });
+}
+
+async function syncRunnerState(runnerEnabled: boolean): Promise<void> {
+  if (!runnerEnabled) {
+    await hapiRunnerManager.stop();
+    return;
+  }
+
+  const ready = await waitForHapiReady();
+  if (!ready) {
+    console.warn('[hapi:runner] Skip start: hapi server is not ready');
+    return;
+  }
+
+  const runnerStatus = await hapiRunnerManager.start();
+  if (!runnerStatus.running && runnerStatus.error) {
+    console.error('[hapi:runner] Start failed:', runnerStatus.error);
+  }
+}
+
+function syncRunnerStateInBackground(runnerEnabled: boolean): void {
+  void syncRunnerState(runnerEnabled).catch((error) => {
+    console.error('[hapi:runner] Failed to sync runner state:', error);
+  });
 }
 
 export function registerHapiHandlers(): void {
@@ -31,26 +86,84 @@ export function registerHapiHandlers(): void {
   });
 
   // Hapi Server handlers
-  ipcMain.handle(IPC_CHANNELS.HAPI_START, async (_, config: HapiConfig) => {
-    return await hapiServerManager.start(config);
+  ipcMain.handle(IPC_CHANNELS.HAPI_START, async (_, config: HapiControlConfig) => {
+    const { runnerEnabled = false, ...hapiConfig } = config;
+    const status = await hapiServerManager.start(hapiConfig);
+
+    if (status.running) {
+      syncRunnerStateInBackground(runnerEnabled);
+    }
+
+    return status;
   });
 
   ipcMain.handle(IPC_CHANNELS.HAPI_STOP, async () => {
+    await hapiRunnerManager.stop();
     return await hapiServerManager.stop();
   });
 
-  ipcMain.handle(IPC_CHANNELS.HAPI_RESTART, async (_, config: HapiConfig) => {
-    return await hapiServerManager.restart(config);
+  ipcMain.handle(IPC_CHANNELS.HAPI_RESTART, async (_, config: HapiControlConfig) => {
+    const { runnerEnabled = false, ...hapiConfig } = config;
+
+    await hapiRunnerManager.stop();
+    const status = await hapiServerManager.restart(hapiConfig);
+
+    if (status.running) {
+      syncRunnerStateInBackground(runnerEnabled);
+    }
+
+    return status;
   });
 
   ipcMain.handle(IPC_CHANNELS.HAPI_GET_STATUS, async () => {
     return hapiServerManager.getStatus();
   });
 
+  // Hapi Runner handlers
+  ipcMain.handle(IPC_CHANNELS.HAPI_RUNNER_START, async () => {
+    const hapiStatus = hapiServerManager.getStatus();
+    if (!hapiStatus.running) {
+      return {
+        running: false,
+        error: 'Hapi server is not running',
+      };
+    }
+
+    const ready = hapiStatus.ready || (await waitForHapiReady());
+    if (!ready) {
+      return {
+        running: false,
+        error: 'Hapi server is not ready',
+      };
+    }
+
+    return await hapiRunnerManager.start();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.HAPI_RUNNER_STOP, async () => {
+    return await hapiRunnerManager.stop();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.HAPI_RUNNER_GET_STATUS, async () => {
+    return await hapiRunnerManager.getStatus();
+  });
+
   hapiServerManager.on('statusChanged', (status) => {
+    if (!status.running && hapiRunnerManager.getStatus().running) {
+      void hapiRunnerManager.stop();
+    }
+
     for (const window of BrowserWindow.getAllWindows()) {
       if (!window.isDestroyed()) {
         window.webContents.send(IPC_CHANNELS.HAPI_STATUS_CHANGED, status);
+      }
+    }
+  });
+
+  hapiRunnerManager.on('statusChanged', (status) => {
+    for (const window of BrowserWindow.getAllWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(IPC_CHANNELS.HAPI_RUNNER_STATUS_CHANGED, status);
       }
     }
   });
@@ -85,7 +198,19 @@ export function registerHapiHandlers(): void {
   });
 }
 
-export function cleanupHapi(): void {
+export async function cleanupHapi(runnerStopTimeoutMs = 5000): Promise<void> {
+  try {
+    await hapiRunnerManager.cleanup(runnerStopTimeoutMs);
+  } catch (error) {
+    console.warn('[hapi:runner] Cleanup error:', error);
+  }
+
+  hapiServerManager.cleanup();
+  cloudflaredManager.cleanup();
+}
+
+export function cleanupHapiSync(): void {
+  hapiRunnerManager.cleanupSync();
   hapiServerManager.cleanup();
   cloudflaredManager.cleanup();
 }
@@ -113,31 +238,24 @@ export async function autoStartHapi(): Promise<void> {
       };
       await hapiServerManager.start(config);
 
+      // Auto-start runner if enabled
+      if (hapiSettings.runnerEnabled) {
+        console.log('[hapi:runner] Auto-starting runner from saved settings...');
+
+        const ready = await waitForHapiReady();
+        if (ready) {
+          await hapiRunnerManager.start();
+        } else {
+          console.warn('[hapi:runner] Skip auto-start: hapi server is not ready');
+        }
+      }
+
       // Auto-start cloudflared if enabled
       if (hapiSettings.cfEnabled) {
         console.log('[cloudflared] Auto-starting tunnel from saved settings...');
-        // Wait for hapi to be ready before starting cloudflared
-        const waitForReady = (): Promise<void> => {
-          return new Promise((resolve) => {
-            let attempts = 0;
-            const maxAttempts = 60;
-            const checkReady = () => {
-              attempts++;
-              const status = hapiServerManager.getStatus();
-              if (status.ready || !status.running || attempts >= maxAttempts) {
-                resolve();
-              } else {
-                setTimeout(checkReady, 500);
-              }
-            };
-            checkReady();
-          });
-        };
 
-        await waitForReady();
-
-        const hapiStatus = hapiServerManager.getStatus();
-        if (hapiStatus.ready) {
+        const ready = await waitForHapiReady();
+        if (ready) {
           const cfConfig: CloudflaredConfig = {
             mode: hapiSettings.tunnelMode || 'quick',
             port: hapiSettings.webappPort || 3006,

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -16,7 +16,12 @@ import {
   cleanupTempFilesSync,
 } from './files';
 import { clearAllGitServices, registerGitHandlers } from './git';
-import { autoStartHapi, cleanupHapi, registerHapiHandlers } from './hapi';
+import {
+  autoStartHapi,
+  cleanupHapi,
+  cleanupHapiSync,
+  registerHapiHandlers,
+} from './hapi';
 
 export { autoStartHapi };
 
@@ -60,8 +65,8 @@ export function registerIpcHandlers(): void {
 export async function cleanupAllResources(): Promise<void> {
   const CLEANUP_TIMEOUT = 3000;
 
-  // Stop Hapi server first (sync, fast)
-  cleanupHapi();
+  // Stop Hapi server first (graceful best-effort with timeout)
+  await cleanupHapi(CLEANUP_TIMEOUT);
 
   // Kill tmux enso server (async, fast)
   cleanupTmux().catch((err) => console.warn('Tmux cleanup warning:', err));
@@ -121,7 +126,7 @@ export function cleanupAllResourcesSync(): void {
   console.log('[app] Sync cleanup starting...');
 
   // Kill Hapi/Cloudflared processes (sync)
-  cleanupHapi();
+  cleanupHapiSync();
 
   // Kill tmux enso server (sync)
   cleanupTmuxSync();

--- a/src/main/services/hapi/HapiRunnerManager.ts
+++ b/src/main/services/hapi/HapiRunnerManager.ts
@@ -1,0 +1,197 @@
+import { spawn } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { killProcessTree } from '../../utils/processUtils';
+import { getEnvForCommand, getShellForCommand } from '../../utils/shell';
+import { hapiServerManager } from './HapiServerManager';
+
+export interface HapiRunnerStatus {
+  running: boolean;
+  pid?: number;
+  error?: string;
+}
+
+type RunnerAction = 'start' | 'stop';
+
+interface RunnerCommandResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+class HapiRunnerManager extends EventEmitter {
+  private status: HapiRunnerStatus = { running: false };
+
+  private async getRunnerCommand(action: RunnerAction): Promise<string> {
+    const hapiCommand = await hapiServerManager.getHapiCommand();
+    return hapiCommand === 'hapi'
+      ? `hapi runner ${action}`
+      : `npx -y @twsxtd/hapi runner ${action}`;
+  }
+
+  private async runRunnerCommand(
+    action: RunnerAction,
+    timeoutMs = 30000
+  ): Promise<RunnerCommandResult> {
+    const command = await this.getRunnerCommand(action);
+    const { shell, args: shellArgs } = getShellForCommand();
+
+    return new Promise((resolve) => {
+      const proc = spawn(shell, [...shellArgs, command], {
+        env: getEnvForCommand(),
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      let stdout = '';
+      let stderr = '';
+      let settled = false;
+
+      const timeout = setTimeout(() => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        killProcessTree(proc);
+        resolve({ code: null, stdout, stderr, timedOut: true });
+      }, timeoutMs);
+
+      proc.stdout?.on('data', (data: Buffer) => {
+        stdout += data.toString();
+      });
+
+      proc.stderr?.on('data', (data: Buffer) => {
+        stderr += data.toString();
+      });
+
+      proc.on('error', (error) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timeout);
+        resolve({
+          code: null,
+          stdout,
+          stderr: `${stderr}\n${error.message}`.trim(),
+          timedOut: false,
+        });
+      });
+
+      proc.on('exit', (code) => {
+        if (settled) {
+          return;
+        }
+
+        settled = true;
+        clearTimeout(timeout);
+        resolve({ code, stdout, stderr, timedOut: false });
+      });
+    });
+  }
+
+  private setStatus(nextStatus: HapiRunnerStatus): HapiRunnerStatus {
+    const changed =
+      this.status.running !== nextStatus.running ||
+      this.status.pid !== nextStatus.pid ||
+      this.status.error !== nextStatus.error;
+
+    this.status = nextStatus;
+
+    if (changed) {
+      this.emit('statusChanged', this.status);
+    }
+
+    return this.status;
+  }
+
+  private buildCommandError(action: RunnerAction, result: RunnerCommandResult): string {
+    const output = `${result.stdout}\n${result.stderr}`.trim();
+    if (output) {
+      return output;
+    }
+
+    if (result.timedOut) {
+      return `hapi runner ${action} timed out`;
+    }
+
+    return `hapi runner ${action} exited with code ${result.code ?? 'unknown'}`;
+  }
+
+  private extractPid(output: string): number | undefined {
+    const match = output.match(/\bpid\s*[:=]?\s*(\d+)\b/i);
+    if (!match) {
+      return undefined;
+    }
+
+    const pid = Number(match[1]);
+    return Number.isFinite(pid) ? pid : undefined;
+  }
+
+  private isRunningOutput(output: string): boolean {
+    return /(already\s+running|\brunning\b|\bactive\b|\bonline\b)/i.test(output);
+  }
+
+  private isStoppedOutput(output: string): boolean {
+    return /(already\s+stopped|not\s+running|\bstopped\b|\binactive\b|no\s+runner)/i.test(output);
+  }
+
+  async start(): Promise<HapiRunnerStatus> {
+    const result = await this.runRunnerCommand('start', 120000);
+    const output = `${result.stdout}\n${result.stderr}`.trim();
+
+    if (result.code === 0 || this.isRunningOutput(output)) {
+      return this.setStatus({
+        running: true,
+        pid: this.extractPid(output),
+      });
+    }
+
+    return this.setStatus({
+      running: false,
+      error: this.buildCommandError('start', result),
+    });
+  }
+
+  async stop(timeoutMs = 30000): Promise<HapiRunnerStatus> {
+    const result = await this.runRunnerCommand('stop', timeoutMs);
+    const output = `${result.stdout}\n${result.stderr}`.trim();
+
+    if (result.code === 0 || this.isStoppedOutput(output)) {
+      return this.setStatus({ running: false });
+    }
+
+    if (this.isRunningOutput(output)) {
+      return this.setStatus({
+        ...this.status,
+        running: true,
+        error: this.buildCommandError('stop', result),
+      });
+    }
+
+    return this.setStatus({
+      running: false,
+      error: this.buildCommandError('stop', result),
+    });
+  }
+
+  getStatus(): HapiRunnerStatus {
+    return this.status;
+  }
+
+  async cleanup(timeoutMs = 5000): Promise<void> {
+    const status = await this.stop(timeoutMs);
+    if (status.error) {
+      console.warn('[hapi:runner] Cleanup warning:', status.error);
+    }
+  }
+
+  cleanupSync(): void {
+    void this.stop(3000).catch((error) => {
+      console.warn('[hapi:runner] Sync cleanup failed:', error);
+    });
+  }
+}
+
+export const hapiRunnerManager = new HapiRunnerManager();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -778,6 +778,7 @@ const electronAPI = {
       telegramBotToken: string;
       webappUrl: string;
       allowedChatIds: string;
+      runnerEnabled?: boolean;
     }): Promise<{
       running: boolean;
       ready?: boolean;
@@ -793,6 +794,7 @@ const electronAPI = {
       telegramBotToken: string;
       webappUrl: string;
       allowedChatIds: string;
+      runnerEnabled?: boolean;
     }): Promise<{
       running: boolean;
       ready?: boolean;
@@ -822,6 +824,35 @@ const electronAPI = {
       ) => callback(status);
       ipcRenderer.on(IPC_CHANNELS.HAPI_STATUS_CHANGED, handler);
       return () => ipcRenderer.off(IPC_CHANNELS.HAPI_STATUS_CHANGED, handler);
+    },
+  },
+
+  // Hapi Runner
+  hapiRunner: {
+    start: (): Promise<{
+      running: boolean;
+      pid?: number;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC_CHANNELS.HAPI_RUNNER_START),
+    stop: (): Promise<{
+      running: boolean;
+      pid?: number;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC_CHANNELS.HAPI_RUNNER_STOP),
+    getStatus: (): Promise<{
+      running: boolean;
+      pid?: number;
+      error?: string;
+    }> => ipcRenderer.invoke(IPC_CHANNELS.HAPI_RUNNER_GET_STATUS),
+    onStatusChanged: (
+      callback: (status: { running: boolean; pid?: number; error?: string }) => void
+    ): (() => void) => {
+      const handler = (
+        _: unknown,
+        status: { running: boolean; pid?: number; error?: string }
+      ) => callback(status);
+      ipcRenderer.on(IPC_CHANNELS.HAPI_RUNNER_STATUS_CHANGED, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.HAPI_RUNNER_STATUS_CHANGED, handler);
     },
   },
 

--- a/src/renderer/components/settings/HapiSettings.tsx
+++ b/src/renderer/components/settings/HapiSettings.tsx
@@ -135,7 +135,10 @@ export function HapiSettings() {
     try {
       if (enabled) {
         const config = getConfig();
-        await window.electronAPI.hapi.start(config);
+        await window.electronAPI.hapi.start({
+          ...config,
+          runnerEnabled: hapiSettings.runnerEnabled,
+        });
       } else {
         await window.electronAPI.hapi.stop();
         // Also stop cloudflared when disabling hapi
@@ -169,10 +172,17 @@ export function HapiSettings() {
     saveSettings();
     try {
       const config = getConfig();
-      await window.electronAPI.hapi.restart(config);
+      await window.electronAPI.hapi.restart({
+        ...config,
+        runnerEnabled: hapiSettings.runnerEnabled,
+      });
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleRunnerEnabledChange = (checked: boolean) => {
+    setHapiSettings({ runnerEnabled: checked });
   };
 
   const handleGenerateToken = () => {
@@ -291,6 +301,25 @@ export function HapiSettings() {
               </Button>
             </div>
           )}
+
+          {/* Runner Section */}
+          <div className="space-y-4 border-t pt-4">
+            <div className="flex items-center justify-between">
+              <div className="space-y-0.5">
+                <span className="text-sm font-medium">{t('Enable Remote Spawn (Runner)')}</span>
+                <p className="text-xs text-muted-foreground">
+                  {t('Automatically start Hapi Runner with Hapi service for remote session spawning')}
+                  {' '}
+                  {t('(Changes apply after service restart)')}
+                </p>
+              </div>
+              <Switch
+                checked={hapiSettings.runnerEnabled}
+                onCheckedChange={handleRunnerEnabledChange}
+                disabled={loading}
+              />
+            </div>
+          </div>
 
           {/* Cloudflared Section */}
           <div className="space-y-4 border-t pt-4">

--- a/src/renderer/stores/settings.ts
+++ b/src/renderer/stores/settings.ts
@@ -388,6 +388,8 @@ export interface HapiSettings {
   tunnelMode: TunnelMode;
   tunnelToken: string;
   useHttp2: boolean;
+  // Hapi runner settings
+  runnerEnabled: boolean;
   // Happy settings
   happyEnabled: boolean;
 }
@@ -404,6 +406,8 @@ export const defaultHapiSettings: HapiSettings = {
   tunnelMode: 'quick',
   tunnelToken: '',
   useHttp2: true,
+  // Hapi runner defaults
+  runnerEnabled: false,
   // Happy defaults
   happyEnabled: false,
 };

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1003,6 +1003,10 @@ export const zhTranslations: Record<string, string> = {
   'Starting...': '启动中...',
   'Use HTTP/2 Protocol': '使用 HTTP/2 协议',
   'More compatible than QUIC when behind firewalls': '在防火墙后比 QUIC 更兼容',
+  'Enable Remote Spawn (Runner)': '启用远程创建会话 (Runner)',
+  'Automatically start Hapi Runner with Hapi service for remote session spawning':
+    '随 Hapi 服务自动启动 Hapi Runner，以支持远程创建新会话',
+  '(Changes apply after service restart)': '（重启服务生效）',
   // Happy
   'Happy Agents': 'Happy Agent',
   'Agents running through Happy': '通过 Happy 运行的 Agent',

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -230,6 +230,12 @@ export const IPC_CHANNELS = {
   HAPI_GET_STATUS: 'hapi:getStatus',
   HAPI_STATUS_CHANGED: 'hapi:statusChanged',
 
+  // Hapi Runner
+  HAPI_RUNNER_START: 'hapiRunner:start',
+  HAPI_RUNNER_STOP: 'hapiRunner:stop',
+  HAPI_RUNNER_GET_STATUS: 'hapiRunner:getStatus',
+  HAPI_RUNNER_STATUS_CHANGED: 'hapiRunner:statusChanged',
+
   // Cloudflared Tunnel
   CLOUDFLARED_CHECK: 'cloudflared:check',
   CLOUDFLARED_INSTALL: 'cloudflared:install',


### PR DESCRIPTION

### 背景

目前 Hapi 已支持远程会话访问，但缺少对 `hapi runner`（远程创建新 session 能力）的统一管理。  
本 PR 将 Runner 作为 Hapi 服务的一个可选属性：用户只需开启「Enable Remote Spawn (Runner)」，无需理解 start/stop 命令细节。

### 变更内容

#### 1) 设置项
- 在 Hapi 设置中新增：
  - `Enable Remote Spawn (Runner)`
- 显示逻辑：
  - 仅在 Hapi 启用后显示
  - 位于 Cloudflared 设置上方
- 文案补充（i18n）：
  - 增加提示：`（重启服务生效）`

#### 2) 配置与持久化
- `hapiSettings` 新增 `runnerEnabled`（默认 `false`）

#### 3) 主进程能力
- 新增 `HapiRunnerManager`，统一封装 runner 启停
- Hapi 生命周期联动：
  - Hapi start/restart：按 `runnerEnabled` 决定是否启动 runner
  - Hapi stop：停止 runner
  - auto-start：按保存设置处理 runner
- 增加 Runner IPC（实现方式与 Cloudflared 风格一致）：
  - `start / stop / getStatus / statusChanged`

### 影响范围（仅限以下模块）

- `src/main/ipc/hapi.ts`
- `src/main/services/hapi/HapiRunnerManager.ts`（新增）
- `src/preload/index.ts`
- `src/renderer/components/settings/HapiSettings.tsx`
- `src/renderer/stores/settings.ts`
- `src/shared/types/ipc.ts`
- `src/shared/i18n.ts`

> **未改动其他业务模块**（如 Git、Terminal、Worktree、Claude Bridge 等），不涉及无关代码。

### 兼容性与风险说明

#### 兼容性
- 默认 `runnerEnabled=false`，**默认行为与现有版本一致**（不启用 runner 管理）。
- 仅用户明确启用 Runner 开关时，才会新增 runner 联动行为。

#### 风险点
- 本地环境缺少 `hapi` / `npx @twsxtd/hapi` 时，runner 启动可能失败（会返回错误状态，不影响主应用运行）。
- Runner 启停依赖本机 shell 环境（与现有 hapi/cloudflared 逻辑一致）。

#### 风险控制
- 不修改 Hapi 核心 server 启动参数语义
- Runner 逻辑与 Hapi/Cloudflared 解耦，问题定位和回滚更直接
- 关闭开关即可回到原行为

### 验证清单

- [x] `pnpm typecheck` 通过
- [x] Hapi 开启后显示 Runner 设置，位置在 Cloudflared 上方
- [x] Runner 开关关闭 + 重启 Hapi：runner 不运行
- [x] Runner 开关开启 + 重启 Hapi：runner 运行
- [x] 停止 Hapi：runner 同步停止
- [x] auto-start 场景下遵循 `runnerEnabled` 配置
