### PR TITLE
refactor: 移除 sessionId prop drilling，改用 useActiveSessionId hook，解决编辑器文件不能发送 comment 的 bug

### DIFF
--- a/src/renderer/components/files/CurrentFilePanel.tsx
+++ b/src/renderer/components/files/CurrentFilePanel.tsx
@@ -38,10 +38,9 @@ function matchesKeybinding(e: KeyboardEvent, binding: TerminalKeybinding): boole
 interface CurrentFilePanelProps {
   rootPath: string | undefined;
   isActive?: boolean;
-  sessionId?: string | null;
 }
 
-export function CurrentFilePanel({ rootPath, isActive = false, sessionId }: CurrentFilePanelProps) {
+export function CurrentFilePanel({ rootPath, isActive = false }: CurrentFilePanelProps) {
   const { t } = useI18n();
   const {
     tabs,
@@ -256,7 +255,6 @@ export function CurrentFilePanel({ rootPath, isActive = false, sessionId }: Curr
           activeTabPath={activeTab?.path ?? null}
           pendingCursor={pendingCursor}
           rootPath={rootPath}
-          sessionId={sessionId}
           onTabClick={handleTabClick}
           onTabClose={handleTabClose}
           onCloseOthers={async (keepPath) => {

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -30,6 +30,7 @@ import {
 import { addToast } from '@/components/ui/toast';
 import { useDebouncedSave } from '@/hooks/useDebouncedSave';
 import { useI18n } from '@/i18n';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import type { EditorTab, PendingCursor } from '@/stores/editor';
 import { useEditorStore } from '@/stores/editor';
 import { useSettingsStore } from '@/stores/settings';
@@ -72,7 +73,6 @@ interface EditorAreaProps {
   activeTabPath: string | null;
   pendingCursor: PendingCursor | null;
   rootPath?: string;
-  sessionId?: string | null;
   onTabClick: (path: string) => void;
   onTabClose: (path: string) => void | Promise<void>;
   onCloseOthers?: (keepPath: string) => void | Promise<void>;
@@ -97,7 +97,6 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
     activeTabPath,
     pendingCursor,
     rootPath,
-    sessionId,
     onTabClick,
     onTabClose,
     onCloseOthers,
@@ -117,6 +116,7 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
   ref: React.Ref<EditorAreaRef>
 ) {
   const { t } = useI18n();
+  const sessionId = useActiveSessionId(rootPath ?? null);
   const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
   const monacoRef = useRef<Monaco | null>(null);
   const [editorInstance, setEditorInstance] = useState<monaco.editor.IStandaloneCodeEditor | null>(
@@ -236,7 +236,6 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
     monacoInstance: monacoInstance,
     filePath: activeTabPath,
     rootPath: rootPath ?? null,
-    sessionId: sessionId ?? null,
     enabled: editorReady && !!sessionId,
   });
 

--- a/src/renderer/components/files/EditorLineComment.tsx
+++ b/src/renderer/components/files/EditorLineComment.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { Button } from '@/components/ui/button';
 import { useI18n } from '@/i18n';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 
 type Monaco = typeof monaco;
@@ -101,7 +102,6 @@ interface UseEditorLineCommentOptions {
   monacoInstance: Monaco | null;
   filePath: string | null;
   rootPath: string | null;
-  sessionId: string | null;
   enabled?: boolean;
 }
 
@@ -110,9 +110,9 @@ export function useEditorLineComment({
   monacoInstance,
   filePath,
   rootPath,
-  sessionId,
   enabled = true,
 }: UseEditorLineCommentOptions) {
+  const sessionId = useActiveSessionId(rootPath);
   const { t } = useI18n();
   const write = useTerminalWriteStore((state) => state.write);
   const focus = useTerminalWriteStore((state) => state.focus);

--- a/src/renderer/components/files/FilePanel.tsx
+++ b/src/renderer/components/files/FilePanel.tsx
@@ -25,6 +25,7 @@ declare global {
 import { useEditor } from '@/hooks/useEditor';
 import { useFileTree } from '@/hooks/useFileTree';
 import { useWindowFocus } from '@/hooks/useWindowFocus';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import { type TerminalKeybinding, useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 import { EditorArea, type EditorAreaRef } from './EditorArea';
@@ -56,13 +57,13 @@ function matchesKeybinding(e: KeyboardEvent, binding: TerminalKeybinding): boole
 interface FilePanelProps {
   rootPath: string | undefined;
   isActive?: boolean;
-  sessionId?: string | null;
 }
 
 type NewItemType = 'file' | 'directory' | null;
 
-export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelProps) {
+export function FilePanel({ rootPath, isActive = false }: FilePanelProps) {
   const { t } = useI18n();
+  const sessionId = useActiveSessionId(rootPath);
   const {
     tree,
     isLoading,
@@ -798,7 +799,6 @@ export function FilePanel({ rootPath, isActive = false, sessionId }: FilePanelPr
           activeTabPath={activeTab?.path ?? null}
           pendingCursor={pendingCursor}
           rootPath={rootPath}
-          sessionId={sessionId}
           onTabClick={handleTabClick}
           onTabClose={handleTabClose}
           onCloseOthers={async (keepPath) => {

--- a/src/renderer/components/layout/MainContent.tsx
+++ b/src/renderer/components/layout/MainContent.tsx
@@ -508,17 +508,9 @@ export function MainContent({
           )}
         >
           {fileTreeDisplayMode === 'current' ? (
-            <CurrentFilePanel
-              rootPath={worktreePath}
-              isActive={activeTab === 'file'}
-              sessionId={activeSessionId}
-            />
+            <CurrentFilePanel rootPath={worktreePath} isActive={activeTab === 'file'} />
           ) : (
-            <FilePanel
-              rootPath={worktreePath}
-              isActive={activeTab === 'file'}
-              sessionId={activeSessionId}
-            />
+            <FilePanel rootPath={worktreePath} isActive={activeTab === 'file'} />
           )}
         </div>
         {/* Source Control tab - keep mounted to preserve selection state */}
@@ -534,7 +526,6 @@ export function MainContent({
             isActive={activeTab === 'source-control'}
             onExpandWorktree={onExpandWorktree}
             worktreeCollapsed={worktreeCollapsed}
-            sessionId={activeSessionId}
           />
         </div>
         {/* Todo tab */}
@@ -593,7 +584,6 @@ export function MainContent({
         open={isReviewModalOpen}
         onOpenChange={setIsReviewModalOpen}
         rootPath={worktreePath}
-        sessionId={activeSessionId}
         onSend={() => onTabChange('chat')}
       />
     </main>

--- a/src/renderer/components/source-control/ChangesList.tsx
+++ b/src/renderer/components/source-control/ChangesList.tsx
@@ -38,7 +38,6 @@ interface ChangesListProps {
   onRefresh?: () => void;
   isRefreshing?: boolean;
   repoPath?: string;
-  sessionId?: string | null;
 }
 
 // M=Modified, A=Added, D=Deleted, R=Renamed, C=Copied, U=Untracked, X=Conflict
@@ -147,7 +146,6 @@ export function ChangesList({
   onRefresh,
   isRefreshing,
   repoPath,
-  sessionId,
 }: ChangesListProps) {
   const { t } = useI18n();
   const { viewMode, setViewMode } = useSourceControlStore();
@@ -251,7 +249,6 @@ export function ChangesList({
           open={isReviewModalOpen}
           onOpenChange={setIsReviewModalOpen}
           repoPath={repoPath}
-          sessionId={sessionId}
         />
       </div>
     );
@@ -445,7 +442,6 @@ export function ChangesList({
         open={isReviewModalOpen}
         onOpenChange={setIsReviewModalOpen}
         repoPath={repoPath}
-        sessionId={sessionId}
       />
     </div>
   );

--- a/src/renderer/components/source-control/CodeReviewModal.tsx
+++ b/src/renderer/components/source-control/CodeReviewModal.tsx
@@ -41,6 +41,7 @@ import { ScrollArea } from '@/components/ui/scroll-area';
 import { toastManager } from '@/components/ui/toast';
 import { useCodeReview } from '@/hooks/useCodeReview';
 import { useI18n } from '@/i18n';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import { stopCodeReview, useCodeReviewContinueStore } from '@/stores/codeReviewContinue';
 import { useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
@@ -132,10 +133,10 @@ interface CodeReviewModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   repoPath: string | undefined;
-  sessionId?: string | null; // Current active chat session
 }
 
-export function CodeReviewModal({ open, onOpenChange, repoPath, sessionId }: CodeReviewModalProps) {
+export function CodeReviewModal({ open, onOpenChange, repoPath }: CodeReviewModalProps) {
+  const sessionId = useActiveSessionId(repoPath);
   const { t } = useI18n();
   const { content, status, error, startReview, reset } = useCodeReview({ repoPath });
   const codeReviewSettings = useSettingsStore((s) => s.codeReview);

--- a/src/renderer/components/source-control/CommitDiffViewer.tsx
+++ b/src/renderer/components/source-control/CommitDiffViewer.tsx
@@ -14,7 +14,6 @@ interface CommitDiffViewerProps {
   onNextFile?: () => void;
   hasPrevFile?: boolean;
   hasNextFile?: boolean;
-  sessionId?: string | null;
 }
 
 export function CommitDiffViewer({
@@ -27,7 +26,6 @@ export function CommitDiffViewer({
   onNextFile,
   hasPrevFile = false,
   hasNextFile = false,
-  sessionId,
 }: CommitDiffViewerProps) {
   const { t } = useI18n();
 
@@ -70,7 +68,6 @@ export function CommitDiffViewer({
           onNextFile={onNextFile}
           hasPrevFile={hasPrevFile}
           hasNextFile={hasNextFile}
-          sessionId={sessionId}
         />
       </div>
     </div>

--- a/src/renderer/components/source-control/DiffReviewModal.tsx
+++ b/src/renderer/components/source-control/DiffReviewModal.tsx
@@ -32,6 +32,7 @@ import { useSubmoduleChanges, useSubmoduleFileDiff, useSubmodules } from '@/hook
 import { useI18n } from '@/i18n';
 import { getXtermTheme, isTerminalThemeDark } from '@/lib/ghosttyTheme';
 import { cn } from '@/lib/utils';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import { useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 
@@ -41,7 +42,6 @@ interface DiffReviewModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   rootPath: string | undefined;
-  sessionId: string | null;
   onSend?: () => void;
 }
 
@@ -285,14 +285,9 @@ function CommentItem({ comment, onDelete }: { comment: CommentData; onDelete: ()
   );
 }
 
-export function DiffReviewModal({
-  open,
-  onOpenChange,
-  rootPath,
-  sessionId,
-  onSend,
-}: DiffReviewModalProps) {
+export function DiffReviewModal({ open, onOpenChange, rootPath, onSend }: DiffReviewModalProps) {
   const { t } = useI18n();
+  const sessionId = useActiveSessionId(rootPath);
   const { terminalTheme, editorSettings } = useSettingsStore();
   const write = useTerminalWriteStore((state) => state.write);
   const focus = useTerminalWriteStore((state) => state.focus);

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -27,6 +27,7 @@ import { useI18n } from '@/i18n';
 import { getXtermTheme, isTerminalThemeDark } from '@/lib/ghosttyTheme';
 import { matchesKeybinding } from '@/lib/keybinding';
 import { cn } from '@/lib/utils';
+import { useActiveSessionId } from '@/stores/agentSessions';
 import { useNavigationStore } from '@/stores/navigation';
 import { useSettingsStore } from '@/stores/settings';
 import { useSourceControlStore } from '@/stores/sourceControl';
@@ -110,7 +111,6 @@ interface DiffViewerProps {
   diff?: { path: string; original: string; modified: string };
   skipFetch?: boolean;
   isCommitView?: boolean; // Add flag to indicate commit history view
-  sessionId?: string | null;
 }
 
 export function DiffViewer({
@@ -124,8 +124,8 @@ export function DiffViewer({
   diff: externalDiff,
   skipFetch = false,
   isCommitView = false,
-  sessionId,
 }: DiffViewerProps) {
+  const sessionId = useActiveSessionId(rootPath);
   const { t } = useI18n();
   const queryClient = useQueryClient();
   const { terminalTheme, sourceControlKeybindings, editorSettings } = useSettingsStore();

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -65,7 +65,6 @@ interface SourceControlPanelProps {
   isActive?: boolean;
   onExpandWorktree?: () => void;
   worktreeCollapsed?: boolean;
-  sessionId?: string | null;
 }
 
 export function SourceControlPanel({
@@ -73,7 +72,6 @@ export function SourceControlPanel({
   isActive = false,
   onExpandWorktree,
   worktreeCollapsed,
-  sessionId,
 }: SourceControlPanelProps) {
   const { t, tNode } = useI18n();
   const queryClient = useQueryClient();
@@ -967,7 +965,6 @@ export function SourceControlPanel({
                       : isFetching || fetchMutation.isPending
                   }
                   repoPath={selectedRepoPath}
-                  sessionId={sessionId}
                 />
               </div>
               {/* Commit Box */}
@@ -1061,7 +1058,6 @@ export function SourceControlPanel({
                 onNextFile={handleNextCommitFile}
                 hasPrevFile={currentCommitFileIndex > 0}
                 hasNextFile={currentCommitFileIndex < commitFiles.length - 1}
-                sessionId={sessionId}
               />
             </div>
           ) : selectedSubmoduleFile && rootPath ? (
@@ -1072,7 +1068,6 @@ export function SourceControlPanel({
                 diff={submoduleFileDiff ?? undefined}
                 skipFetch={true}
                 isActive={isActive}
-                sessionId={sessionId}
               />
             </div>
           ) : (
@@ -1085,7 +1080,6 @@ export function SourceControlPanel({
                 onNextFile={handleNextFile}
                 hasPrevFile={currentFileIndex > 0}
                 hasNextFile={currentFileIndex < allFiles.length - 1}
-                sessionId={sessionId}
               />
             </div>
           )}

--- a/src/renderer/stores/agentSessions.ts
+++ b/src/renderer/stores/agentSessions.ts
@@ -511,6 +511,25 @@ export const useAgentSessionsStore = create<AgentSessionsState>()(
   }))
 );
 
+/**
+ * Selector hook: get active session ID for a given worktree path.
+ * Falls back to the first session under that cwd.
+ */
+export function useActiveSessionId(cwd: string | undefined | null): string | null {
+  return useAgentSessionsStore((state) => {
+    if (!cwd) return null;
+    const key = normalizePath(cwd);
+    const activeId = state.activeIds[key];
+    if (activeId) {
+      const session = state.sessions.find((s) => s.id === activeId);
+      if (session) return activeId;
+    }
+    // Fallback to first session for this cwd
+    const first = state.sessions.find((s) => normalizePath(s.cwd) === key);
+    return first?.id ?? null;
+  });
+}
+
 // Subscribe to state changes and persist to localStorage
 useAgentSessionsStore.subscribe(
   (state) => ({ sessions: state.sessions, activeIds: state.activeIds }),


### PR DESCRIPTION
## Summary
- 新增 `useActiveSessionId(cwd)` selector hook，从 `useAgentSessionsStore` 直接读取 sessionId
- 消除 12 个组件间的 `sessionId` 逐层透传（prop drilling）
- 末端消费组件（EditorArea、EditorLineComment、DiffViewer、DiffReviewModal、CodeReviewModal、FilePanel）改为内部调用 hook
- 中间组件（CurrentFilePanel、SourceControlPanel、ChangesList、CommitDiffViewer）移除 sessionId 透传
- 保留 `!sessionId` 守卫逻辑，没有 session 时不展示 comment 功能

## Test plan
- [ ] 打开编辑器，选择代码 → 有 session 时 "Add comment" 按钮正常出现
- [ ] 有 session 时提交评论 → 正常发送到终端
- [ ] 无 session 时 → comment 按钮不显示
- [ ] 审查模式(DiffReviewModal)中选择代码 → 按钮正常
- [ ] DiffViewer 中选择代码 → 按钮正常
- [ ] CodeReviewModal "Send to Current Session" 功能正常
- [ ] TypeScript 编译通过（无新增错误）

🤖 Generated with [Claude Code](https://claude.com/claude-code)