### PR TITLE
fix(sidebar): 修复项目右键菜单与「移动到分组」子菜单贴近视窗边缘时被裁切

### DIFF
--- a/src/renderer/components/group/MoveToGroupSubmenu.tsx
+++ b/src/renderer/components/group/MoveToGroupSubmenu.tsx
@@ -1,6 +1,8 @@
 import { Check, ChevronRight, FolderSymlink } from 'lucide-react';
+import { useCallback, useRef, useState } from 'react';
 import type { RepositoryGroup } from '@/App/constants';
 import { useI18n } from '@/i18n';
+import { cn } from '@/lib/utils';
 
 interface MoveToGroupSubmenuProps {
   groups: RepositoryGroup[];
@@ -16,11 +18,21 @@ export function MoveToGroupSubmenu({
   onClose,
 }: MoveToGroupSubmenuProps) {
   const { t } = useI18n();
+  const submenuRef = useRef<HTMLDivElement>(null);
+  const [alignBottom, setAlignBottom] = useState(false);
+
+  const handleMouseEnter = useCallback(() => {
+    if (submenuRef.current) {
+      const rect = submenuRef.current.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      setAlignBottom(rect.bottom > viewportHeight - 8);
+    }
+  }, []);
 
   if (groups.length === 0) return null;
 
   return (
-    <div className="relative group/submenu">
+    <div className="relative group/submenu" onMouseEnter={handleMouseEnter}>
       <button
         type="button"
         className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"
@@ -29,7 +41,13 @@ export function MoveToGroupSubmenu({
         {t('Move to Group')}
         <ChevronRight className="ml-auto h-3.5 w-3.5" />
       </button>
-      <div className="absolute left-full top-0 z-50 min-w-36 rounded-lg border bg-popover p-1 shadow-lg opacity-0 invisible group-hover/submenu:opacity-100 group-hover/submenu:visible transition-all">
+      <div
+        ref={submenuRef}
+        className={cn(
+          'absolute left-full z-50 min-w-36 rounded-lg border bg-popover p-1 shadow-lg opacity-0 invisible group-hover/submenu:opacity-100 group-hover/submenu:visible transition-all',
+          alignBottom ? 'bottom-0' : 'top-0'
+        )}
+      >
         <button
           type="button"
           className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-accent"

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -233,6 +233,7 @@ export function TreeSidebar({
   const [repoMenuPosition, setRepoMenuPosition] = useState({ x: 0, y: 0 });
   const [repoMenuTarget, setRepoMenuTarget] = useState<Repository | null>(null);
   const [repoToRemove, setRepoToRemove] = useState<Repository | null>(null);
+  const repoMenuRef = useRef<HTMLDivElement>(null);
 
   // Repository settings dialog
   const [repoSettingsOpen, setRepoSettingsOpen] = useState(false);
@@ -514,6 +515,30 @@ export function TreeSidebar({
     setRepoMenuTarget(repo);
     setRepoMenuOpen(true);
   };
+
+  // Adjust repo menu position if it overflows viewport
+  useEffect(() => {
+    if (repoMenuOpen && repoMenuRef.current) {
+      const menu = repoMenuRef.current;
+      const rect = menu.getBoundingClientRect();
+      const viewportHeight = window.innerHeight;
+      const viewportWidth = window.innerWidth;
+
+      let { x, y } = repoMenuPosition;
+
+      if (y + rect.height > viewportHeight - 8) {
+        y = Math.max(8, viewportHeight - rect.height - 8);
+      }
+
+      if (x + rect.width > viewportWidth - 8) {
+        x = Math.max(8, viewportWidth - rect.width - 8);
+      }
+
+      if (x !== repoMenuPosition.x || y !== repoMenuPosition.y) {
+        setRepoMenuPosition({ x, y });
+      }
+    }
+  }, [repoMenuOpen, repoMenuPosition]);
 
   const handleRemoveRepoClick = () => {
     if (repoMenuTarget) {
@@ -1148,6 +1173,7 @@ export function TreeSidebar({
             role="presentation"
           />
           <div
+            ref={repoMenuRef}
             className="fixed z-50 min-w-32 rounded-lg border bg-popover p-1 shadow-lg"
             style={{ left: repoMenuPosition.x, top: repoMenuPosition.y }}
           >


### PR DESCRIPTION
- 项目右键菜单：打开时根据视口检测并调整 x/y，避免超出右下边界
- 移动到分组子菜单：根据悬停位置在 top-0 / bottom-0 间切换，避免超出底部