### PR TITLE
fix(agent): 修复从存储恢复时 activeSessionId 未正确同步的问题

### DIFF
--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -1308,10 +1308,17 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
     // If no groups exist but sessions do, create a group with all sessions
     if (!currentState || currentState.groups.length === 0) {
       const sessionIds = currentWorktreeSessions.map((s) => s.id);
+
+      // Get the active session ID from store (if set) or fallback to first session
+      const storeActiveId = useAgentSessionsStore.getState().activeIds[normalizedCwd];
+      const validActiveId = sessionIds.includes(storeActiveId || '')
+        ? storeActiveId
+        : sessionIds[0];
+
       const newGroup: AgentGroupType = {
         id: crypto.randomUUID(),
         sessionIds,
-        activeSessionId: sessionIds[0] || null,
+        activeSessionId: validActiveId || null,
       };
       setGroupState(cwd, {
         groups: [newGroup],


### PR DESCRIPTION
## 问题

当用户刷新页面或重启应用后，从 localStorage 恢复的 agent sessions 无法正确获取到活跃的 sessionId，导致：

- UI 显示错误的活跃 session
- `getCurrentActiveSessionId()` 返回错误值
- 某些依赖 sessionId 的功能无法正常工作

## 根因

在 `AgentPanel.tsx` 的 "Sync sessions to groups on initial load" effect 中，创建 group 时直接使用 `sessionIds[0]` 作为 `activeSessionId`，忽略了 store 中已持久化的 `activeIds`。

## 修复

- 在创建 group 时从 store 的 `activeIds` 读取活跃 session ID
- 验证该 session ID 是否存在于当前 `sessionIds` 中
- 如果无效则回退到第一个 session

## 测试

1. 创建多个 agent sessions
2. 切换到非第一个 session
3. 刷新页面
4. 确认活跃 session 保持不变

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)