### PR TITLE
fix(source-control): 修复 submodule 分支切换出现 HEAD 及不实时刷新的问题

### DIFF
--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -437,17 +437,7 @@ export class GitService {
 
   async checkout(branch: string): Promise<void> {
     if (branch.startsWith('remotes/')) {
-      // "remotes/origin/dev" → remoteBranch="origin/dev", localBranch="dev"
-      const remoteBranch = branch.slice(8);
-      const slashIdx = remoteBranch.indexOf('/');
-      const localBranch = slashIdx >= 0 ? remoteBranch.slice(slashIdx + 1) : remoteBranch;
-      try {
-        // Prefer switching to existing local branch
-        await this.git.checkout(localBranch);
-      } catch {
-        // Local branch does not exist: create it and track the remote
-        await this.git.checkout(['-b', localBranch, '--track', remoteBranch]);
-      }
+      await this.checkoutRemoteBranch(this.git, branch);
     } else {
       await this.git.checkout(branch);
     }
@@ -1130,6 +1120,38 @@ export class GitService {
   }
 
   /**
+   * Checkout a remote branch by extracting the local branch name and creating
+   * a tracking branch if it does not exist locally.
+   * @param git - SimpleGit instance (main repo or submodule)
+   * @param branch - Remote branch name in format "remotes/origin/branch-name"
+   */
+  private async checkoutRemoteBranch(git: SimpleGit, branch: string): Promise<void> {
+    // "remotes/origin/dev" → remoteBranch="origin/dev", localBranch="dev"
+    const remoteBranch = branch.slice(8);
+    const slashIdx = remoteBranch.indexOf('/');
+    const localBranch = slashIdx >= 0 ? remoteBranch.slice(slashIdx + 1) : remoteBranch;
+
+    try {
+      // Prefer switching to existing local branch
+      await git.checkout(localBranch);
+    } catch (error) {
+      // Check if error is due to branch not existing
+      const msg = error instanceof Error ? error.message : String(error);
+      if (
+        msg.includes('did not match') ||
+        msg.includes('pathspec') ||
+        msg.includes('unknown revision')
+      ) {
+        // Local branch does not exist: create it and track the remote
+        await git.checkout(['-b', localBranch, '--track', remoteBranch]);
+      } else {
+        // Re-throw other errors (e.g., uncommitted changes blocking checkout)
+        throw error;
+      }
+    }
+  }
+
+  /**
    * Fetch 单个子模块
    */
   async fetchSubmodule(submodulePath: string): Promise<void> {
@@ -1351,15 +1373,7 @@ export class GitService {
   async checkoutSubmoduleBranch(submodulePath: string, branch: string): Promise<void> {
     const subGit = this.getSubmoduleGit(submodulePath);
     if (branch.startsWith('remotes/')) {
-      // "remotes/origin/dev" → remoteBranch="origin/dev", localBranch="dev"
-      const remoteBranch = branch.slice(8);
-      const slashIdx = remoteBranch.indexOf('/');
-      const localBranch = slashIdx >= 0 ? remoteBranch.slice(slashIdx + 1) : remoteBranch;
-      try {
-        await subGit.checkout(localBranch);
-      } catch {
-        await subGit.checkout(['-b', localBranch, '--track', remoteBranch]);
-      }
+      await this.checkoutRemoteBranch(subGit, branch);
     } else {
       await subGit.checkout(branch);
     }

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -427,9 +427,14 @@ export function SourceControlPanel({
           refetchStatus();
         }
 
+        // Normalize branch name for display (remotes/origin/dev → dev)
+        const displayBranch = branch.startsWith('remotes/')
+          ? branch.slice(branch.indexOf('/', 8) + 1)
+          : branch;
+
         toastManager.add({
           title: t('Branch switched'),
-          description: t('Branch switched to {{branch}}', { branch }),
+          description: t('Branch switched to {{branch}}', { branch: displayBranch }),
           type: 'success',
           timeout: 3000,
         });


### PR DESCRIPTION
## 问题描述

版本管理面板中切换 submodule 分支存在两个 bug：

1. **切换后显示 `HEAD`**：选择远程分支（如 `remotes/origin/dev`）后，submodule 进入 detached HEAD 状态，分支名显示为 `HEAD`
2. **切换后不实时刷新**：分支切换成功后 UI 需要等待约 10 秒轮询才显示新分支名

## 根因分析

### Bug 1 — detached HEAD

`GitService.checkout()` 对远程分支名的处理不完整：

```
// 修复前
"remotes/origin/dev".slice(8) → "origin/dev"
git checkout origin/dev  → detached HEAD ❌

// 修复后
"remotes/origin/dev" → localBranch="dev", remoteBranch="origin/dev"
git checkout dev              （已有本地分支）✅
git checkout -b dev --track origin/dev  （本地不存在时创建）✅
```

`checkoutSubmoduleBranch()` 完全没有 normalize 逻辑，同样修复。

### Bug 2 — 缓存 key 不匹配

`handleBranchCheckout` 对 submodule 误用了 `useGitCheckout`，其 `onSuccess` 以 submodule 绝对路径失效缓存，但 `useSubmodules` 的 queryKey 是主仓库路径，两者永不匹配，只能靠 10s 轮询补救。

## 修复方案

**`src/main/services/git/GitService.ts`**
- `checkout()` 和 `checkoutSubmoduleBranch()` 统一处理 `remotes/` 前缀：提取本地分支名，try checkout / catch 创建追踪分支

**`src/renderer/components/source-control/SourceControlPanel.tsx`**
- `handleBranchCheckout` 根据 submodule 列表判断目标仓库类型
- submodule 改用 `useCheckoutSubmoduleBranch`，其 `onSuccess` 以 `rootPath` 正确失效 `['git', 'submodules', rootPath]` 缓存，切换后立即刷新

## 测试方式

1. 打开含 submodule 的仓库，进入版本管理面板
2. 选中 submodule，点击分支切换器，选择一个远程分支（如 `remotes/origin/xxx`）
3. 验证：切换后显示本地分支名而非 `HEAD`，且分支名立即更新无需等待