### PR TITLE
fix(file-tree): 修复切换仓库后目录树展开状态丢失的问题

### DIFF
--- a/src/renderer/hooks/useFileTree.ts
+++ b/src/renderer/hooks/useFileTree.ts
@@ -163,37 +163,14 @@ export function useFileTree({ rootPath, enabled = true, isActive = true }: UseFi
       const newExpanded = new Set(expandedPathsRef.current);
 
       if (newExpanded.has(path)) {
-        // 折叠时，同时折叠所有被压缩的子目录
-        const collectCompactedPaths = (nodes: FileTreeNode[], targetPath: string): string[] => {
-          for (const node of nodes) {
-            if (node.path === targetPath && node.isDirectory) {
-              // 始终包含目标路径，即使 children 不存在（加载失败的情况）
-              const paths = [targetPath];
-              if (node.children) {
-                let current = node;
-                while (
-                  current.children?.length === 1 &&
-                  current.children[0].isDirectory &&
-                  newExpanded.has(current.children[0].path)
-                ) {
-                  current = current.children[0];
-                  paths.push(current.path);
-                }
-              }
-              return paths;
-            }
-            if (node.children) {
-              const found = collectCompactedPaths(node.children, targetPath);
-              if (found.length > 0) return found;
-            }
+        // Collapse: remove this path and all its expanded descendants so that
+        // no orphaned child paths remain in localStorage. This prevents the
+        // inconsistency where a child appears "expanded" (arrow icon) but has
+        // no content after the parent is re-opened following a repo switch.
+        for (const p of [...newExpanded]) {
+          if (p === path || p.startsWith(`${path}/`)) {
+            newExpanded.delete(p);
           }
-          // 如果节点未在树中找到（边缘情况），仍删除目标路径
-          return [targetPath];
-        };
-
-        const pathsToCollapse = collectCompactedPaths(treeRef.current, path);
-        for (const p of pathsToCollapse) {
-          newExpanded.delete(p);
         }
         setAndPersistExpandedPaths(newExpanded);
       } else {


### PR DESCRIPTION
## 问题描述

当用户在目录树中展开多层文件夹，然后收起父节点或某个祖先节点之后，切换到目录树的别的仓库，再次切换回来时，目录树的展开状态会丢失。

具体表现：
- 用户收起父节点后，子节点的展开路径残留在 localStorage 中
- 切换仓库后，这些孤立的路径在恢复时找不到对应的树节点
- 用户重新打开父节点时，子节点显示"展开"箭头但内容为空

## 根因分析

折叠逻辑（`collectCompactedPaths`）仅处理"压缩链"（只有单个子目录的连续路径），当父节点有多个子目录时：
- 仅删除父节点路径
- 所有子节点路径残留在 expandedPaths Set 和 localStorage 中

切换仓库回来时（`restoreChildren`）：
- 尝试恢复孤立的子路径，但其父节点未展开
- `updateTreeWithChain` 在树结构中找不到这些路径，静默失败
- expandedPaths 中残留孤立路径，导致 UI 显示不一致

## 修复方案

简化折叠逻辑：直接清除目标路径及其所有展开的后代路径。

```typescript
// 之前：仅沿 compact chain 收集路径
const pathsToCollapse = collectCompactedPaths(treeRef.current, path);

// 之后：清除所有后代路径
for (const p of [...newExpanded]) {
  if (p === path || p.startsWith(`${path}/`)) {
    newExpanded.delete(p);
  }
}
```

## 行为对比

| 场景 | 修复前 | 修复后 |
|---|---|---|
| 折叠有多个子目录的父节点 | ❌ 子路径残留 | ✅ 全部清除 |
| 折叠 compact chain | ✅ 沿链逐个删除 | ✅ 同样全部删除 |
| 切换仓库再切回 | ❌ 节点箭头但无内容 | ✅ 展开状态正确 |

## 测试步骤

1. 打开项目并展开多层文件夹（如 `src/renderer/components/files/`)
2. 收起最上层父节点（如 `/components`)
3. 切换到另一个仓库
4. 再次切换回当前仓库
5. 重新展开该父节点，应能正确看到文件树内容（无空节点）

🤖 Generated with [Claude Code](https://claude.com/claude-code)