### PR TITLE
fix(git): WSL 仓库 Git 操作全链路统一走 WSL Git

### DIFF
--- a/src/main/services/git/encoding.ts
+++ b/src/main/services/git/encoding.ts
@@ -1,9 +1,6 @@
-import { spawn } from 'node:child_process';
 import iconv from 'iconv-lite';
 import jschardet from 'jschardet';
-import { getProxyEnvVars } from '../proxy/ProxyConfig';
-import { getEnhancedPath } from '../terminal/PtyManager';
-import { withSafeDirectoryEnv } from './safeDirectory';
+import { spawnGit } from './runtime';
 
 export function decodeBuffer(buffer: Buffer): string {
   if (buffer.length === 0) return '';
@@ -16,17 +13,9 @@ export function gitShowBuffer(workdir: string, ref: string): Promise<Buffer> {
   return new Promise((resolve) => {
     const chunks: Buffer[] = [];
 
-    const proc = spawn('git', ['show', ref], {
+    const proc = spawnGit(workdir, ['show', ref], {
       cwd: workdir,
       windowsHide: true,
-      env: withSafeDirectoryEnv(
-        {
-          ...process.env,
-          ...getProxyEnvVars(),
-          PATH: getEnhancedPath(),
-        },
-        workdir
-      ),
     });
 
     proc.stdout.on('data', (chunk: Buffer) => {

--- a/src/main/services/git/runtime.ts
+++ b/src/main/services/git/runtime.ts
@@ -1,0 +1,152 @@
+import {
+  type ChildProcessWithoutNullStreams,
+  type SpawnOptionsWithoutStdio,
+  spawn,
+} from 'node:child_process';
+import simpleGit, { type SimpleGit, type SimpleGitOptions } from 'simple-git';
+import { getProxyEnvVars } from '../proxy/ProxyConfig';
+import { getEnhancedPath } from '../terminal/PtyManager';
+import { withSafeDirectoryEnv } from './safeDirectory';
+
+const WSL_UNC_PREFIXES = ['//wsl.localhost/', '//wsl$/'];
+
+type WslPathInfo = {
+  host: 'wsl.localhost' | 'wsl$';
+  distro: string;
+  linuxPath: string;
+};
+
+function normalizePath(inputPath: string): string {
+  return inputPath.replace(/\\/g, '/').trim();
+}
+
+function parseWslUncPath(inputPath: string): WslPathInfo | null {
+  if (process.platform !== 'win32') {
+    return null;
+  }
+
+  const normalized = normalizePath(inputPath);
+  const lower = normalized.toLowerCase();
+
+  let prefix: string | null = null;
+  let host: WslPathInfo['host'] | null = null;
+  for (const candidate of WSL_UNC_PREFIXES) {
+    if (lower.startsWith(candidate)) {
+      prefix = candidate;
+      host = candidate === '//wsl$/' ? 'wsl$' : 'wsl.localhost';
+      break;
+    }
+  }
+
+  if (!prefix || !host) {
+    return null;
+  }
+
+  const rest = normalized.slice(prefix.length);
+  const segments = rest.split('/').filter((segment) => segment.length > 0);
+  if (segments.length === 0) {
+    return null;
+  }
+
+  const [distro, ...pathSegments] = segments;
+  return {
+    host,
+    distro,
+    linuxPath: pathSegments.length > 0 ? `/${pathSegments.join('/')}` : '/',
+  };
+}
+
+function toWindowsUncPath(host: WslPathInfo['host'], distro: string, linuxPath: string): string {
+  const normalizedLinuxPath = normalizePath(linuxPath).replace(/^\/+/, '').replace(/\/+$/, '');
+  if (!normalizedLinuxPath) {
+    return `\\\\${host}\\${distro}`;
+  }
+  return `\\\\${host}\\${distro}\\${normalizedLinuxPath.replace(/\//g, '\\')}`;
+}
+
+export function isWslGitRepository(workdir: string): boolean {
+  return parseWslUncPath(workdir) !== null;
+}
+
+export function toGitPath(workdir: string, inputPath: string): string {
+  const repoInfo = parseWslUncPath(workdir);
+  if (!repoInfo) {
+    return inputPath;
+  }
+
+  const inputInfo = parseWslUncPath(inputPath);
+  if (!inputInfo) {
+    return inputPath;
+  }
+
+  if (inputInfo.distro.toLowerCase() !== repoInfo.distro.toLowerCase()) {
+    return inputPath;
+  }
+
+  return inputInfo.linuxPath;
+}
+
+export function fromGitPath(workdir: string, inputPath: string): string {
+  const repoInfo = parseWslUncPath(workdir);
+  if (!repoInfo) {
+    return inputPath;
+  }
+
+  if (!inputPath.startsWith('/')) {
+    return inputPath;
+  }
+
+  return toWindowsUncPath(repoInfo.host, repoInfo.distro, inputPath);
+}
+
+export function normalizeGitRelativePath(inputPath: string): string {
+  return inputPath.replace(/\\/g, '/');
+}
+
+export function createGitEnv(workdir: string): NodeJS.ProcessEnv {
+  return withSafeDirectoryEnv(
+    {
+      ...process.env,
+      ...getProxyEnvVars(),
+      PATH: getEnhancedPath(),
+    },
+    workdir
+  );
+}
+
+export function createSimpleGit(
+  workdir: string,
+  options: Partial<SimpleGitOptions> = {}
+): SimpleGit {
+  const resolvedOptions: Partial<SimpleGitOptions> = {
+    ...options,
+    baseDir: options.baseDir ?? workdir,
+  };
+  const baseDir = typeof resolvedOptions.baseDir === 'string' ? resolvedOptions.baseDir : workdir;
+
+  if (isWslGitRepository(baseDir) && !resolvedOptions.binary) {
+    resolvedOptions.binary = ['wsl.exe', 'git'];
+  }
+
+  return simpleGit(resolvedOptions).env(createGitEnv(baseDir));
+}
+
+export function spawnGit(
+  workdir: string,
+  args: string[],
+  options: SpawnOptionsWithoutStdio = {}
+): ChildProcessWithoutNullStreams {
+  const cwd = typeof options.cwd === 'string' ? options.cwd : workdir;
+  const env = options.env ?? createGitEnv(cwd);
+  const gitArgs = args.map((arg) => toGitPath(cwd, arg));
+
+  if (isWslGitRepository(cwd)) {
+    return spawn('wsl.exe', ['git', ...gitArgs], {
+      ...options,
+      cwd,
+      env,
+    }) as ChildProcessWithoutNullStreams;
+  }
+
+  return spawn('git', gitArgs, { ...options, cwd, env }) as ChildProcessWithoutNullStreams;
+}


### PR DESCRIPTION
## 背景
在 Windows 环境下操作 WSL UNC 仓库（如 `\\wsl.localhost\...` / `\\wsl$\...`）时，部分 Git 命令链路仍使用 Windows Git 或直接传 UNC 参数给 WSL Git，导致 `worktree` 等场景出现路径不兼容和执行失败。

## 目标
对 **WSL 中的 Git 仓库**，全链路使用 **WSL Git**（包括 `git worktree`、`git status`、`git diff`、`git log`、`git show`、`check-ignore` 等）。

## 改动内容
- 新增统一 Git 运行时：`src/main/services/git/runtime.ts`
- 在 `GitService` 中统一接入运行时（status/diff/log/clone 等链路）：`src/main/services/git/GitService.ts`
- 在 `WorktreeService` 中统一处理 WSL 路径入参/回参转换：`src/main/services/git/WorktreeService.ts`
- 在编码读取链路改用统一 spawn 入口：`src/main/services/git/encoding.ts`
- 在 code-review 的 Git 调用链路改用统一入口：`src/main/services/ai/code-review.ts`
- 在文件 IPC 的 gitignore 检查链路接入统一运行时：`src/main/ipc/files.ts`

## 最小化 / 非侵入说明
- 仅修改 6 个后端文件，无 UI/交互改动。
- 仅在检测到 WSL UNC 仓库时走 `wsl.exe git`，其它仓库保持原有行为。
- 未修改 IPC 协议、未改业务流程分支、未引入特例化 UI 逻辑。
- 改动集中在 Git 执行入口与路径转换层，尽量减少扩散面。

## 对 WSL 以外行为的影响
- 无行为变化。
- 非 WSL 仓库继续使用原生 `git` 执行路径。

## 验证
- `pnpm typecheck` 通过。
- `biome check --formatter-enabled=false`（针对本 PR 6 个文件）通过。
- WSL 临时仓库烟测结果：
  - `wsl git worktree remove --force <UNC路径>` 退出码 `128`（失败）
  - `wsl git worktree remove --force <Linux路径>` 退出码 `0`（成功）
  - 说明本 PR 的 UNC->Linux 路径转换是必要且有效的。