### PR TITLE
fix(chat): 修复 Cursor CLI 会话生成的历史记录都是 New Agent 的问题

### DIFF
--- a/src/renderer/components/chat/SessionBar.tsx
+++ b/src/renderer/components/chat/SessionBar.tsx
@@ -284,7 +284,7 @@ function SessionTab({
               className="w-20 bg-transparent outline-none border-b border-current"
             />
           ) : (
-            <span>{session.name}</span>
+            <span>{session.terminalTitle || session.name}</span>
           )}
           <button
             type="button"
@@ -358,7 +358,7 @@ function SessionTab({
             className="relative z-10 w-20 bg-transparent outline-none border-b border-current"
           />
         ) : (
-          <span className="relative z-10">{session.name}</span>
+          <span className="relative z-10">{session.terminalTitle || session.name}</span>
         )}
         <button
           type="button"
@@ -684,7 +684,7 @@ export function SessionBar({
 
   const handleStartEdit = useCallback((session: Session) => {
     setEditingId(session.id);
-    setEditingName(session.name);
+    setEditingName(session.terminalTitle || session.name);
     setTimeout(() => inputRef.current?.select(), 0);
   }, []);
 

--- a/src/renderer/components/layout/RunningProjectsPopover.tsx
+++ b/src/renderer/components/layout/RunningProjectsPopover.tsx
@@ -353,12 +353,9 @@ export function RunningProjectsPopover({
                         >
                           <Bot className="h-3.5 w-3.5 shrink-0" />
                           <span className="min-w-0 flex-1 truncate text-left">
-                            {item.session.name || item.session.agentId}
-                            {item.session.terminalTitle && (
-                              <span className="ml-1 text-muted-foreground/70">
-                                ({item.session.terminalTitle})
-                              </span>
-                            )}
+                            {item.session.terminalTitle ||
+                              item.session.name ||
+                              item.session.agentId}
                           </span>
                         </button>
                       );


### PR DESCRIPTION
- 仅对 Cursor agent 应用终端标题（OSC）与首行输入作为会话名，不影响其他 agent
- 展示优先级：用户重命名 > 终端标题 > 首行内容 > 默认 agent 名
- 用户手动重命名时清除 terminalTitle；SessionBar / RunningProjectsPopover 展示 terminalTitle || name
- useXterm 的 onCustomKey 增加 getCurrentLine，首行作为会话名时截断至 36 字符

之前 cursor-cli 有个问题，所有的 cursor 对话在历史记录中的 ```/resume``` 中的记录都是 New Agent
本次提交主要修复了这个问题
<img width="3190" height="1566" alt="999a22b5cc56e555487a4e55498dc360" src="https://github.com/user-attachments/assets/3a5eecbc-0c37-4768-b509-2beac4d9f999" />
