### PR TITLE
fix(chat): 修复增强输入在 Quick Terminal 与新建项对话框中的焦点让渡与恢复

### DIFF
--- a/src/renderer/components/chat/QuickTerminalModal.tsx
+++ b/src/renderer/components/chat/QuickTerminalModal.tsx
@@ -188,6 +188,7 @@ export function QuickTerminalModal({
     // biome-ignore lint/a11y/useKeyWithClickEvents: ESC 键已在 useEffect 中处理
     <div
       onClick={handleBackdropClick}
+      data-quick-terminal={open ? 'true' : 'false'}
       className={cn(
         'fixed inset-0 z-50 transition-all',
         // 打开时显示半透明背景

--- a/src/renderer/lib/focusLock.ts
+++ b/src/renderer/lib/focusLock.ts
@@ -1,0 +1,101 @@
+export type SessionId = string;
+
+type PauseToken = symbol;
+const ENHANCED_INPUT_SELECTOR = '[data-enhanced-input-session-id]';
+
+interface FocusLockState {
+  locked: boolean;
+  pauses: Set<PauseToken>;
+}
+
+const focusLockStates = new Map<SessionId, FocusLockState>();
+
+function getOrCreateFocusLockState(sessionId: SessionId): FocusLockState {
+  const existing = focusLockStates.get(sessionId);
+  if (existing) return existing;
+
+  const created: FocusLockState = {
+    locked: false,
+    pauses: new Set<PauseToken>(),
+  };
+  focusLockStates.set(sessionId, created);
+  return created;
+}
+
+function cleanupFocusLockState(sessionId: SessionId): void {
+  const state = focusLockStates.get(sessionId);
+  if (!state) return;
+  if (state.locked || state.pauses.size > 0) return;
+  focusLockStates.delete(sessionId);
+}
+
+export function lockFocus(sessionId: SessionId): void {
+  getOrCreateFocusLockState(sessionId).locked = true;
+}
+
+export function unlockFocus(sessionId: SessionId): void {
+  const state = getOrCreateFocusLockState(sessionId);
+  state.locked = false;
+  state.pauses.clear();
+  cleanupFocusLockState(sessionId);
+}
+
+export function isFocusLocked(sessionId: SessionId): boolean {
+  const state = focusLockStates.get(sessionId);
+  if (!state) return false;
+  return state.locked && state.pauses.size === 0;
+}
+
+export function pauseFocusLock(sessionId: SessionId): () => void {
+  const state = getOrCreateFocusLockState(sessionId);
+  const token: PauseToken = Symbol('focus-pause');
+  let released = false;
+
+  state.pauses.add(token);
+
+  return () => {
+    if (released) return;
+    released = true;
+
+    const currentState = focusLockStates.get(sessionId);
+    if (!currentState) return;
+
+    currentState.pauses.delete(token);
+    cleanupFocusLockState(sessionId);
+  };
+}
+
+export async function withFocusPause<T>(
+  sessionId: SessionId,
+  fn: () => Promise<T> | T
+): Promise<T> {
+  const release = pauseFocusLock(sessionId);
+  try {
+    return await fn();
+  } finally {
+    release();
+  }
+}
+
+function findEnhancedInputTarget(sessionId: SessionId): HTMLTextAreaElement | undefined {
+  return Array.from(document.querySelectorAll<HTMLTextAreaElement>(ENHANCED_INPUT_SELECTOR)).find(
+    (node) => node.dataset.enhancedInputSessionId === sessionId
+  );
+}
+
+export function restoreFocus(sessionId: SessionId): boolean {
+  const target = findEnhancedInputTarget(sessionId);
+
+  if (!target) return false;
+
+  requestAnimationFrame(() => {
+    target.focus();
+  });
+
+  return true;
+}
+
+export function restoreFocusIfLocked(sessionId: SessionId): boolean {
+  if (!isFocusLocked(sessionId)) return false;
+  return restoreFocus(sessionId);
+}


### PR DESCRIPTION
## 变更内容

本 PR 修复增强输入在以下场景中的焦点问题：

- 打开 Quick Terminal 时，增强输入应让渡焦点
- 关闭 Quick Terminal 后，焦点应恢复到增强输入
- 打开“新建文件 / 新建文件夹”对话框时，焦点应让渡给对话框输入框
- 关闭“新建文件 / 新建文件夹”对话框后，焦点应恢复到增强输入

## 实现说明

- 新增 `src/renderer/lib/focusLock.ts`
  - 提供 `lockFocus` / `unlockFocus` / `pauseFocusLock`
  - 提供 `restoreFocus` / `restoreFocusIfLocked`
- 调整 `EnhancedInput` 的 blur 处理时序
  - 增加 overlay 检测
  - 避免弹窗打开过程中抢回焦点
- 调整 `AgentPanel` 中 Quick Terminal 的焦点让渡/恢复逻辑
  - 打开前先 pause
  - 关闭后延迟恢复，避免恢复早于 pause 清理
- 调整 `FileSidebar` 新建项对话框的焦点让渡/恢复逻辑
  - 打开时暂停当前增强输入焦点锁
  - 关闭后恢复到原增强输入

## 影响文件

- `src/renderer/lib/focusLock.ts`
- `src/renderer/components/chat/EnhancedInput.tsx`
- `src/renderer/components/chat/AgentPanel.tsx`
- `src/renderer/components/chat/QuickTerminalModal.tsx`
- `src/renderer/components/files/FileSidebar.tsx`

## 手测建议

- 打开增强输入后，点击 Quick Terminal，焦点应进入终端
- 关闭 Quick Terminal，焦点应回到增强输入
- 打开增强输入后，新建文件/文件夹，焦点应进入对话框输入框
- 关闭或确认新建项对话框，焦点应回到增强输入
