### PR TITLE
fix(terminal): 优化分屏终端下快捷键处理逻辑

### DIFF
--- a/src/renderer/components/terminal/ShellTerminal.tsx
+++ b/src/renderer/components/terminal/ShellTerminal.tsx
@@ -3,7 +3,6 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { useTerminalScrollToBottom } from '@/hooks/useTerminalScrollToBottom';
 import { useXterm } from '@/hooks/useXterm';
 import { useI18n } from '@/i18n';
-import { matchesKeybinding } from '@/lib/keybinding';
 import { useSettingsStore } from '@/stores/settings';
 import { TerminalSearchBar, type TerminalSearchBarRef } from './TerminalSearchBar';
 
@@ -67,7 +66,7 @@ export function ShellTerminal({
   });
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const searchBarRef = useRef<TerminalSearchBarRef>(null);
-  const xtermKeybindings = useSettingsStore((state) => state.xtermKeybindings);
+  const _xtermKeybindings = useSettingsStore((state) => state.xtermKeybindings);
   const { showScrollToBottom, handleScrollToBottom } = useTerminalScrollToBottom(terminal);
 
   // Handle keyboard shortcuts
@@ -83,14 +82,8 @@ export function ShellTerminal({
         }
         return;
       }
-
-      if (matchesKeybinding(e, xtermKeybindings.clear)) {
-        e.preventDefault();
-        clear();
-        return;
-      }
     },
-    [isSearchOpen, xtermKeybindings, clear]
+    [isSearchOpen]
   );
 
   // Handle right-click context menu

--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -925,6 +925,15 @@ export function TerminalPanel({ repoPath, cwd, isActive = false }: TerminalPanel
                       left: `${position.left}%`,
                       width: `${position.width}%`,
                     }}
+                    role="button"
+                    tabIndex={0}
+                    onClick={() => handleGroupClick(info.group.id)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        handleGroupClick(info.group.id);
+                      }
+                    }}
                   >
                     <ShellTerminal
                       cwd={info.tab.cwd}

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -170,6 +170,9 @@ export function useXterm({
   const [isLoading, setIsLoading] = useState(false);
   const hasReceivedDataRef = useRef(false);
   const initialCommandRef = useRef(initialCommand);
+  // Track if this terminal should respond to global shortcuts
+  const isActiveRef = useRef(isActive);
+  isActiveRef.current = isActive;
   // Memoize command key to avoid dependency array issues
   const commandKey = useMemo(
     () =>
@@ -461,13 +464,21 @@ export function useXterm({
         return true;
       }
 
+      // Only respond to tab/clear shortcuts when this terminal is active
+      const shouldHandleShortcuts = isActiveRef.current;
       if (
         matchesKeybinding(event, settings.xtermKeybindings.newTab) ||
         matchesKeybinding(event, settings.xtermKeybindings.closeTab) ||
         matchesKeybinding(event, settings.xtermKeybindings.nextTab) ||
-        matchesKeybinding(event, settings.xtermKeybindings.prevTab) ||
-        matchesKeybinding(event, settings.xtermKeybindings.clear)
+        matchesKeybinding(event, settings.xtermKeybindings.prevTab)
       ) {
+        return false;
+      }
+      // Handle clear directly here, only when active
+      if (shouldHandleShortcuts && matchesKeybinding(event, settings.xtermKeybindings.clear)) {
+        if (event.type === 'keydown') {
+          terminal.clear();
+        }
         return false;
       }
       if (event.type === 'keydown') {

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -262,7 +262,7 @@ export const defaultXtermKeybindings: XtermKeybindings = {
   prevTab: { key: '[', meta: true },
   split: { key: 'd', meta: true },
   merge: { key: 'd', meta: true, shift: true },
-  clear: { key: 'r', meta: true },
+  clear: { key: 'k', meta: true },
 };
 
 export const defaultMainTabKeybindings: MainTabKeybindings = {


### PR DESCRIPTION
## 摘要

- 将 clear 快捷键从 `Cmd+R` 改为 `Cmd+K`，避免与浏览器刷新快捷键冲突
- clear 快捷键仅在终端激活时响应，防止误触影响非活动终端
- 移除 `ShellTerminal` 中重复的 clear 处理逻辑
- 修复终端分组点击事件并添加键盘无障碍支持

## 测试计划

- [x] 验证 `Cmd+K` 可以清空活动终端
- [x] 验证快捷键不会影响非活动终端
- [x] 验证终端分组可以通过点击或键盘（Enter/Space）激活
- [x] 确认 `Cmd+R` 恢复浏览器默认行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)