### PR TITLE
🐛 fix(file-tree): 修复展开状态恢复时的 stale ref 导致状态丢失

### DIFF
--- a/src/renderer/hooks/useFileTree.ts
+++ b/src/renderer/hooks/useFileTree.ts
@@ -118,8 +118,10 @@ export function useFileTree({ rootPath, enabled = true, isActive = true }: UseFi
     if (childrenRestoredRef.current) return;
     childrenRestoredRef.current = true;
 
-    // Use the already-loaded ref instead of re-reading localStorage
-    const restored = expandedPathsRef.current;
+    // Read directly from localStorage to avoid stale ref when this effect fires
+    // in the same flush as the rootPath effect (expandedPathsRef may still hold
+    // the previous rootPath's paths before setExpandedPaths state update is applied)
+    const restored = loadFileTreeExpandedPaths(rootPath);
     if (restored.size === 0) return;
 
     // Sort shallow-first so parent nodes are populated before their children


### PR DESCRIPTION
## 问题描述

PR #324 修复了切换 Worktree 时展开状态丢失的问题，但引入了新的 bug：**来回切换仓库后，展开状态仍然会丢失**。

## 根本原因

在 `rootFiles` effect 中读取 `expandedPathsRef.current` 时存在 stale ref 问题：

当 `rootPath` 从 B 切回 A，两个 effect 在同一 flush 内触发：

1. **rootPath effect**（第55行）调用 `setExpandedPaths(loadFileTreeExpandedPaths('/A'))`
   - 只是**调度**状态更新，未立即生效
2. **rootFiles effect**（第99行）读取 `expandedPathsRef.current`
   - 此时 `expandedPathsRef` 仍持有 **B 的展开路径**（stale data）
3. 尝试在 A 的树中恢复 B 的路径 → 全部失败
4. 设置 `childrenRestoredRef.current = true`，阻止后续真正的恢复

## 修复方案

在 rootFiles effect 的 restore 阶段，**直接从 localStorage 读取**而非依赖 stale ref：

```typescript
// 改为：
const restored = loadFileTreeExpandedPaths(rootPath); // rootPath 已是新值
```

这样无论两个 effect 以什么顺序执行，restore 逻辑总能读到当前 `rootPath` 对应的正确展开状态。

## 验证方法

1. 打开仓库 A，展开若干目录
2. 切换到仓库 B，再展开若干目录
3. **切回 A** → 原来的展开状态恢复 ✅
4. **再切回 B** → 上次的展开状态也恢复 ✅
5. 多次反复切换 → 展开状态始终正确保留 ✅

## 改动范围

仅修改 `src/renderer/hooks/useFileTree.ts` 第122-124行，改进注释并修改一行代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)