### PR TITLE
feat(editor): 改进 Zed 编辑器 CLI 路径检测

### DIFF
--- a/src/main/services/app/AppDetector.ts
+++ b/src/main/services/app/AppDetector.ts
@@ -560,33 +560,25 @@ export class AppDetector {
   }
 
   private getEditorCliPath(bundleId: string, appPath: string): string | null {
-    // VSCode, Cursor, Codium
+    // VSCode, Cursor, Codium, Zed
     if (
       bundleId.includes('com.microsoft.VSCode') ||
       bundleId.includes('com.todesktop.230313mzl4w4u92') || // Cursor
-      bundleId.includes('com.visualstudio.code')
+      bundleId.includes('com.visualstudio.code') ||
+      bundleId.includes('dev.zed.Zed')
     ) {
-      // Try to find CLI in common locations
       const possiblePaths = [
         '/usr/local/bin/cursor',
         '/opt/homebrew/bin/cursor',
         '/usr/local/bin/code',
         '/opt/homebrew/bin/code',
+        '/usr/local/bin/zed',
+        '/opt/homebrew/bin/zed',
         `${appPath}/Contents/Resources/app/bin/cursor`,
         `${appPath}/Contents/Resources/app/bin/code`,
+        `${appPath}/Contents/Resources/zed`,
       ];
 
-      for (const path of possiblePaths) {
-        try {
-          execSync(`test -f "${path}"`);
-          return path;
-        } catch {}
-      }
-    }
-
-    // Zed
-    if (bundleId.includes('dev.zed.Zed')) {
-      const possiblePaths = ['/usr/local/bin/zed', '/opt/homebrew/bin/zed'];
       for (const path of possiblePaths) {
         try {
           execSync(`test -f "${path}"`);

--- a/src/main/services/app/AppDetector.ts
+++ b/src/main/services/app/AppDetector.ts
@@ -560,30 +560,39 @@ export class AppDetector {
   }
 
   private getEditorCliPath(bundleId: string, appPath: string): string | null {
-    // VSCode, Cursor, Codium, Zed
-    if (
-      bundleId.includes('com.microsoft.VSCode') ||
-      bundleId.includes('com.todesktop.230313mzl4w4u92') || // Cursor
-      bundleId.includes('com.visualstudio.code') ||
-      bundleId.includes('dev.zed.Zed')
-    ) {
-      const possiblePaths = [
+    let possiblePaths: string[] = [];
+
+    // Cursor
+    if (bundleId.includes('com.todesktop.230313mzl4w4u92')) {
+      possiblePaths = [
         '/usr/local/bin/cursor',
         '/opt/homebrew/bin/cursor',
+        `${appPath}/Contents/Resources/app/bin/cursor`,
+      ];
+    }
+    // VSCode / Codium
+    else if (
+      bundleId.includes('com.microsoft.VSCode') ||
+      bundleId.includes('com.visualstudio.code')
+    ) {
+      possiblePaths = [
         '/usr/local/bin/code',
         '/opt/homebrew/bin/code',
+        `${appPath}/Contents/Resources/app/bin/code`,
+      ];
+    }
+    // Zed
+    else if (bundleId.includes('dev.zed.Zed')) {
+      possiblePaths = [
         '/usr/local/bin/zed',
         '/opt/homebrew/bin/zed',
-        `${appPath}/Contents/Resources/app/bin/cursor`,
-        `${appPath}/Contents/Resources/app/bin/code`,
         `${appPath}/Contents/Resources/zed`,
       ];
+    }
 
-      for (const path of possiblePaths) {
-        try {
-          execSync(`test -f "${path}"`);
-          return path;
-        } catch {}
+    for (const path of possiblePaths) {
+      if (existsSync(path)) {
+        return path;
       }
     }
 


### PR DESCRIPTION
## 概述
改进 Zed 编辑器的 CLI 路径检测，使其与 VSCode/Cursor 保持一致的逻辑。

## 改动内容
- 将 Zed 的 CLI 路径检测合并到 VSCode/Cursor 的条件判断中
- 添加系统路径检测：`/usr/local/bin/zed` 和 `/opt/homebrew/bin/zed`
- 添加 app 内部路径检测：`Contents/Resources/zed`
- 统一代码逻辑，减少重复

## 测试
- macOS 上测试通过
- 系统安装的 `zed` 命令可正常检测
- Homebrew 安装的 `zed` 命令可正常检测

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>