### PR TITLE
fix(editor): 修复文件被外部修改后切换 tab 仍显示旧内容的问题

### DIFF
--- a/src/renderer/components/files/CurrentFilePanel.tsx
+++ b/src/renderer/components/files/CurrentFilePanel.tsx
@@ -20,6 +20,7 @@ declare global {
 }
 
 import { useEditor } from '@/hooks/useEditor';
+import { useWindowFocus } from '@/hooks/useWindowFocus';
 import { type TerminalKeybinding, useSettingsStore } from '@/stores/settings';
 import { EditorArea, type EditorAreaRef } from './EditorArea';
 import type { UnsavedChangesChoice } from './UnsavedChangesDialog';
@@ -54,9 +55,21 @@ export function CurrentFilePanel({ rootPath, isActive = false, sessionId }: Curr
     reorderTabs,
     setPendingCursor,
     navigateToFile,
+    refreshFileContent,
   } = useEditor();
 
   const editorAreaRef = useRef<EditorAreaRef>(null);
+
+  // Refresh active tab content when window regains focus (like mini-program onShow)
+  const { isWindowFocused } = useWindowFocus();
+  const prevFocusedRef = useRef(isWindowFocused);
+  useEffect(() => {
+    const wasFocused = prevFocusedRef.current;
+    prevFocusedRef.current = isWindowFocused;
+    if (isWindowFocused && !wasFocused && activeTab?.path) {
+      refreshFileContent(activeTab.path);
+    }
+  }, [isWindowFocused, activeTab?.path, refreshFileContent]);
 
   // Global search state
   const [searchOpen, setSearchOpen] = useState(false);
@@ -192,8 +205,10 @@ export function CurrentFilePanel({ rootPath, isActive = false, sessionId }: Curr
   const handleTabClick = useCallback(
     (path: string) => {
       setActiveFile(path);
+      // Background refresh to pick up external modifications
+      refreshFileContent(path);
     },
-    [setActiveFile]
+    [setActiveFile, refreshFileContent]
   );
 
   // Handle tab close

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -369,6 +369,16 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
     };
   }, [tabs, activeTabPath, onContentChange, markExternalChange, setEditorValueProgrammatically]);
 
+  // Sync Monaco editor when store content is updated by background refresh (tab switch reload)
+  useEffect(() => {
+    if (!activeTab || !editorRef.current || activeTab.isDirty) return;
+    const editor = editorRef.current;
+    const currentValue = editor.getValue();
+    if (currentValue !== activeTab.content) {
+      setEditorValueProgrammatically(editor, activeTab.content);
+    }
+  }, [activeTab, setEditorValueProgrammatically]);
+
   // Define custom theme on mount and when terminal theme / background image settings change
   useEffect(() => {
     defineMonacoTheme(terminalTheme, {

--- a/src/renderer/components/files/FilePanel.tsx
+++ b/src/renderer/components/files/FilePanel.tsx
@@ -24,6 +24,7 @@ declare global {
 
 import { useEditor } from '@/hooks/useEditor';
 import { useFileTree } from '@/hooks/useFileTree';
+import { useWindowFocus } from '@/hooks/useWindowFocus';
 import { type TerminalKeybinding, useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 import { EditorArea, type EditorAreaRef } from './EditorArea';
@@ -90,6 +91,7 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
     reorderTabs,
     setPendingCursor,
     navigateToFile,
+    refreshFileContent,
   } = useEditor();
 
   const [newItemType, setNewItemType] = useState<NewItemType>(null);
@@ -170,6 +172,17 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
     // Expand parent directories to reveal the file
     revealFile(activeTab.path);
   }, [activeTab?.path, rootPath, revealFile]);
+
+  // Refresh active tab content when window regains focus (like mini-program onShow)
+  const { isWindowFocused } = useWindowFocus();
+  const prevFocusedRef = useRef(isWindowFocused);
+  useEffect(() => {
+    const wasFocused = prevFocusedRef.current;
+    prevFocusedRef.current = isWindowFocused;
+    if (isWindowFocused && !wasFocused && activeTab?.path) {
+      refreshFileContent(activeTab.path);
+    }
+  }, [isWindowFocused, activeTab?.path, refreshFileContent]);
 
   // Handle file deleted (from undo operation)
   const handleFileDeleted = useCallback(
@@ -407,8 +420,10 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
   const handleTabClick = useCallback(
     (path: string) => {
       setActiveFile(path);
+      // Background refresh to pick up external modifications
+      refreshFileContent(path);
     },
-    [setActiveFile]
+    [setActiveFile, refreshFileContent]
   );
 
   // Handle tab close

--- a/src/renderer/hooks/useEditor.ts
+++ b/src/renderer/hooks/useEditor.ts
@@ -24,6 +24,28 @@ export function useEditor() {
 
   const queryClient = useQueryClient();
 
+  // Background refresh: re-read file from disk and silently update store (only if tab is not dirty)
+  const refreshFileContent = useCallback(
+    async (path: string) => {
+      const currentTabs = useEditorStore.getState().tabs;
+      const tab = currentTabs.find((t) => t.path === path);
+      if (!tab || tab.isDirty) return;
+
+      try {
+        const { content, isBinary } = await window.electronAPI.file.read(path);
+        if (isBinary) return;
+        // Re-check after async IO to avoid race conditions
+        const latestTab = useEditorStore.getState().tabs.find((t) => t.path === path);
+        if (latestTab && !latestTab.isDirty && latestTab.content !== content) {
+          updateFileContent(path, content, false);
+        }
+      } catch {
+        // File may have been deleted or become inaccessible
+      }
+    },
+    [updateFileContent]
+  );
+
   const loadFile = useMutation({
     mutationFn: async (path: string) => {
       const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
@@ -65,6 +87,8 @@ export function useEditor() {
 
       if (existingTab) {
         setActiveFile(path);
+        // Background refresh to pick up external modifications
+        refreshFileContent(path);
       } else {
         try {
           const { content, encoding, isBinary } = await window.electronAPI.file.read(path);
@@ -85,7 +109,7 @@ export function useEditor() {
         setPendingCursor({ path, line, column, matchLength, previewMode });
       }
     },
-    [tabs, setActiveFile, openFile, setPendingCursor]
+    [tabs, setActiveFile, openFile, setPendingCursor, refreshFileContent]
   );
 
   const activeTab = tabs.find((f) => f.path === activeTabPath) || null;
@@ -107,5 +131,6 @@ export function useEditor() {
     reorderTabs,
     setPendingCursor,
     navigateToFile,
+    refreshFileContent,
   };
 }


### PR DESCRIPTION
## Summary

- 文件被外部修改后（如 CLI agent、其他编辑器），编辑器 tab 仍显示旧的缓存内容。文件监听器并不总能捕获到所有变更。
- 新增 `refreshFileContent` 后台刷新机制，在 tab 切换、`navigateToFile` 跳转、窗口重新聚焦时自动从磁盘读取最新内容并静默更新
- 仅在 tab 非 dirty 时更新，不会覆盖用户未保存的编辑

## Changes

| 文件 | 变更 |
|------|------|
| `src/renderer/hooks/useEditor.ts` | 新增 `refreshFileContent`，更新 `navigateToFile` |
| `src/renderer/components/files/FilePanel.tsx` | `handleTabClick` + 窗口聚焦刷新 |
| `src/renderer/components/files/CurrentFilePanel.tsx` | 同上 |
| `src/renderer/components/files/EditorArea.tsx` | 添加 content sync effect 同步 Monaco |

## Test plan

- [ ] 打开文件 A → 终端修改 A → 切到其他 tab → 切回 A → 内容应更新
- [ ] 打开文件 A → 编辑（dirty）→ 终端修改 A → 切 tab → 切回 → 不覆盖用户编辑
- [ ] 通过搜索结果 `navigateToFile` 跳转到已打开文件 → 应展示最新内容
- [ ] 切换到其他应用修改文件 → 切回窗口 → 当前 tab 内容应自动更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)