### PR TITLE
feat: add Provider Watcher toggle setting

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -586,8 +586,12 @@ app.whenReady().then(async () => {
     webInspectorServer.setMainWindow(null);
     mainWindow = null;
   });
-  // Initialize Claude Provider Watcher
-  initClaudeProviderWatcher(mainWindow);
+  // Initialize Claude Provider Watcher (only when enableProviderWatcher is true)
+  const appSettings = readSettings();
+  const providerWatcherEnabled =
+    (appSettings?.claudeCodeIntegration as Record<string, unknown>)?.enableProviderWatcher !==
+    false;
+  initClaudeProviderWatcher(mainWindow, providerWatcherEnabled);
 
   // IMPORTANT: Set up did-finish-load handler BEFORE handling command line args
   // to avoid race condition where page loads before handler is registered

--- a/src/main/ipc/claudeProvider.ts
+++ b/src/main/ipc/claudeProvider.ts
@@ -5,6 +5,7 @@ import {
   applyProvider,
   extractProviderFromSettings,
   readClaudeSettings,
+  unwatchClaudeSettings,
   watchClaudeSettings,
 } from '../services/claude/ClaudeProviderManager';
 
@@ -22,9 +23,26 @@ export function registerClaudeProviderHandlers(): void {
   });
 }
 
+// Keep a reference to the window for dynamic watcher toggling
+let watcherWindow: BrowserWindow | null = null;
+
 /**
- * 初始化 Provider 监听
+ * Initialize provider watcher (only starts watching if enabled)
  */
-export function initClaudeProviderWatcher(window: BrowserWindow): void {
-  watchClaudeSettings(window);
+export function initClaudeProviderWatcher(window: BrowserWindow, enabled: boolean): void {
+  watcherWindow = window;
+  if (enabled) {
+    watchClaudeSettings(window);
+  }
+}
+
+/**
+ * Toggle provider watcher based on setting change
+ */
+export function toggleClaudeProviderWatcher(enabled: boolean): void {
+  if (enabled && watcherWindow && !watcherWindow.isDestroyed()) {
+    watchClaudeSettings(watcherWindow);
+  } else {
+    unwatchClaudeSettings();
+  }
 }

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync, renameSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { IPC_CHANNELS } from '@shared/types';
 import { app, ipcMain } from 'electron';
+import { toggleClaudeProviderWatcher } from './claudeProvider';
 
 function getSettingsPath(): string {
   return join(app.getPath('userData'), 'settings.json');
@@ -82,8 +83,19 @@ export function registerSettingsHandlers(): void {
 
   ipcMain.handle(IPC_CHANNELS.SETTINGS_WRITE, async (_, data: unknown) => {
     try {
+      const newData = data as Record<string, unknown>;
+
+      // Detect enableProviderWatcher change and toggle watcher accordingly
+      const oldEnabled = (cachedSettings?.claudeCodeIntegration as Record<string, unknown>)
+        ?.enableProviderWatcher;
+      const newEnabled = (newData.claudeCodeIntegration as Record<string, unknown>)
+        ?.enableProviderWatcher;
+      if (oldEnabled !== newEnabled) {
+        toggleClaudeProviderWatcher(newEnabled !== false);
+      }
+
       // 更新内存缓存
-      cachedSettings = data as Record<string, unknown>;
+      cachedSettings = newData;
       isDirty = true;
 
       // 防抖写入

--- a/src/renderer/App/hooks/useClaudeProviderListener.ts
+++ b/src/renderer/App/hooks/useClaudeProviderListener.ts
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from 'react';
-import { consumeClaudeProviderSwitch, isClaudeProviderMatch } from '@/lib/claudeProvider';
-import { addToast, toastManager } from '@/components/ui/toast';
-import { useSettingsStore } from '@/stores/settings';
-import { useI18n } from '@/i18n';
 import type { SettingsCategory } from '@/components/settings/constants';
+import { addToast, toastManager } from '@/components/ui/toast';
+import { useI18n } from '@/i18n';
+import { consumeClaudeProviderSwitch, isClaudeProviderMatch } from '@/lib/claudeProvider';
+import { useSettingsStore } from '@/stores/settings';
 
 export function useClaudeProviderListener(
   setSettingsCategory: (category: SettingsCategory) => void,
@@ -13,10 +13,16 @@ export function useClaudeProviderListener(
 ) {
   const { t } = useI18n();
   const claudeProviders = useSettingsStore((s) => s.claudeCodeIntegration.providers);
+  const enableProviderWatcher = useSettingsStore(
+    (s) => s.claudeCodeIntegration.enableProviderWatcher ?? true
+  );
   const providerToastRef = useRef<ReturnType<typeof toastManager.add> | null>(null);
 
   useEffect(() => {
     const cleanup = window.electronAPI.claudeProvider.onSettingsChanged((data) => {
+      // Skip if provider watcher is disabled
+      if (!enableProviderWatcher) return;
+
       const { extracted } = data;
       if (!extracted?.baseUrl) return;
 
@@ -86,5 +92,13 @@ export function useClaudeProviderListener(
       }
       cleanup();
     };
-  }, [claudeProviders, t, openSettings, setSettingsCategory, setScrollToProvider, setPendingProviderAction]);
+  }, [
+    claudeProviders,
+    t,
+    openSettings,
+    setSettingsCategory,
+    setScrollToProvider,
+    setPendingProviderAction,
+    enableProviderWatcher,
+  ]);
 }

--- a/src/renderer/components/settings/IntegrationSettings.tsx
+++ b/src/renderer/components/settings/IntegrationSettings.tsx
@@ -539,6 +539,22 @@ export function IntegrationSettings({ scrollToProvider }: IntegrationSettingsPro
           />
         </div>
 
+        {/* Provider Watcher */}
+        <div className="flex items-center justify-between">
+          <div className="space-y-0.5">
+            <span className="text-sm font-medium">{t('Provider Watcher')}</span>
+            <p className="text-xs text-muted-foreground">
+              {t('Watch Claude Code settings.json for external changes')}
+            </p>
+          </div>
+          <Switch
+            checked={claudeCodeIntegration.enableProviderWatcher ?? true}
+            onCheckedChange={(checked) =>
+              setClaudeCodeIntegration({ enableProviderWatcher: checked })
+            }
+          />
+        </div>
+
         {/* Provider Disable Feature */}
         <div className="flex items-center justify-between">
           <div className="space-y-0.5">

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -154,6 +154,7 @@ export const defaultClaudeCodeIntegrationSettings: ClaudeCodeIntegrationSettings
   statusLineFields: defaultStatusLineFieldSettings,
   tmuxEnabled: false, // Disable tmux wrapping by default
   showProviderSwitcher: true,
+  enableProviderWatcher: true, // Enable provider watcher by default
   enableProviderDisableFeature: false,
   providers: [],
   enhancedInputEnabled: false, // Disable enhanced input by default

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -187,6 +187,7 @@ export interface ClaudeCodeIntegrationSettings {
   statusLineFields: StatusLineFieldSettings; // Which fields to display in status line
   tmuxEnabled: boolean; // Enable tmux session wrapping for persistent terminal sessions
   showProviderSwitcher: boolean; // Show provider switcher in SessionBar
+  enableProviderWatcher: boolean; // Enable watcher for Claude Code settings.json changes
   enableProviderDisableFeature: boolean; // Enable/disable the provider temporary disable feature
   providers: import('@shared/types').ClaudeProvider[];
   enhancedInputEnabled: boolean; // Enable enhanced input panel for Claude Code

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1087,6 +1087,8 @@ export const zhTranslations: Record<string, string> = {
   'Allow temporarily disabling individual providers': '允许临时禁用单个 Provider',
   'Show provider switcher in SessionBar for quick switching':
     '在 SessionBar 上显示 Provider 切换器，方便快速切换',
+  'Provider Watcher': 'Provider 监听',
+  'Watch Claude Code settings.json for external changes': '监听 Claude Code 配置文件的外部变化',
   'Select Provider': 'Switch Provider',
   'Click to enable this Provider': '单击启用该 Provider',
   'Click to disable this Provider': '单击临时禁用该 Provider',


### PR DESCRIPTION
## Summary

Add a new `enableProviderWatcher` setting to control whether the app watches Claude Code's `settings.json` for external changes.

## Changes

- Add `enableProviderWatcher` field to `ClaudeCodeIntegrationSettings` type (default: `true`)
- Add UI toggle in Integration Settings
- Main process only starts watcher when setting is enabled
- Frontend listener also respects the setting
- Update snapshot after `applyProvider` to prevent self-triggered notifications
- Add i18n translations for the new setting

## Motivation

Users who don't need external config change detection (e.g., using `cc-switch` CLI) can now disable the watcher to avoid unnecessary file monitoring and notifications.

🤖 Generated with [Claude Code](https://claude.com/claude-code)