### PR TITLE
fix(worktree): Windows Permission denied 删除 worktree 时的兜底处理

### DIFF
--- a/src/main/services/git/WorktreeService.ts
+++ b/src/main/services/git/WorktreeService.ts
@@ -89,6 +89,20 @@ export class WorktreeService {
   }
 
   /**
+   * Force delete a directory by killing locking processes and using system-level removal
+   */
+  private async forceDeleteDirectory(dirPath: string): Promise<void> {
+    await killProcessesInDirectory(dirPath);
+    // Wait briefly for processes to release file handles
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    if (process.platform === 'win32') {
+      await execAsync(`rmdir /s /q "${dirPath}"`);
+    } else {
+      await rm(dirPath, { recursive: true, force: true });
+    }
+  }
+
+  /**
    * Safely delete a worktree and optionally its branch
    */
   private async deleteWorktreeSafely(
@@ -108,15 +122,8 @@ export class WorktreeService {
 
       // On Windows, locked files cause "Permission denied" — fall back to force removal
       if (msg.includes('Permission denied') && existsSync(worktreePath)) {
-        await killProcessesInDirectory(worktreePath);
-        // Wait briefly for processes to release file handles
-        await new Promise((resolve) => setTimeout(resolve, 500));
         try {
-          if (process.platform === 'win32') {
-            await execAsync(`rmdir /s /q "${worktreePath}"`);
-          } else {
-            await rm(worktreePath, { recursive: true, force: true });
-          }
+          await this.forceDeleteDirectory(worktreePath);
           // Clean up the stale worktree entry from git's registry
           await git.raw(['worktree', 'prune']);
           worktreeDeleted = true;
@@ -227,19 +234,8 @@ export class WorktreeService {
       if (isPermissionDenied || isNotWorktree) {
         // Try to clean up the directory manually
         if (existsSync(options.path)) {
-          // First attempt: try to kill processes using the directory
-          await killProcessesInDirectory(options.path);
-
-          // Wait a bit for processes to terminate
-          await new Promise((resolve) => setTimeout(resolve, 500));
-
           try {
-            if (process.platform === 'win32') {
-              // Use Windows rmdir which can be more effective for locked files
-              await execAsync(`rmdir /s /q "${options.path}"`);
-            } else {
-              await rm(options.path, { recursive: true, force: true });
-            }
+            await this.forceDeleteDirectory(options.path);
           } catch {
             // If manual deletion also fails, throw a more helpful error
             throw new Error(


### PR DESCRIPTION
## 摘要

修复 Windows 上合并 worktree 后删除时经常出现 "Permission denied" 错误的问题。

## 问题分析

`deleteWorktreeSafely()` 方法在删除 worktree 时，如果 `git worktree remove --force` 因文件被锁定而失败，会直接把错误降级为警告返回，没有任何兜底机制。

在 Windows 上，这个场景很常见：
- worktree 目录下有终端/命令行仍在运行
- VS Code、资源管理器等程序正在访问该目录
- node_modules 下的文件被进程占用

## 解决方案

添加与 `remove()` 方法相同的 Windows 兜底逻辑：

1. **检测 Permission denied 错误**：识别文件锁问题
2. **杀进程**：调用 `killProcessesInDirectory()` 终止占用目录的进程
3. **等待释放**：延迟 500ms 让文件句柄释放
4. **强制删除**：
   - Windows：使用 `rmdir /s /q` 命令
   - Unix：使用 `rm -rf` 命令
5. **清理索引**：执行 `git worktree prune` 移除 stale 记录

## 变更内容

- 在 `deleteWorktreeSafely()` 中添加 Permission denied 异常处理
- 跳过兜底删除的分支删除逻辑合并，简化代码流程
- 添加 `worktreeDeleted` 标志追踪删除状态

## 测试方案

### Windows 手动测试（推荐）
1. 启动应用，创建 worktree
2. 在 worktree 目录下打开终端（制造文件锁）
3. 合并该 worktree，勾选"合并后删除"
4. **修复前**：出现 "Permission denied" 警告
5. **修复后**：正常删除，无警告

### 代码逻辑验证
| 场景 | 修复前 | 修复后 |
|---|---|---|
| `git worktree remove` 成功 | 删分支 ✅ | 删分支 ✅ |
| Permission denied（文件锁） | 警告 + 跳过删分支 ❌ | 杀进程 + 强制删除 + 删分支 ✅ |
| 兜底也失败 | — | 警告（安全降级） ✅ |
| 其他错误 | 警告 ✅ | 警告 ✅ |

## 相关 Issue

Closes #183