### PR TITLE
fix(terminal): 修复生产环境 Ctrl+R 被拦截无法触发终端反向历史搜索

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -512,7 +512,43 @@ app.whenReady().then(async () => {
   // Default open or close DevTools by F12 in development
   // Also intercept Cmd+- for all windows to bypass Monaco Editor interception
   app.on('browser-window-created', (_, window) => {
+    // Snapshot listeners before the optimizer adds its own, only needed in production.
+    const listenersBefore = app.isPackaged
+      ? new Set(window.webContents.listeners('before-input-event'))
+      : undefined;
     optimizer.watchWindowShortcuts(window);
+
+    // In production, allow Ctrl+R to pass through to terminal for reverse
+    // history search. The optimizer blocks it by default via
+    // before-input-event preventDefault.
+    // Depends on @electron-toolkit/utils implementing shortcut blocking via
+    // before-input-event listeners (verified up to v4.x).
+    if (listenersBefore) {
+      const newListeners = window.webContents
+        .listeners('before-input-event')
+        .filter((l) => !listenersBefore.has(l));
+
+      if (newListeners.length === 0) {
+        console.warn(
+          '[ctrl-r-passthrough] watchWindowShortcuts did not add any before-input-event listener'
+        );
+      }
+
+      const isCtrlR = (input: Electron.Input): boolean =>
+        input.code === 'KeyR' && input.control && !input.shift && !input.meta && !input.alt;
+
+      // Remove and re-add each listener with a wrapper. This moves them to
+      // the end of the listener queue, which is acceptable since no other
+      // before-input-event listeners depend on their ordering.
+      for (const listener of newListeners) {
+        const handler = listener as (event: Electron.Event, input: Electron.Input) => void;
+        window.webContents.removeListener('before-input-event', handler);
+        window.webContents.on('before-input-event', (event, input) => {
+          if (isCtrlR(input)) return;
+          handler(event, input);
+        });
+      }
+    }
 
     // Intercept Cmd+- before renderer process to bypass Monaco Editor interception
     window.webContents.on('before-input-event', (event, input) => {

--- a/src/main/services/MenuBuilder.ts
+++ b/src/main/services/MenuBuilder.ts
@@ -92,8 +92,7 @@ export function buildAppMenu(mainWindow: BrowserWindow, options: MenuOptions = {
           click: () => sendAction('open-action-panel'),
         },
         { type: 'separator' as const },
-        { role: 'reload' as const },
-        { role: 'forceReload' as const },
+        ...(app.isPackaged ? [] : [{ role: 'reload' as const }, { role: 'forceReload' as const }]),
         {
           label: t('Developer Tools'),
           accelerator: 'CommandOrControl+Option+I',


### PR DESCRIPTION
## 描述与修改
- Windows 下需要在Agent和终端使用 Ctrl+R 来搜索 prompt 和命令
- 生产环境下 `electron-toolkit` 的 `optimizer.watchWindowShortcuts` 会通过
  `before-input-event` 的 `preventDefault` 阻止 Ctrl+R 到达渲染进程，导致终端
  无法触发反向历史搜索
- 通过检测并包装 optimizer 新增的 `before-input-event` 监听器，在检测到 Ctrl+R
  时跳过 `preventDefault`，使按键正常传递给终端
- 移除生产环境的 `reload` / `forceReload` 菜单项，避免菜单加速键与终端快捷键冲突

## 修改后行为
- 生产包中按 Ctrl+R，终端触发 reverse-i-search
- 生产包中确认页面不会被 reload
- 开发模式下 Ctrl+R 仍可正常 reload
- macOS 上 Cmd+R 行为不受影响