### PR TITLE
feat(chat): EnhancedInput 支持 Claude / 斜杠命令补全（commands/skills + 自动学习）

### DIFF
--- a/src/main/ipc/claudeCompletions.ts
+++ b/src/main/ipc/claudeCompletions.ts
@@ -1,0 +1,41 @@
+import { type ClaudeSlashCompletionsSnapshot, IPC_CHANNELS } from '@shared/types';
+import { BrowserWindow, ipcMain } from 'electron';
+import {
+  getClaudeSlashCompletionsSnapshot,
+  learnClaudeSlashCompletion,
+  refreshClaudeSlashCompletions,
+  startClaudeSlashCompletionsWatcher,
+  stopClaudeSlashCompletionsWatcher,
+} from '../services/claude/ClaudeCompletionsManager';
+
+function broadcast(snapshot: ClaudeSlashCompletionsSnapshot): void {
+  for (const win of BrowserWindow.getAllWindows()) {
+    if (win.isDestroyed()) continue;
+    win.webContents.send(IPC_CHANNELS.CLAUDE_COMPLETIONS_UPDATED, snapshot);
+  }
+}
+
+export function registerClaudeCompletionsHandlers(): void {
+  // Start watcher: when ~/.claude/commands or ~/.claude/skills changes, refresh completion items automatically.
+  startClaudeSlashCompletionsWatcher((next) => {
+    broadcast(next);
+  }).catch((err) => {
+    console.warn('[ClaudeCompletions] watcher 启动失败：', err);
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CLAUDE_COMPLETIONS_GET, () => {
+    return getClaudeSlashCompletionsSnapshot();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CLAUDE_COMPLETIONS_REFRESH, () => {
+    return refreshClaudeSlashCompletions();
+  });
+
+  ipcMain.handle(IPC_CHANNELS.CLAUDE_COMPLETIONS_LEARN, (_event, label: string) => {
+    return learnClaudeSlashCompletion(label);
+  });
+}
+
+export async function stopClaudeCompletionsWatchers(): Promise<void> {
+  await stopClaudeSlashCompletionsWatcher();
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -4,6 +4,10 @@ import { autoUpdaterService } from '../services/updater/AutoUpdater';
 import { webInspectorServer } from '../services/webInspector';
 import { registerAgentHandlers } from './agent';
 import { registerAppHandlers } from './app';
+import {
+  registerClaudeCompletionsHandlers,
+  stopClaudeCompletionsWatchers,
+} from './claudeCompletions';
 import { registerClaudeConfigHandlers } from './claudeConfig';
 import { registerClaudeProviderHandlers } from './claudeProvider';
 import { registerCliHandlers } from './cli';
@@ -16,12 +20,7 @@ import {
   stopAllFileWatchersSync,
 } from './files';
 import { clearAllGitServices, registerGitHandlers } from './git';
-import {
-  autoStartHapi,
-  cleanupHapi,
-  cleanupHapiSync,
-  registerHapiHandlers,
-} from './hapi';
+import { autoStartHapi, cleanupHapi, cleanupHapiSync, registerHapiHandlers } from './hapi';
 
 export { autoStartHapi };
 
@@ -60,6 +59,7 @@ export function registerIpcHandlers(): void {
   registerHapiHandlers();
   registerClaudeProviderHandlers();
   registerClaudeConfigHandlers();
+  registerClaudeCompletionsHandlers();
   registerWebInspectorHandlers();
   registerTempWorkspaceHandlers();
   registerTmuxHandlers();
@@ -106,6 +106,21 @@ export async function cleanupAllResources(): Promise<void> {
     ]);
   } catch (err) {
     console.warn('File watcher cleanup warning:', err);
+  }
+
+  // Stop Claude completions watcher (best-effort)
+  try {
+    await Promise.race([
+      stopClaudeCompletionsWatchers(),
+      new Promise((_, reject) =>
+        setTimeout(
+          () => reject(new Error('Claude completions watcher cleanup timeout')),
+          CLEANUP_TIMEOUT
+        )
+      ),
+    ]);
+  } catch (err) {
+    console.warn('Claude completions watcher cleanup warning:', err);
   }
 
   // Clear service caches (sync, fast)

--- a/src/main/services/claude/ClaudeCompletionsManager.ts
+++ b/src/main/services/claude/ClaudeCompletionsManager.ts
@@ -1,0 +1,480 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { type AsyncSubscription, subscribe } from '@parcel/watcher';
+import type { ClaudeSlashCompletionItem, ClaudeSlashCompletionsSnapshot } from '@shared/types';
+
+function getClaudeConfigDir(): string {
+  if (process.env.CLAUDE_CONFIG_DIR) {
+    return process.env.CLAUDE_CONFIG_DIR;
+  }
+  return path.join(os.homedir(), '.claude');
+}
+
+function getPrimaryClaudeConfigDir(): string {
+  return getClaudeConfigDir();
+}
+
+type LearnedSlashCacheV1 = {
+  version: 1;
+  items: Record<string, { count: number; lastUsedAt: number }>;
+};
+
+function getClaudeConfigDirs(): string[] {
+  const homeDir = path.join(os.homedir(), '.claude');
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+
+  const candidates = [homeDir];
+  if (envDir && envDir.trim()) {
+    candidates.push(envDir);
+  }
+
+  const normalized = candidates.map((d) => path.resolve(d));
+  const unique: string[] = [];
+  for (const dir of normalized) {
+    if (!unique.includes(dir)) unique.push(dir);
+  }
+  return unique;
+}
+
+function getClaudeCommandsDirs(): string[] {
+  return getClaudeConfigDirs().map((d) => path.join(d, 'commands'));
+}
+
+function getClaudeSkillsDirs(): string[] {
+  return getClaudeConfigDirs().map((d) => path.join(d, 'skills'));
+}
+
+function getLearnedCacheFilePath(): string {
+  // The learned cache follows CLAUDE_CONFIG_DIR (if set); otherwise it defaults to ~/.claude.
+  return path.join(getPrimaryClaudeConfigDir(), 'cache', 'ensoai-slash-learned.json');
+}
+
+let snapshot: ClaudeSlashCompletionsSnapshot = { items: [], updatedAt: 0 };
+let subscriptions: AsyncSubscription[] = [];
+let debounceTimer: NodeJS.Timeout | null = null;
+let maxWaitTimer: NodeJS.Timeout | null = null;
+let watchersRetryTimer: NodeJS.Timeout | null = null;
+let watchersRetryInProgress = false;
+let isStarted = false;
+let starting: Promise<void> | null = null;
+let onUpdate: ((next: ClaudeSlashCompletionsSnapshot) => void) | null = null;
+
+function cleanupTimers(): void {
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
+  if (maxWaitTimer) {
+    clearTimeout(maxWaitTimer);
+    maxWaitTimer = null;
+  }
+}
+
+function cleanupWatchersRetryTimer(): void {
+  if (watchersRetryTimer) {
+    clearInterval(watchersRetryTimer);
+    watchersRetryTimer = null;
+  }
+  watchersRetryInProgress = false;
+}
+
+function scheduleWatchersRetry(): void {
+  if (watchersRetryTimer) return;
+  // Poll for directory creation: users may create ~/.claude/commands|skills while the app is running.
+  watchersRetryTimer = setInterval(() => {
+    if (subscriptions.length > 0) {
+      cleanupWatchersRetryTimer();
+      return;
+    }
+    if (watchersRetryInProgress) return;
+    watchersRetryInProgress = true;
+    startWatchers()
+      .catch(() => {
+        // Ignore retry errors; a later tick may succeed.
+      })
+      .finally(() => {
+        watchersRetryInProgress = false;
+      });
+  }, 2000);
+}
+
+function scheduleRefresh(): void {
+  const run = () => {
+    cleanupTimers();
+    refreshSnapshot()
+      .then((next) => {
+        onUpdate?.(next);
+      })
+      .catch((err) => {
+        console.warn('[ClaudeCompletions] 刷新失败：', err);
+      });
+  };
+
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+  }
+
+  if (!maxWaitTimer) {
+    maxWaitTimer = setTimeout(() => {
+      run();
+    }, 2000);
+  }
+
+  debounceTimer = setTimeout(() => {
+    run();
+  }, 400);
+}
+
+function stripQuotes(input: string): string {
+  const trimmed = input.trim();
+  return trimmed.replace(/^['"]|['"]$/g, '');
+}
+
+function parseMarkdownHeading(content: string): string | null {
+  const lines = content.split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('# ')) {
+      return trimmed.slice(2).trim();
+    }
+  }
+  return null;
+}
+
+function parseSkillFrontMatter(content: string): { name?: string; description?: string } | null {
+  const lines = content.split(/\r?\n/);
+  if (lines.length < 3) return null;
+  if (lines[0]?.trim() !== '---') return null;
+
+  const endIndex = lines.slice(1).findIndex((l) => l.trim() === '---');
+  if (endIndex === -1) return null;
+
+  const metaLines = lines.slice(1, endIndex + 1);
+  const meta: { name?: string; description?: string } = {};
+  for (const line of metaLines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const idx = trimmed.indexOf(':');
+    if (idx <= 0) continue;
+    const key = trimmed.slice(0, idx).trim();
+    const value = stripQuotes(trimmed.slice(idx + 1));
+    if (!value) continue;
+    if (key === 'name') meta.name = value;
+    if (key === 'description') meta.description = value;
+  }
+  if (!meta.name && !meta.description) return null;
+  return meta;
+}
+
+async function readTextFileSafe(filePath: string): Promise<string | null> {
+  try {
+    return await fs.promises.readFile(filePath, 'utf-8');
+  } catch (err) {
+    console.warn('[ClaudeCompletions] 读取失败：', filePath, err);
+    return null;
+  }
+}
+
+async function readLearnedCacheSafe(): Promise<LearnedSlashCacheV1> {
+  const filePath = getLearnedCacheFilePath();
+  try {
+    const raw = await fs.promises.readFile(filePath, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LearnedSlashCacheV1>;
+    if (parsed?.version !== 1 || !parsed.items || typeof parsed.items !== 'object') {
+      return { version: 1, items: {} };
+    }
+    return { version: 1, items: parsed.items as LearnedSlashCacheV1['items'] };
+  } catch {
+    return { version: 1, items: {} };
+  }
+}
+
+async function writeLearnedCacheSafe(cache: LearnedSlashCacheV1): Promise<void> {
+  const filePath = getLearnedCacheFilePath();
+  try {
+    await fs.promises.mkdir(path.dirname(filePath), { recursive: true });
+    await fs.promises.writeFile(filePath, JSON.stringify(cache, null, 2), 'utf-8');
+  } catch (err) {
+    console.warn('[ClaudeCompletions] 写入学习缓存失败：', filePath, err);
+  }
+}
+
+function normalizeSlashLabel(input: string): string | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (!trimmed.startsWith('/')) return null;
+  const token = trimmed.split(/\s+/)[0] ?? '';
+  if (token.length < 2) return null;
+  if (token.length > 120) return null;
+  // Disallow invisible characters to avoid polluting the cache.
+  if (/[\r\n\t]/.test(token)) return null;
+  // Avoid learning path-like tokens such as `/usr/local/bin`.
+  const rest = token.slice(1);
+  if (rest.includes('/') || rest.includes('\\')) return null;
+  return token;
+}
+
+async function loadLearnedCommands(): Promise<ClaudeSlashCompletionItem[]> {
+  const cache = await readLearnedCacheSafe();
+  const items: ClaudeSlashCompletionItem[] = [];
+  for (const [label, meta] of Object.entries(cache.items)) {
+    if (!label.startsWith('/')) continue;
+    items.push({
+      kind: 'command',
+      label,
+      insertText: `${label} `,
+      description: meta?.count ? `自动学习（已使用 ${meta.count} 次）` : '自动学习',
+      source: 'learned',
+    });
+  }
+  return items;
+}
+
+async function loadUserCommands(): Promise<ClaudeSlashCompletionItem[]> {
+  const items: ClaudeSlashCompletionItem[] = [];
+
+  for (const dir of getClaudeCommandsDirs()) {
+    if (!fs.existsSync(dir)) continue;
+
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(dir, { withFileTypes: true });
+    } catch (err) {
+      console.warn('[ClaudeCompletions] 读取 commands 目录失败：', dir, err);
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.toLowerCase().endsWith('.md')) continue;
+      const commandName = entry.name.slice(0, -3);
+      const filePath = path.join(dir, entry.name);
+      const content = await readTextFileSafe(filePath);
+      const heading = content ? parseMarkdownHeading(content) : null;
+
+      items.push({
+        kind: 'command',
+        label: `/${commandName}`,
+        insertText: `/${commandName} `,
+        description: heading ?? undefined,
+        source: 'user',
+      });
+    }
+  }
+  return items;
+}
+
+async function walkDirForSkillFiles(root: string): Promise<string[]> {
+  const result: string[] = [];
+  const stack: string[] = [root];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) break;
+    let entries: fs.Dirent[];
+    try {
+      entries = await fs.promises.readdir(current, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const entry of entries) {
+      const next = path.join(current, entry.name);
+      if (entry.isDirectory()) {
+        stack.push(next);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (entry.name.toLowerCase() !== 'skill.md') continue;
+      result.push(next);
+    }
+  }
+  return result;
+}
+
+async function loadUserSkills(): Promise<ClaudeSlashCompletionItem[]> {
+  const items: ClaudeSlashCompletionItem[] = [];
+  for (const dir of getClaudeSkillsDirs()) {
+    if (!fs.existsSync(dir)) continue;
+
+    const skillFiles = await walkDirForSkillFiles(dir);
+    for (const filePath of skillFiles) {
+      const content = await readTextFileSafe(filePath);
+      if (!content) continue;
+
+      const meta = parseSkillFrontMatter(content);
+      const fallbackName = path.basename(path.dirname(filePath));
+      const name = meta?.name ?? fallbackName;
+      const description = meta?.description ?? parseMarkdownHeading(content) ?? undefined;
+
+      items.push({
+        kind: 'skill',
+        label: `/${name}`,
+        insertText: `/${name} `,
+        description,
+        source: 'user',
+      });
+    }
+  }
+
+  return items;
+}
+
+function loadBuiltinCommands(): ClaudeSlashCompletionItem[] {
+  // Built-in Claude Code CLI `/` commands. If the CLI cannot be enumerated reliably, provide a small seed list.
+  // Note: this does not affect CLI behavior; it is only used for UI hints and insert text.
+  const commands: Array<{ command: string; description: string }> = [
+    { command: 'help', description: '查看帮助' },
+    { command: 'init', description: '初始化项目（生成 CLAUDE.md）' },
+    { command: 'clear', description: '清屏 / 清空当前视图' },
+    { command: 'compact', description: '压缩上下文' },
+    { command: 'model', description: '切换/查看模型' },
+    { command: 'cost', description: '查看用量/费用' },
+    { command: 'status', description: '查看状态' },
+    { command: 'memory', description: '查看/编辑记忆' },
+    { command: 'config', description: '查看/修改配置' },
+    { command: 'review', description: '进入评审/检查流程' },
+    { command: 'permissions', description: '查看/修改权限设置' },
+    { command: 'output-style', description: '配置输出风格（如 concise/detailed）' },
+    { command: 'theme', description: '切换主题' },
+    { command: 'fast', description: '切换快速模式' },
+    { command: 'keybindings', description: '编辑快捷键配置' },
+    { command: 'rewind', description: '回退最近一轮对话/变更' },
+    { command: 'resume', description: '恢复之前的会话' },
+    { command: 'add-dir', description: '添加额外目录到上下文' },
+    { command: 'doctor', description: '诊断环境问题' },
+    { command: 'usage', description: '查看用量限制进度' },
+    { command: 'context-viz', description: '可视化上下文窗口使用情况' },
+    { command: 'todo', description: '查看当前会话待办' },
+    { command: 'login', description: '登录/切换账号' },
+    { command: 'logout', description: '登出当前会话' },
+    { command: 'mcp', description: '管理 MCP 集成' },
+  ];
+
+  const dedup = new Map<string, { command: string; description: string }>();
+  for (const c of commands) {
+    dedup.set(c.command, c);
+  }
+
+  return Array.from(dedup.values()).map((c) => ({
+    kind: 'command' as const,
+    label: `/${c.command}`,
+    insertText: `/${c.command} `,
+    description: c.description,
+    source: 'builtin' as const,
+  }));
+}
+
+async function buildSnapshot(): Promise<ClaudeSlashCompletionsSnapshot> {
+  const learned = await loadLearnedCommands();
+  const builtin = loadBuiltinCommands();
+  const [commands, skills] = await Promise.all([loadUserCommands(), loadUserSkills()]);
+  const dedup = new Map<string, ClaudeSlashCompletionItem>();
+  // Let user-defined items override built-ins (same label: last write wins).
+  // Learned items have the lowest priority; they are only used as a fallback for discovery.
+  for (const item of [...learned, ...builtin, ...commands, ...skills]) {
+    dedup.set(item.label, item);
+  }
+  return { items: Array.from(dedup.values()), updatedAt: Date.now() };
+}
+
+async function refreshSnapshot(): Promise<ClaudeSlashCompletionsSnapshot> {
+  snapshot = await buildSnapshot();
+  return snapshot;
+}
+
+async function startWatchers(): Promise<void> {
+  if (subscriptions.length > 0) {
+    cleanupWatchersRetryTimer();
+    return;
+  }
+
+  const watchTargets = [...getClaudeCommandsDirs(), ...getClaudeSkillsDirs()].filter((d) =>
+    fs.existsSync(d)
+  );
+  if (watchTargets.length === 0) {
+    scheduleWatchersRetry();
+    return;
+  }
+
+  cleanupWatchersRetryTimer();
+
+  for (const dir of watchTargets) {
+    try {
+      const sub = await subscribe(dir, (err, events) => {
+        if (err) {
+          console.warn('[ClaudeCompletions] watcher 错误：', err);
+          return;
+        }
+        const hasRelevantChange = events.some((e) => e.path.toLowerCase().endsWith('.md'));
+        if (!hasRelevantChange) return;
+        scheduleRefresh();
+      });
+      subscriptions.push(sub);
+    } catch (err) {
+      console.warn('[ClaudeCompletions] watcher 启动失败：', dir, err);
+    }
+  }
+}
+
+async function ensureStarted(): Promise<void> {
+  if (isStarted) return;
+  if (starting) return starting;
+  starting = (async () => {
+    await refreshSnapshot();
+    await startWatchers();
+    isStarted = true;
+  })();
+  await starting;
+  starting = null;
+}
+
+export async function startClaudeSlashCompletionsWatcher(
+  callback: (next: ClaudeSlashCompletionsSnapshot) => void
+): Promise<void> {
+  onUpdate = callback;
+  await ensureStarted();
+}
+
+export async function stopClaudeSlashCompletionsWatcher(): Promise<void> {
+  cleanupTimers();
+  cleanupWatchersRetryTimer();
+  onUpdate = null;
+
+  const subs = subscriptions;
+  subscriptions = [];
+  await Promise.allSettled(subs.map((s) => s.unsubscribe()));
+
+  isStarted = false;
+  starting = null;
+}
+
+export async function getClaudeSlashCompletionsSnapshot(): Promise<ClaudeSlashCompletionsSnapshot> {
+  await ensureStarted();
+  return snapshot;
+}
+
+export async function refreshClaudeSlashCompletions(): Promise<ClaudeSlashCompletionsSnapshot> {
+  await ensureStarted();
+  const next = await refreshSnapshot();
+  onUpdate?.(next);
+  return next;
+}
+
+export async function learnClaudeSlashCompletion(
+  label: string
+): Promise<ClaudeSlashCompletionsSnapshot> {
+  await ensureStarted();
+
+  const normalized = normalizeSlashLabel(label);
+  if (!normalized) return snapshot;
+
+  const cache = await readLearnedCacheSafe();
+  const now = Date.now();
+  const current = cache.items[normalized] ?? { count: 0, lastUsedAt: 0 };
+  cache.items[normalized] = { count: Math.max(0, current.count) + 1, lastUsedAt: now };
+  await writeLearnedCacheSafe(cache);
+
+  const next = await refreshSnapshot();
+  onUpdate?.(next);
+  return next;
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -808,6 +808,23 @@ const electronAPI = {
     },
   },
 
+  // Claude Slash Completions (/ commands + skills)
+  claudeCompletions: {
+    get: (): Promise<import('@shared/types').ClaudeSlashCompletionsSnapshot> =>
+      ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_COMPLETIONS_GET),
+    refresh: (): Promise<import('@shared/types').ClaudeSlashCompletionsSnapshot> =>
+      ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_COMPLETIONS_REFRESH),
+    learn: (label: string): Promise<import('@shared/types').ClaudeSlashCompletionsSnapshot> =>
+      ipcRenderer.invoke(IPC_CHANNELS.CLAUDE_COMPLETIONS_LEARN, label),
+    onUpdated: (
+      callback: (data: import('@shared/types').ClaudeSlashCompletionsSnapshot) => void
+    ): (() => void) => {
+      const handler = (_: unknown, data: Parameters<typeof callback>[0]) => callback(data);
+      ipcRenderer.on(IPC_CHANNELS.CLAUDE_COMPLETIONS_UPDATED, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.CLAUDE_COMPLETIONS_UPDATED, handler);
+    },
+  },
+
   // Search
   search: {
     files: (params: FileSearchParams): Promise<FileSearchResult[]> =>
@@ -895,10 +912,8 @@ const electronAPI = {
     onStatusChanged: (
       callback: (status: { running: boolean; pid?: number; error?: string }) => void
     ): (() => void) => {
-      const handler = (
-        _: unknown,
-        status: { running: boolean; pid?: number; error?: string }
-      ) => callback(status);
+      const handler = (_: unknown, status: { running: boolean; pid?: number; error?: string }) =>
+        callback(status);
       ipcRenderer.on(IPC_CHANNELS.HAPI_RUNNER_STATUS_CHANGED, handler);
       return () => ipcRenderer.off(IPC_CHANNELS.HAPI_RUNNER_STATUS_CHANGED, handler);
     },

--- a/src/renderer/components/chat/EnhancedInput.tsx
+++ b/src/renderer/components/chat/EnhancedInput.tsx
@@ -1,3 +1,4 @@
+import type { ClaudeSlashCompletionItem, ClaudeSlashCompletionsSnapshot } from '@shared/types';
 import type { FileSearchResult } from '@shared/types/search';
 import { Paperclip, Send, X } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -67,6 +68,40 @@ export function EnhancedInput({
   const [mentionIndex, setMentionIndex] = useState(0);
   const mentionListRef = useRef<HTMLDivElement>(null);
 
+  // Slash command completions (indexed in main process from ~/.claude/commands and ~/.claude/skills)
+  const [slashItems, setSlashItems] = useState<ClaudeSlashCompletionItem[]>([]);
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [slashResults, setSlashResults] = useState<ClaudeSlashCompletionItem[]>([]);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const slashListRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const api = window.electronAPI?.claudeCompletions;
+    if (!api) return;
+
+    api
+      .get()
+      .then((data: ClaudeSlashCompletionsSnapshot) => {
+        if (!alive) return;
+        setSlashItems(data.items ?? []);
+      })
+      .catch(() => {
+        if (!alive) return;
+        setSlashItems([]);
+      });
+
+    const cleanup = api.onUpdated((data: ClaudeSlashCompletionsSnapshot) => {
+      if (!alive) return;
+      setSlashItems(data.items ?? []);
+    });
+
+    return () => {
+      alive = false;
+      cleanup?.();
+    };
+  }, []);
+
   // Extract mention query from text before cursor
   const extractMentionQuery = useCallback((text: string, cursorPos: number): string | null => {
     for (let i = cursorPos - 1; i >= 0; i--) {
@@ -77,25 +112,49 @@ export function EnhancedInput({
     return null;
   }, []);
 
+  const findSlashTokenStart = useCallback((text: string, cursorPos: number): number | null => {
+    for (let i = cursorPos - 1; i >= 0; i--) {
+      const ch = text[i];
+      if (ch === '/') {
+        const prev = i > 0 ? text[i - 1] : ' ';
+        const isTokenStart = i === 0 || prev === ' ' || prev === '\n' || prev === '\r';
+        if (!isTokenStart) return null;
+        return i;
+      }
+      if (ch === ' ' || ch === '\n' || ch === '\r') return null;
+    }
+    return null;
+  }, []);
+
+  const extractSlashQuery = useCallback(
+    (text: string, cursorPos: number): string | null => {
+      const slashPos = findSlashTokenStart(text, cursorPos);
+      if (slashPos === null) return null;
+      return text.slice(slashPos + 1, cursorPos);
+    },
+    [findSlashTokenStart]
+  );
+
   // Detect @ mention on content change
   const handleContentChange = useCallback(
     (value: string) => {
       onContentChange(value);
-      // Skip mention detection during IME composition
-      if (composingRef.current || !cwd) {
-        if (!cwd) setMentionQuery(null);
-        return;
-      }
+      // Skip detection during IME composition
+      if (composingRef.current) return;
       const ta = textareaRef.current;
       if (!ta) return;
       // Use setTimeout to read selectionStart after React updates the value
       setTimeout(() => {
         const cursor = ta.selectionStart;
-        setMentionQuery(extractMentionQuery(value, cursor));
+        const nextMentionQuery = cwd ? extractMentionQuery(value, cursor) : null;
+        setMentionQuery(nextMentionQuery);
         setMentionIndex(0);
+        const nextSlashQuery = nextMentionQuery === null ? extractSlashQuery(value, cursor) : null;
+        setSlashQuery(nextSlashQuery);
+        setSlashIndex(0);
       }, 0);
     },
-    [cwd, onContentChange, extractMentionQuery]
+    [cwd, onContentChange, extractMentionQuery, extractSlashQuery]
   );
 
   // Debounced file search
@@ -112,6 +171,40 @@ export function EnhancedInput({
     }, 150);
     return () => clearTimeout(timer);
   }, [mentionQuery, cwd]);
+
+  useEffect(() => {
+    if (slashQuery === null) {
+      setSlashResults([]);
+      return;
+    }
+
+    const q = slashQuery.toLowerCase();
+    const results = slashItems
+      .filter(
+        (item) => item.label.toLowerCase().includes(`/${q}`) || item.label.toLowerCase().includes(q)
+      )
+      .sort((a, b) => {
+        // Sort by kind first: commands before skills
+        const kindRank = (x: ClaudeSlashCompletionItem) => (x.kind === 'command' ? 0 : 1);
+        const diffKind = kindRank(a) - kindRank(b);
+        if (diffKind !== 0) return diffKind;
+
+        // Then prefer prefix matches
+        const aKey = a.label.startsWith('/')
+          ? a.label.slice(1).toLowerCase()
+          : a.label.toLowerCase();
+        const bKey = b.label.startsWith('/')
+          ? b.label.slice(1).toLowerCase()
+          : b.label.toLowerCase();
+        const aStarts = Number(aKey.startsWith(q));
+        const bStarts = Number(bKey.startsWith(q));
+        if (aStarts !== bStarts) return bStarts - aStarts;
+        return aKey.localeCompare(bKey);
+      })
+      .slice(0, 10);
+
+    setSlashResults(results);
+  }, [slashQuery, slashItems]);
 
   // Insert selected mention into textarea
   const insertMention = useCallback(
@@ -145,6 +238,38 @@ export function EnhancedInput({
     [content, onContentChange]
   );
 
+  const executeSlash = useCallback(
+    (item: ClaudeSlashCompletionItem) => {
+      const ta = textareaRef.current;
+      const cursor = ta ? ta.selectionStart : content.length;
+      const text = content;
+
+      const slashPos = findSlashTokenStart(text, cursor);
+      if (slashPos === null) return;
+      const replacement = item.label;
+      const newContent = (text.slice(0, slashPos) + replacement + text.slice(cursor)).trim();
+      if (!newContent) return;
+
+      // Close the popup first to avoid flicker while sending/closing.
+      setSlashQuery(null);
+      setSlashResults([]);
+
+      // Auto-learn: executing a slash item should be counted in the learned cache.
+      const token = newContent.match(/^\/\S+/)?.[0];
+      if (token && !token.slice(1).includes('/') && !token.includes('\\')) {
+        window.electronAPI?.claudeCompletions?.learn(token).catch(() => {
+          // Ignore learning failures; they should not block sending.
+        });
+      }
+
+      onSend(newContent, imagePaths);
+      if (!keepOpenAfterSend) {
+        onOpenChange(false);
+      }
+    },
+    [content, imagePaths, keepOpenAfterSend, onOpenChange, onSend, findSlashTokenStart]
+  );
+
   // Scroll highlighted mention into view
   useEffect(() => {
     const list = mentionListRef.current;
@@ -152,6 +277,13 @@ export function EnhancedInput({
     const item = list.children[mentionIndex] as HTMLElement | undefined;
     item?.scrollIntoView({ block: 'nearest' });
   }, [mentionIndex]);
+
+  useEffect(() => {
+    const list = slashListRef.current;
+    if (!list) return;
+    const item = list.children[slashIndex] as HTMLElement | undefined;
+    item?.scrollIntoView({ block: 'nearest' });
+  }, [slashIndex]);
 
   const handleResizeStart = useCallback((e: React.MouseEvent) => {
     e.preventDefault();
@@ -190,7 +322,7 @@ export function EnhancedInput({
     ta.style.height = `${Math.max(scrollH, minH)}px`;
   }, [content, manualMinH]);
 
-  // 当前会话激活且增强输入已打开时，启用焦点锁。
+  // When the session is active and the enhanced input is open, enable focus lock.
   useEffect(() => {
     if (!sessionId || !open || !isActive) return;
 
@@ -209,7 +341,7 @@ export function EnhancedInput({
   // Focus trap: only refocus textarea when focus leaves this panel.
   // This avoids breaking keyboard navigation to Upload/Close/Send buttons.
   const handleBlur = useCallback(() => {
-    // 延后两帧，给 overlay 挂载和浏览器焦点结算留出时间，避免在弹窗打开过程中抢回焦点。
+    // Wait two frames to allow overlays to mount and focus to settle, avoiding focus steal while opening popups.
     requestAnimationFrame(() => {
       requestAnimationFrame(() => {
         if (!open || !sessionId || !isFocusLocked(sessionId)) return;
@@ -240,9 +372,21 @@ export function EnhancedInput({
   // Draft is now preserved in store - no reset on close
 
   const handleSend = useCallback(async () => {
-    if (!content.trim() && imagePaths.length === 0) return;
+    const trimmed = content.trim();
+    if (!trimmed && imagePaths.length === 0) return;
     try {
-      onSend(content.trim(), imagePaths);
+      // Auto-learn: if the message starts with `/xxx`, record it for future completion suggestions.
+      if (trimmed.startsWith('/')) {
+        const token = trimmed.match(/^\/\S+/)?.[0];
+        // Avoid learning path-like tokens such as `/usr/local/bin`.
+        if (token && !token.slice(1).includes('/') && !token.includes('\\')) {
+          window.electronAPI?.claudeCompletions?.learn(token).catch(() => {
+            // Ignore learning failures; they should not block sending.
+          });
+        }
+      }
+
+      onSend(trimmed, imagePaths);
       // Only close panel if not in 'always open' mode
       if (!keepOpenAfterSend) {
         onOpenChange(false);
@@ -287,14 +431,14 @@ export function EnhancedInput({
     (e: React.KeyboardEvent) => {
       if (e.key !== 'Escape') return;
       // If mention popup is open, let handleKeyDown close it first
-      if (mentionQuery !== null) return;
+      if (mentionQuery !== null || slashQuery !== null) return;
 
       // Keep ESC behavior identical to clicking the close (X) button.
       e.preventDefault();
       e.stopPropagation();
       onOpenChange(false);
     },
-    [onOpenChange, mentionQuery]
+    [onOpenChange, mentionQuery, slashQuery]
   );
 
   const handleKeyDown = useCallback(
@@ -329,6 +473,29 @@ export function EnhancedInput({
           return;
         }
       }
+      // When slash popup is active, intercept navigation keys
+      if (slashQuery !== null && slashResults.length > 0) {
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setSlashIndex((prev) => (prev + 1) % slashResults.length);
+          return;
+        }
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setSlashIndex((prev) => (prev - 1 + slashResults.length) % slashResults.length);
+          return;
+        }
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          executeSlash(slashResults[slashIndex]);
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setSlashQuery(null);
+          return;
+        }
+      }
       // Send with Enter (without Shift)
       if (e.key === 'Enter' && !e.shiftKey) {
         e.preventDefault();
@@ -336,7 +503,17 @@ export function EnhancedInput({
       }
       // Esc close is handled at the panel level so it works for buttons too.
     },
-    [handleSend, mentionQuery, mentionResults, mentionIndex, insertMention]
+    [
+      handleSend,
+      mentionQuery,
+      mentionResults,
+      mentionIndex,
+      insertMention,
+      slashQuery,
+      slashResults,
+      slashIndex,
+      executeSlash,
+    ]
   );
 
   const saveImageToTemp = useCallback(
@@ -526,6 +703,63 @@ export function EnhancedInput({
                 Enter
               </kbd>
               Select
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px] leading-none">
+                Esc
+              </kbd>
+              Close
+            </span>
+          </div>
+        </div>
+      )}
+
+      {/* / slash command popup — outside overflow-hidden container */}
+      {slashQuery !== null && slashResults.length > 0 && (
+        <div className="absolute bottom-full left-3 mb-1 w-80 rounded-lg border bg-popover shadow-lg z-10 overflow-hidden">
+          <div ref={slashListRef} className="max-h-[240px] overflow-y-auto py-1">
+            {slashResults.map((item, i) => (
+              <button
+                type="button"
+                key={`${item.kind}:${item.label}`}
+                onMouseDown={(e) => {
+                  e.preventDefault();
+                  executeSlash(item);
+                }}
+                className={cn(
+                  'w-full text-left px-3 py-1.5 text-sm transition-colors',
+                  i === slashIndex
+                    ? 'bg-accent text-accent-foreground'
+                    : 'text-foreground hover:bg-accent/50'
+                )}
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="font-mono">{item.label}</span>
+                  <span className="text-muted-foreground text-xs shrink-0">
+                    {item.kind === 'command' ? '命令' : '技能'}
+                  </span>
+                </div>
+                {item.description && (
+                  <div className="text-muted-foreground text-xs truncate mt-0.5">
+                    {item.description}
+                  </div>
+                )}
+              </button>
+            ))}
+          </div>
+          {/* Keyboard shortcut hints */}
+          <div className="flex items-center gap-3 border-t px-3 py-1.5 text-xs text-muted-foreground">
+            <span className="flex items-center gap-1">
+              <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px] leading-none">
+                ↑↓
+              </kbd>
+              Navigate
+            </span>
+            <span className="flex items-center gap-1">
+              <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px] leading-none">
+                Enter
+              </kbd>
+              Execute
             </span>
             <span className="flex items-center gap-1">
               <kbd className="rounded border bg-muted px-1 py-0.5 font-mono text-[10px] leading-none">

--- a/src/shared/types/claude.ts
+++ b/src/shared/types/claude.ts
@@ -1,6 +1,6 @@
 /**
- * Claude Provider 配置
- * 用于管理多组 Claude API 配置
+ * Claude provider config
+ * Used to manage multiple Claude API configurations.
  */
 export interface ClaudeProvider {
   id: string;
@@ -12,12 +12,12 @@ export interface ClaudeProvider {
   defaultSonnetModel?: string;
   defaultOpusModel?: string;
   defaultHaikuModel?: string;
-  displayOrder?: number; // 显示顺序，用于拖拽排序
-  enabled?: boolean; // 是否启用，默认 true
+  displayOrder?: number; // Display order (used for drag sorting)
+  enabled?: boolean; // Whether enabled (default: true)
 }
 
 /**
- * Claude settings.json 中的 env 字段结构
+ * `env` field shape in Claude `settings.json`
  */
 export interface ClaudeSettingsEnv {
   ANTHROPIC_BASE_URL?: string;
@@ -30,7 +30,7 @@ export interface ClaudeSettingsEnv {
 }
 
 /**
- * Claude settings.json 结构（部分）
+ * Claude `settings.json` (partial)
  */
 export interface ClaudeSettings {
   env?: ClaudeSettingsEnv;
@@ -38,4 +38,29 @@ export interface ClaudeSettings {
   hooks?: Record<string, unknown>;
   permissions?: Record<string, unknown>;
   [key: string]: unknown;
+}
+
+/**
+ * Claude Code CLI `/` completion items
+ * - Supports built-in seeds and user-defined items (from `~/.claude/commands`, `~/.claude/skills`)
+ * - Only used for UI hints and insert text; it does not change CLI behavior
+ */
+export type ClaudeSlashCompletionKind = 'command' | 'skill';
+
+export interface ClaudeSlashCompletionItem {
+  kind: ClaudeSlashCompletionKind;
+  /** Display label (with `/` prefix), e.g. `/save-context` */
+  label: string;
+  /** Insert text, e.g. `/save-context ` */
+  insertText: string;
+  /** Optional description */
+  description?: string;
+  /** Data source */
+  source: 'builtin' | 'user' | 'learned';
+}
+
+export interface ClaudeSlashCompletionsSnapshot {
+  items: ClaudeSlashCompletionItem[];
+  /** Generated timestamp (ms) */
+  updatedAt: number;
 }

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -207,6 +207,12 @@ export const IPC_CHANNELS = {
   CLAUDE_PROMPTS_WRITE: 'claude:prompts:write',
   CLAUDE_PROMPTS_BACKUP: 'claude:prompts:backup',
 
+  // Claude Slash Completions (/ commands + skills)
+  CLAUDE_COMPLETIONS_GET: 'claude:completions:get',
+  CLAUDE_COMPLETIONS_REFRESH: 'claude:completions:refresh',
+  CLAUDE_COMPLETIONS_LEARN: 'claude:completions:learn',
+  CLAUDE_COMPLETIONS_UPDATED: 'claude:completions:updated',
+
   // Claude Plugins Management
   CLAUDE_PLUGINS_LIST: 'claude:plugins:list',
   CLAUDE_PLUGINS_SET_ENABLED: 'claude:plugins:setEnabled',


### PR DESCRIPTION
变更内容
- 新增 ClaudeCompletionsManager 服务，索引内置命令、用户自定义命令和技能
- 监听 ~/.claude/commands 和 ~/.claude/skills 目录变化，实时刷新补全列表
- 支持自动学习用户常用命令，按使用频次排序
- EnhancedInput 中新增斜杠弹出菜单，支持模糊搜索与键盘导航

交互与行为
输入 /（且 / 前是空格或行首）触发补全弹窗
↑/↓ 选择条目，Enter 执行并发送，Esc 关闭弹窗
与 @ 文件提及互斥：当 @ 提及弹窗激活时不触发 / 补全
防止学习缓存污染：路径样式（如 /usr/local/bin）不会被写入学习缓存

变更文件
src/main/services/claude/ClaudeCompletionsManager.ts
src/main/ipc/claudeCompletions.ts
src/main/ipc/index.ts
src/preload/index.ts
src/renderer/components/chat/EnhancedInput.tsx
src/shared/types/claude.ts
src/shared/types/ipc.ts

如何验证
打开增强输入框，在行首输入 /，应出现补全列表
↑/↓ 切换高亮，按 Enter 应直接发送替换后的 /xxx 消息
运行期间新建 ~/.claude/commands 或 ~/.claude/skills 并添加 .md/SKILL.md，应在短时间内自动出现在补全中（无需重启）
发送以路径开头的文本（如 /usr/local/bin）不应污染后续补全候选