### PR TITLE
fix: 修复应用关闭后出现异常退出提示的问题

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -653,14 +653,21 @@ app.on('will-quit', (event) => {
   unwatchClaudeSettings();
   gitAutoFetchService.cleanup();
 
+  // Guard against double-cleanup: sync cleanup in the force-exit path must be
+  // skipped if async cleanup already finished, otherwise both paths would
+  // concurrently tear down node-pty native resources and cause a crash.
+  let asyncCleanupDone = false;
+
   const forceExitTimer = setTimeout(() => {
     console.error('[app] Cleanup timed out, forcing exit');
-    // Best-effort: kill native resources synchronously before forcing exit to
-    // avoid deadlocking during Node addon cleanup (e.g. node-pty on macOS).
-    try {
-      cleanupAllResourcesSync();
-    } catch (err) {
-      console.error('[app] Sync cleanup error:', err);
+    if (!asyncCleanupDone) {
+      // Async cleanup is still running — kill native resources synchronously
+      // before Node starts tearing down addons to avoid a deadlock/crash.
+      try {
+        cleanupAllResourcesSync();
+      } catch (err) {
+        console.error('[app] Sync cleanup error:', err);
+      }
     }
     app.exit(0);
   }, FORCE_EXIT_TIMEOUT_MS);
@@ -668,6 +675,7 @@ app.on('will-quit', (event) => {
   cleanupAllResources()
     .catch((err) => console.error('[app] Cleanup error:', err))
     .finally(() => {
+      asyncCleanupDone = true;
       clearTimeout(forceExitTimer);
       app.exit(0);
     });

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -68,84 +68,61 @@ export function registerIpcHandlers(): void {
 }
 
 export async function cleanupAllResources(): Promise<void> {
-  const CLEANUP_TIMEOUT = 3000;
+  // Single global deadline well within FORCE_EXIT_TIMEOUT_MS (8000ms).
+  // Previous approach ran steps serially with per-step 3000ms timeouts, which
+  // could stack up to ~15s total — triggering the force-exit while async cleanup
+  // was still running and causing double-cleanup of node-pty native resources.
+  const TOTAL_ASYNC_TIMEOUT = 5500;
+  const deadline = new Promise<void>((resolve) => setTimeout(resolve, TOTAL_ASYNC_TIMEOUT));
 
-  // Ensure any in-flight execInPty commands are terminated before Node shutdown.
-  // Leaving node-pty PTYs alive can deadlock native addon cleanup on macOS.
-  await cleanupExecInPtys(CLEANUP_TIMEOUT);
+  const safeRun = async (fn: () => Promise<void>, label: string): Promise<void> => {
+    try {
+      await fn();
+    } catch (err) {
+      console.warn(`[cleanup] ${label} warning:`, err);
+    }
+  };
 
-  // Stop Hapi server first (graceful best-effort with timeout)
-  await cleanupHapi(CLEANUP_TIMEOUT);
+  // Run all independent async cleanup steps in parallel, bounded by a single deadline.
+  await Promise.race([
+    Promise.allSettled([
+      // node-pty PTYs used by short-lived commands (exec-in-pty pool)
+      safeRun(() => cleanupExecInPtys(4000), 'execInPty'),
+      // Hapi server + runner + cloudflared
+      safeRun(() => cleanupHapi(4000), 'hapi'),
+      // Interactive terminal PTY sessions
+      safeRun(async () => {
+        try {
+          await destroyAllTerminalsAndWait();
+        } catch (err) {
+          console.warn('[cleanup] terminals warning:', err);
+          // Fallback: force-kill without waiting
+          destroyAllTerminals();
+        }
+      }, 'terminals'),
+      // File system watchers
+      safeRun(() => stopAllFileWatchers(), 'fileWatchers'),
+      // Claude completions file watcher
+      safeRun(() => stopClaudeCompletionsWatchers(), 'claudeCompletions'),
+      // Temp files
+      safeRun(() => cleanupTempFiles(), 'tempFiles'),
+    ]),
+    deadline,
+  ]);
 
-  // Kill tmux enso server (sync, best-effort). Avoid spawning new PTYs during shutdown.
+  // Fast synchronous cleanup (runs after async steps or deadline)
   try {
     cleanupTmuxSync();
   } catch (err) {
-    console.warn('Tmux cleanup warning:', err);
+    console.warn('[cleanup] tmux warning:', err);
   }
-
-  // Stop Web Inspector server (sync, fast)
   webInspectorServer.stop();
-
-  // Stop all code review processes (sync, fast)
   stopAllCodeReviews();
-
-  // Destroy all PTY sessions and wait for them to exit
-  // This prevents crashes when PTY exit callbacks fire during Node cleanup
-  try {
-    await Promise.race([
-      destroyAllTerminalsAndWait(),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('Terminal cleanup timeout')), CLEANUP_TIMEOUT)
-      ),
-    ]);
-  } catch (err) {
-    console.warn('Terminal cleanup warning:', err);
-    // Force destroy without waiting as fallback
-    destroyAllTerminals();
-  }
-
-  // Stop file watchers with timeout to prevent hanging
-  try {
-    await Promise.race([
-      stopAllFileWatchers(),
-      new Promise((_, reject) =>
-        setTimeout(() => reject(new Error('File watcher cleanup timeout')), CLEANUP_TIMEOUT)
-      ),
-    ]);
-  } catch (err) {
-    console.warn('File watcher cleanup warning:', err);
-  }
-
-  // Stop Claude completions watcher (best-effort)
-  try {
-    await Promise.race([
-      stopClaudeCompletionsWatchers(),
-      new Promise((_, reject) =>
-        setTimeout(
-          () => reject(new Error('Claude completions watcher cleanup timeout')),
-          CLEANUP_TIMEOUT
-        )
-      ),
-    ]);
-  } catch (err) {
-    console.warn('Claude completions watcher cleanup warning:', err);
-  }
-
-  // Clear service caches (sync, fast)
   clearAllGitServices();
   clearAllWorktreeServices();
-
   autoUpdaterService.cleanup();
-
-  // Dispose Claude IDE Bridge
   disposeClaudeIdeBridge();
-
-  // Close Todo database
   cleanupTodo();
-
-  // Clean up temp files
-  await cleanupTempFiles();
 }
 
 /**


### PR DESCRIPTION
## 问题描述

应用关闭后几秒钟，macOS 会弹出"应用程序意外退出"的提示。

## 根本原因

### 竞态条件：串行清理总耗时超出强制退出阈值

`cleanupAllResources()` 中有 5 个异步步骤**串行**执行，每步独立拥有 3000ms 超时：

| 步骤 | 最大耗时 |
|------|---------|
| `cleanupExecInPtys` | 3000ms |
| `cleanupHapi` | 3000ms |
| `destroyAllTerminalsAndWait` | 3000ms |
| `stopAllFileWatchers` | 3000ms |
| `stopClaudeCompletionsWatchers` | 3000ms |
| **总计** | **最多 15000ms** |

但 `FORCE_EXIT_TIMEOUT_MS = 8000ms`，因此强制退出会在异步清理仍在运行时触发，导致：

1. `cleanupAllResourcesSync()` 强制同步 kill 所有 PTY
2. `app.exit(0)` 触发 Node.js native addon 析构
3. 异步 `cleanupAllResources()` 仍在运行，继续操作已被销毁的 node-pty native 对象
4. **SIGSEGV/SIGABRT → macOS 报告"异常退出"**

## 修复方案

### 1. `src/main/ipc/index.ts` — 并行清理 + 单一全局截止时间

将串行步骤改为 `Promise.allSettled` 并行执行，统一受 **5500ms** 全局截止时间约束，确保总耗时远低于 8000ms 阈值。

### 2. `src/main/index.ts` — 防止双重清理

添加 `asyncCleanupDone` 标志：异步清理正常完成后，强制退出路径跳过 `cleanupAllResourcesSync()`，消除两条路径并发操作同一 node-pty native 资源的竞态条件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)