### PR TITLE
fix(editor): 检测二进制文件并显示不支持预览提示

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "emoji-picker-react": "^4.16.1",
     "framer-motion": "^12.23.26",
     "iconv-lite": "^0.7.1",
-    "isbinaryfile": "^6.0.0",
+    "isbinaryfile": "^5.0.7",
     "jschardet": "^3.1.4",
     "lucide-react": "^0.562.0",
     "match-sorter": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "emoji-picker-react": "^4.16.1",
     "framer-motion": "^12.23.26",
     "iconv-lite": "^0.7.1",
+    "isbinaryfile": "^6.0.0",
     "jschardet": "^3.1.4",
     "lucide-react": "^0.562.0",
     "match-sorter": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.2
       isbinaryfile:
-        specifier: ^6.0.0
-        version: 6.0.0
+        specifier: ^5.0.7
+        version: 5.0.7
       jschardet:
         specifier: ^3.1.4
         version: 3.1.4
@@ -2284,10 +2284,6 @@ packages:
   isbinaryfile@5.0.7:
     resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
     engines: {node: '>= 18.0.0'}
-
-  isbinaryfile@6.0.0:
-    resolution: {integrity: sha512-2FN2B8MAqKv6d5TaKsLvMrwMcghxwHTpcKy0L5mhNbRqjNqo2++SpCqN6eG1lCC1GmTQgvrYJYXv2+Chvyevag==}
-    engines: {node: '>= 24.0.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -5751,8 +5747,6 @@ snapshots:
   isbinaryfile@4.0.10: {}
 
   isbinaryfile@5.0.7: {}
-
-  isbinaryfile@6.0.0: {}
 
   isexe@2.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       iconv-lite:
         specifier: ^0.7.1
         version: 0.7.2
+      isbinaryfile:
+        specifier: ^6.0.0
+        version: 6.0.0
       jschardet:
         specifier: ^3.1.4
         version: 3.1.4
@@ -353,24 +356,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.3.11':
     resolution: {integrity: sha512-l4xkGa9E7Uc0/05qU2lMYfN1H+fzzkHgaJoy98wO+b/7Gl78srbCRRgwYSW+BTLixTBrM6Ede5NSBwt7rd/i6g==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.3.11':
     resolution: {integrity: sha512-vU7a8wLs5C9yJ4CB8a44r12aXYb8yYgBn+WeyzbMjaCMklzCv1oXr8x+VEyWodgJt9bDmhiaW/I0RHbn7rsNmw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.3.11':
     resolution: {integrity: sha512-/1s9V/H3cSe0r0Mv/Z8JryF5x9ywRxywomqZVLHAoa/uN0eY7F8gEngWKNS5vbbN/BsfpCG5yeBT5ENh50Frxg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.3.11':
     resolution: {integrity: sha512-PZQ6ElCOnkYapSsysiTy0+fYX+agXPlWugh6+eQ6uPKI3vKAqNp6TnMhoM3oY2NltSB89hz59o8xIfOdyhi9Iw==}
@@ -865,36 +872,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.4':
     resolution: {integrity: sha512-kGO8RPvVrcAotV4QcWh8kZuHr9bXi9a3bSZw7kFarYR0+fGliU7hd/zevhjw8fnvIKG3J9EO5G6sXNGCSNMYPQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.4':
     resolution: {integrity: sha512-KU75aooXhqGFY2W5/p8DYYHt4hrjHZod8AhcGAmhzPn/etTa+lYCDB2b1sJy3sWJ8ahFVTdy+EbqSBvMx3iFlw==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.4':
     resolution: {integrity: sha512-Qx8uNiIekVutnzbVdrgSanM+cbpDD3boB1f8vMtnuG5Zau4/bdDbXyKwIn0ToqFhIuob73bcxV9NwRm04/hzHQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.4':
     resolution: {integrity: sha512-UYBQvhYmgAv61LNUn24qGQdjtycFBKSK3EXr72DbJqX9aaLbtCOO8+1SkKhD/GNiJ97ExgcHBrukcYhVjrnogA==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.4':
     resolution: {integrity: sha512-YoRWCVgxv8akZrMhdyVi6/TyoeeMkQ0PGGOf2E4omODrvd1wxniXP+DBynKoHryStks7l+fDAMUBRzqNHrVOpg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.4':
     resolution: {integrity: sha512-iby+D/YNXWkiQNYcIhg8P5hSjzXEHaQrk2SLrWOUD7VeC4Ohu0WQvmV+HDJokZVJ2UjJ4AGXW3bx7Lls9Ln4TQ==}
@@ -965,66 +978,79 @@ packages:
     resolution: {integrity: sha512-AEXMESUDWWGqD6LwO/HkqCZgUE1VCJ1OhbvYGsfqX2Y6w5quSXuyoy/Fg3nRqiwro+cJYFxiw5v4kB2ZDLhxrw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.55.2':
     resolution: {integrity: sha512-ZV7EljjBDwBBBSv570VWj0hiNTdHt9uGznDtznBB4Caj3ch5rgD4I2K1GQrtbvJ/QiB+663lLgOdcADMNVC29Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.55.2':
     resolution: {integrity: sha512-uvjwc8NtQVPAJtq4Tt7Q49FOodjfbf6NpqXyW/rjXoV+iZ3EJAHLNAnKT5UJBc6ffQVgmXTUL2ifYiLABlGFqA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.55.2':
     resolution: {integrity: sha512-s3KoWVNnye9mm/2WpOZ3JeUiediUVw6AvY/H7jNA6qgKA2V2aM25lMkVarTDfiicn/DLq3O0a81jncXszoyCFA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.55.2':
     resolution: {integrity: sha512-gi21faacK+J8aVSyAUptML9VQN26JRxe484IbF+h3hpG+sNVoMXPduhREz2CcYr5my0NE3MjVvQ5bMKX71pfVA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.55.2':
     resolution: {integrity: sha512-qSlWiXnVaS/ceqXNfnoFZh4IiCA0EwvCivivTGbEu1qv2o+WTHpn1zNmCTAoOG5QaVr2/yhCoLScQtc/7RxshA==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.55.2':
     resolution: {integrity: sha512-rPyuLFNoF1B0+wolH277E780NUKf+KoEDb3OyoLbAO18BbeKi++YN6gC/zuJoPPDlQRL3fIxHxCxVEWiem2yXw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.55.2':
     resolution: {integrity: sha512-g+0ZLMook31iWV4PvqKU0i9E78gaZgYpSrYPed/4Bu+nGTgfOPtfs1h11tSSRPXSjC5EzLTjV/1A7L2Vr8pJoQ==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.55.2':
     resolution: {integrity: sha512-i+sGeRGsjKZcQRh3BRfpLsM3LX3bi4AoEVqmGDyc50L6KfYsN45wVCSz70iQMwPWr3E5opSiLOwsC9WB4/1pqg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.55.2':
     resolution: {integrity: sha512-C1vLcKc4MfFV6I0aWsC7B2Y9QcsiEcvKkfxprwkPfLaN8hQf0/fKHwSF2lcYzA9g4imqnhic729VB9Fo70HO3Q==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.55.2':
     resolution: {integrity: sha512-68gHUK/howpQjh7g7hlD9DvTTt4sNLp1Bb+Yzw2Ki0xvscm2cOdCLZNJNhd2jW8lsTPrHAHuF751BygifW4bkQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.55.2':
     resolution: {integrity: sha512-1e30XAuaBP1MAizaOBApsgeGZge2/Byd6wV4a8oa6jPdHELbRHBiw7wvo4dp7Ie2PE8TZT4pj9RLGZv9N4qwlw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.55.2':
     resolution: {integrity: sha512-4BJucJBGbuGnH6q7kpPqGJGzZnYrpAzRd60HQSt3OpX/6/YVgSsJnNzR8Ot74io50SeVT4CtCWe/RYIAymFPwA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.55.2':
     resolution: {integrity: sha512-cT2MmXySMo58ENv8p6/O6wI/h/gLnD3D6JoajwXFZH6X9jz4hARqUhWpGuQhOgLNXscfZYRQMJvZDtWNzMAIDw==}
@@ -1129,24 +1155,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2255,6 +2285,10 @@ packages:
     resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
     engines: {node: '>= 18.0.0'}
 
+  isbinaryfile@6.0.0:
+    resolution: {integrity: sha512-2FN2B8MAqKv6d5TaKsLvMrwMcghxwHTpcKy0L5mhNbRqjNqo2++SpCqN6eG1lCC1GmTQgvrYJYXv2+Chvyevag==}
+    engines: {node: '>= 24.0.0'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
@@ -2351,24 +2385,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -5713,6 +5751,8 @@ snapshots:
   isbinaryfile@4.0.10: {}
 
   isbinaryfile@5.0.7: {}
+
+  isbinaryfile@6.0.0: {}
 
   isexe@2.0.0: {}
 

--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -129,7 +129,13 @@ export function registerFileHandlers(): void {
 
   ipcMain.handle(IPC_CHANNELS.FILE_READ, async (_, filePath: string): Promise<FileReadResult> => {
     // First check if file is binary (only reads first 512 bytes)
-    const isBinary = await isBinaryFile(filePath);
+    let isBinary = false;
+    try {
+      isBinary = await isBinaryFile(filePath);
+    } catch {
+      // If binary detection fails, assume it's a text file and continue
+    }
+
     if (isBinary) {
       return {
         content: '',

--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -80,7 +80,7 @@ function isBinaryBuffer(buffer: Buffer, sampleSize = 8192): boolean {
     if (byte === 0) {
       nullCount++;
       // If we find more than a few null bytes, it's likely binary
-      if (nullCount > 2) {
+      if (nullCount > 5) {
         return true;
       }
     }
@@ -88,6 +88,10 @@ function isBinaryBuffer(buffer: Buffer, sampleSize = 8192): boolean {
     // Count control characters (excluding common whitespace: tab, newline, carriage return)
     if (byte < 32 && byte !== 9 && byte !== 10 && byte !== 13) {
       controlCount++;
+      // Early return if control character ratio exceeds threshold
+      if (i >= 100 && controlCount / (i + 1) > 0.1) {
+        return true;
+      }
     }
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1144,8 +1144,11 @@ export default function App() {
             }
           } else {
             try {
-              const { content } = await window.electronAPI.file.read(tab.path);
-              useEditorStore.getState().updateFileContent(tab.path, content, false);
+              const { content, isBinary } = await window.electronAPI.file.read(tab.path);
+              // Skip content update for binary files (they have no text content)
+              if (!isBinary) {
+                useEditorStore.getState().updateFileContent(tab.path, content, false);
+              }
             } catch (err) {
               const message = err instanceof Error ? err.message : String(err);
               toastManager.add({

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -1,5 +1,5 @@
 import Editor, { type OnMount } from '@monaco-editor/react';
-import { ChevronRight, Eye, EyeOff, FileCode, Maximize2, MessageSquare } from 'lucide-react';
+import { ChevronRight, Eye, EyeOff, FileCode, FileX, Maximize2, MessageSquare } from 'lucide-react';
 import type * as monaco from 'monaco-editor';
 import {
   forwardRef,
@@ -942,7 +942,19 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
                       : 0,
               }}
             >
-              {isImage ? (
+              {activeTab.isUnsupported ? (
+                <Empty className="flex-1">
+                  <EmptyMedia variant="icon">
+                    <FileX className="h-4.5 w-4.5" />
+                  </EmptyMedia>
+                  <EmptyHeader>
+                    <EmptyTitle>{t('No preview available')}</EmptyTitle>
+                    <EmptyDescription>
+                      {t('This file type is not supported for preview')}
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
+              ) : isImage ? (
                 <ImagePreview path={activeTab.path} />
               ) : isPdf ? (
                 <PdfPreview path={activeTab.path} />

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -259,7 +259,10 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
       if (!changedTab) return;
 
       try {
-        const { content: latestContent } = await window.electronAPI.file.read(event.path);
+        const { content: latestContent, isBinary } = await window.electronAPI.file.read(event.path);
+        // Skip content update for binary files (they have no text content)
+        if (isBinary) return;
+
         onContentChange(event.path, latestContent, changedTab.isDirty);
 
         if (event.path === activeTabPath && editorRef.current) {

--- a/src/renderer/components/files/fileIcons.tsx
+++ b/src/renderer/components/files/fileIcons.tsx
@@ -145,3 +145,15 @@ export function isPdfFile(path: string | null | undefined): boolean {
   const ext = path.split('.').pop()?.toLowerCase() || '';
   return ext === 'pdf';
 }
+
+/**
+ * Check if a binary file is unsupported for preview.
+ * Images and PDFs are binary but have dedicated preview components.
+ */
+export function isUnsupportedBinaryFile(
+  path: string | null | undefined,
+  isBinary: boolean | undefined
+): boolean {
+  if (!isBinary) return false;
+  return !isImageFile(path) && !isPdfFile(path);
+}

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -25,9 +25,9 @@ export function useEditor() {
 
   const loadFile = useMutation({
     mutationFn: async (path: string) => {
-      const { content, encoding } = await window.electronAPI.file.read(path);
-      openFile({ path, content, encoding, isDirty: false });
-      return { content, encoding };
+      const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
+      openFile({ path, content, encoding, isDirty: false, isUnsupported: isBinary });
+      return { content, encoding, isBinary };
     },
   });
 
@@ -60,8 +60,8 @@ export function useEditor() {
         setActiveFile(path);
       } else {
         try {
-          const { content, encoding } = await window.electronAPI.file.read(path);
-          openFile({ path, content, encoding, isDirty: false });
+          const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
+          openFile({ path, content, encoding, isDirty: false, isUnsupported: isBinary });
         } catch {
           return;
         }

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
-import { isImageFile, isPdfFile } from '@/components/files/fileIcons';
+import { isUnsupportedBinaryFile } from '@/components/files/fileIcons';
 import { useEditorStore } from '@/stores/editor';
 
 export function useEditor() {
@@ -27,9 +27,13 @@ export function useEditor() {
   const loadFile = useMutation({
     mutationFn: async (path: string) => {
       const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
-      // Binary files like images and PDFs have dedicated preview components
-      const isUnsupported = isBinary && !isImageFile(path) && !isPdfFile(path);
-      openFile({ path, content, encoding, isDirty: false, isUnsupported });
+      openFile({
+        path,
+        content,
+        encoding,
+        isDirty: false,
+        isUnsupported: isUnsupportedBinaryFile(path, isBinary),
+      });
       return { content, encoding, isBinary };
     },
   });
@@ -64,9 +68,13 @@ export function useEditor() {
       } else {
         try {
           const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
-          // Binary files like images and PDFs have dedicated preview components
-          const isUnsupported = isBinary && !isImageFile(path) && !isPdfFile(path);
-          openFile({ path, content, encoding, isDirty: false, isUnsupported });
+          openFile({
+            path,
+            content,
+            encoding,
+            isDirty: false,
+            isUnsupported: isUnsupportedBinaryFile(path, isBinary),
+          });
         } catch {
           return;
         }

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
+import { isImageFile, isPdfFile } from '@/components/files/fileIcons';
 import { useEditorStore } from '@/stores/editor';
 
 export function useEditor() {
@@ -26,7 +27,9 @@ export function useEditor() {
   const loadFile = useMutation({
     mutationFn: async (path: string) => {
       const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
-      openFile({ path, content, encoding, isDirty: false, isUnsupported: isBinary });
+      // Binary files like images and PDFs have dedicated preview components
+      const isUnsupported = isBinary && !isImageFile(path) && !isPdfFile(path);
+      openFile({ path, content, encoding, isDirty: false, isUnsupported });
       return { content, encoding, isBinary };
     },
   });
@@ -61,7 +64,9 @@ export function useEditor() {
       } else {
         try {
           const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
-          openFile({ path, content, encoding, isDirty: false, isUnsupported: isBinary });
+          // Binary files like images and PDFs have dedicated preview components
+          const isUnsupported = isBinary && !isImageFile(path) && !isPdfFile(path);
+          openFile({ path, content, encoding, isDirty: false, isUnsupported });
         } catch {
           return;
         }

--- a/src/renderer/stores/editor.ts
+++ b/src/renderer/stores/editor.ts
@@ -7,6 +7,7 @@ export interface EditorTab {
   isDirty: boolean;
   encoding?: string;
   viewState?: unknown;
+  isUnsupported?: boolean;
 }
 
 export interface PendingCursor {

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -963,6 +963,7 @@ export const zhTranslations: Record<string, string> = {
   'No matches found': '未找到匹配',
   'Type to search in files': '输入以搜索文件内容',
   'No preview available': '无法预览',
+  'This file type is not supported for preview': '此文件类型暂不支持预览',
   'Select a result to preview': '选择结果以预览',
   'Unable to load file': '无法加载文件',
   'Use .gitignore': '使用 .gitignore',

--- a/src/shared/types/file.ts
+++ b/src/shared/types/file.ts
@@ -17,4 +17,5 @@ export interface FileReadResult {
   encoding: string;
   detectedEncoding: string;
   confidence: number;
+  isBinary?: boolean;
 }


### PR DESCRIPTION
## Summary

- 修复打开二进制文件（视频、音频、Word、Excel 等）时编辑器卡顿的问题
- 在读取文件时检测二进制内容，对二进制文件显示"无法预览"提示
- 图片和 PDF 文件仍可正常预览

## Changes

- 在 main 进程的 `FILE_READ` handler 中添加 `isBinaryBuffer()` 函数检测二进制文件
- 对于二进制文件，不读取内容，返回 `isBinary: true` 标记
- 前端根据 `isBinary` 标记显示"无法预览"提示

## Test plan

- [ ] 打开文本文件（js, ts, json 等）正常编辑
- [ ] 打开图片文件正常预览
- [ ] 打开 PDF 文件正常预览
- [ ] 打开二进制文件（视频、Word、Excel 等）显示"无法预览"提示，不卡顿

🤖 Generated with [Claude Code](https://claude.ai/code)