### PR TITLE
fix(source-control): 修复 diff 视图显示旧内容的问题

### DIFF
--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -146,11 +146,7 @@ export function DiffViewer({
   // In commit view, we don't fetch diff - we use the provided externalDiff
   const shouldFetch = !skipFetch && !isCommitView;
 
-  const {
-    data: fetchedDiff,
-    isLoading,
-    refetch,
-  } = useFileDiff(
+  const { data: fetchedDiff, isLoading } = useFileDiff(
     rootPath,
     file?.path ?? null,
     file?.staged ?? false,
@@ -994,10 +990,6 @@ export function DiffViewer({
     hasAutoNavigatedRef.current = false;
     setIsEditing(false);
     setEditedContent(null);
-    // Force refetch diff data when file changes
-    if (file && shouldFetch) {
-      refetch();
-    }
   }, [file?.path, file?.staged]);
 
   if (!file) {

--- a/src/renderer/hooks/useGitHistory.ts
+++ b/src/renderer/hooks/useGitHistory.ts
@@ -94,7 +94,5 @@ export function useCommitDiff(
       );
     },
     enabled: !!workdir && !!hash && !!filePath,
-    staleTime: 0, // Always consider data stale
-    refetchOnMount: 'always', // Always refetch when component mounts
   });
 }


### PR DESCRIPTION
## 问题描述

版本管理的 diff 视图存在缓存问题：
- 第一次查看文件 diff 显示正确
- 文件再次修改后，diff 内容不更新
- 无论如何切换文件都无法刷新，始终显示第一次查看时的内容

## 修复方案

### 1. 工作区文件 diff（主要修复）
- **添加轮询机制**：`useFileDiff` 每 2 秒自动刷新（仅在窗口聚焦时）
- **强制刷新**：文件切换时主动调用 `refetch()`
- **配置优化**：`staleTime: 0` 确保数据立即过期

### 2. 历史提交 diff（预防性修复）
- **显式配置**：`useCommitDiff` 添加 `staleTime: 0` 和 `refetchOnMount: 'always'`
- **确保一致性**：避免潜在的缓存问题

## 技术细节

**修改文件：**
- `src/renderer/hooks/useSourceControl.ts` - 添加轮询机制
- `src/renderer/components/source-control/DiffViewer.tsx` - 添加强制刷新逻辑
- `src/renderer/hooks/useGitHistory.ts` - 添加显式刷新配置

**工作原理：**
- 用户持续查看同一文件 → 每 2 秒自动轮询获取最新 diff
- 用户切换文件 → 立即触发 `refetch()` 获取最新数据
- 窗口失焦 → 停止轮询，节省资源

## 测试验证

1. 修改文件并查看 diff
2. 再次修改同一文件
3. 确认 diff 视图自动更新（最多 2 秒延迟）
4. 切换到其他文件再切回来，确认显示最新内容

## 相关 Issue

修复了版本管理 diff 视图显示旧内容的问题。