### PR TITLE
feat(todo): 任务卡片启动 Agent 时自动发送任务内容 & 新建待办支持 AI 润色

### DIFF
--- a/src/main/ipc/todo.ts
+++ b/src/main/ipc/todo.ts
@@ -1,5 +1,7 @@
 import { IPC_CHANNELS } from '@shared/types';
 import { ipcMain } from 'electron';
+import type { AIProvider, ModelId, ReasoningEffort } from '../services/ai';
+import { polishTodoTask } from '../services/ai';
 import * as todoService from '../services/todo/TodoService';
 
 let readyPromise: Promise<void>;
@@ -78,6 +80,30 @@ export function registerTodoHandlers(): void {
     await ensureReady();
     return todoService.migrateFromLocalStorage(boardsJson);
   });
+
+  ipcMain.handle(
+    IPC_CHANNELS.TODO_AI_POLISH,
+    async (
+      _,
+      options: {
+        text: string;
+        timeout: number;
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+        prompt?: string;
+      }
+    ): Promise<{ success: boolean; title?: string; description?: string; error?: string }> => {
+      return polishTodoTask({
+        text: options.text,
+        timeout: options.timeout,
+        provider: (options.provider ?? 'claude-code') as AIProvider,
+        model: options.model as ModelId,
+        reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        prompt: options.prompt,
+      });
+    }
+  );
 }
 
 export function cleanupTodo(): void {

--- a/src/main/services/ai/index.ts
+++ b/src/main/services/ai/index.ts
@@ -11,3 +11,8 @@ export {
   generateCommitMessage,
 } from './commit-message';
 export type { AIProvider, ModelId, ReasoningEffort } from './providers';
+export {
+  polishTodoTask,
+  type TodoPolishOptions,
+  type TodoPolishResult,
+} from './todo-polish';

--- a/src/main/services/ai/todo-polish.ts
+++ b/src/main/services/ai/todo-polish.ts
@@ -73,7 +73,7 @@ Raw requirement:
 {text}`;
 
   const promptTemplate = customPrompt || defaultPrompt;
-  const prompt = promptTemplate.replace(/\{text\}/g, text);
+  const prompt = promptTemplate.replace(/\{text\}/g, () => text);
 
   return new Promise((resolve) => {
     const timeoutMs = timeout * 1000;

--- a/src/main/services/ai/todo-polish.ts
+++ b/src/main/services/ai/todo-polish.ts
@@ -91,8 +91,10 @@ Raw requirement:
 
     let stdout = '';
     let stderr = '';
+    let settled = false;
 
     const timer = setTimeout(() => {
+      settled = true;
       kill();
       resolve({ success: false, error: 'timeout' });
     }, timeoutMs);
@@ -107,6 +109,8 @@ Raw requirement:
 
     proc.on('close', (code) => {
       clearTimeout(timer);
+      if (settled) return;
+      settled = true;
 
       if (code !== 0) {
         console.error(`[todo-polish] Exit code: ${code}, stderr: ${stderr}`);
@@ -131,6 +135,8 @@ Raw requirement:
 
     proc.on('error', (err) => {
       clearTimeout(timer);
+      if (settled) return;
+      settled = true;
       console.error(`[todo-polish] Process error:`, err);
       resolve({ success: false, error: err.message });
     });

--- a/src/main/services/ai/todo-polish.ts
+++ b/src/main/services/ai/todo-polish.ts
@@ -1,0 +1,138 @@
+import type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
+import { parseCLIOutput, spawnCLI } from './providers';
+
+export interface TodoPolishOptions {
+  text: string; // Raw requirement text to polish
+  timeout: number; // in seconds
+  provider: AIProvider;
+  model: ModelId;
+  reasoningEffort?: ReasoningEffort;
+  prompt?: string; // Custom prompt template (with {text} placeholder)
+}
+
+export interface TodoPolishResult {
+  success: boolean;
+  title?: string;
+  description?: string;
+  error?: string;
+}
+
+/** Strip markdown code fence from AI output */
+function stripCodeFence(text: string): string {
+  const trimmed = text.trim();
+  const fenceMatch = trimmed.match(/```\w*\s*[\r\n]+([\s\S]*?)[\r\n]+\s*```\s*$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  return trimmed
+    .replace(/^```\w*\s*[\r\n]*/, '')
+    .replace(/[\r\n]*\s*```\s*$/, '')
+    .trim();
+}
+
+/** Parse JSON output from AI (expects { title, description } format) */
+function parsePolishOutput(raw: string): { title: string; description: string } | null {
+  const cleaned = stripCodeFence(raw);
+
+  // Try direct JSON parse
+  try {
+    const parsed = JSON.parse(cleaned);
+    if (parsed && typeof parsed.title === 'string' && typeof parsed.description === 'string') {
+      return { title: parsed.title.trim(), description: parsed.description.trim() };
+    }
+  } catch {
+    // Try extracting JSON from text
+    const jsonMatch = cleaned.match(/\{[\s\S]*?"title"[\s\S]*?"description"[\s\S]*?\}/);
+    if (jsonMatch) {
+      try {
+        const parsed = JSON.parse(jsonMatch[0]);
+        if (parsed && typeof parsed.title === 'string' && typeof parsed.description === 'string') {
+          return { title: parsed.title.trim(), description: parsed.description.trim() };
+        }
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  return null;
+}
+
+export async function polishTodoTask(options: TodoPolishOptions): Promise<TodoPolishResult> {
+  const { text, timeout, provider, model, reasoningEffort, prompt: customPrompt } = options;
+
+  const defaultPrompt = `You are a task management assistant. Convert the following raw requirement text into a structured todo task.
+
+Output a JSON object with exactly two fields:
+- "title": A concise, action-oriented title (max 60 characters)
+- "description": A clear, detailed description that is AI-agent-friendly. Include context, acceptance criteria, and any technical details from the input. Write it so an AI coding agent can understand and execute the task directly.
+
+Important: Output ONLY the JSON object, no explanation, no markdown fences.
+
+Raw requirement:
+{text}`;
+
+  const promptTemplate = customPrompt || defaultPrompt;
+  const prompt = promptTemplate.replace(/\{text\}/g, text);
+
+  return new Promise((resolve) => {
+    const timeoutMs = timeout * 1000;
+
+    console.log(`[todo-polish] Starting with provider=${provider}, model=${model}`);
+
+    const { proc, kill } = spawnCLI({
+      provider,
+      model,
+      prompt,
+      cwd: process.cwd(),
+      reasoningEffort,
+      outputFormat: 'json',
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    const timer = setTimeout(() => {
+      kill();
+      resolve({ success: false, error: 'timeout' });
+    }, timeoutMs);
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+
+      if (code !== 0) {
+        console.error(`[todo-polish] Exit code: ${code}, stderr: ${stderr}`);
+        resolve({ success: false, error: stderr || `Exit code: ${code}` });
+        return;
+      }
+
+      const result = parseCLIOutput(provider, stdout);
+      console.log(`[todo-polish] Parse result:`, result);
+
+      if (result.success && result.text) {
+        const parsed = parsePolishOutput(result.text);
+        if (parsed) {
+          resolve({ success: true, title: parsed.title, description: parsed.description });
+        } else {
+          resolve({ success: false, error: 'Failed to parse AI output as JSON' });
+        }
+      } else {
+        resolve({ success: false, error: result.error || 'Unknown error' });
+      }
+    });
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      console.error(`[todo-polish] Process error:`, err);
+      resolve({ success: false, error: err.message });
+    });
+  });
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -550,6 +550,15 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.TODO_REORDER_TASKS, repoPath, status, orderedIds),
     migrate: (boardsJson: string): Promise<void> =>
       ipcRenderer.invoke(IPC_CHANNELS.TODO_MIGRATE, boardsJson),
+    aiPolish: (options: {
+      text: string;
+      timeout: number;
+      provider: string;
+      model: string;
+      reasoningEffort?: string;
+      prompt?: string;
+    }): Promise<{ success: boolean; title?: string; description?: string; error?: string }> =>
+      ipcRenderer.invoke(IPC_CHANNELS.TODO_AI_POLISH, options),
   },
 
   // Environment

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -23,6 +23,7 @@ import { initAgentStatusListener } from '@/stores/agentStatus';
 import { useCodeReviewContinueStore } from '@/stores/codeReviewContinue';
 import { BUILTIN_AGENT_IDS, useSettingsStore } from '@/stores/settings';
 import { useTerminalStore } from '@/stores/terminal';
+import { useTerminalWriteStore } from '@/stores/terminalWrite';
 import { useWorktreeActivityStore } from '@/stores/worktreeActivity';
 import { AgentGroup } from './AgentGroup';
 import { AgentTerminal } from './AgentTerminal';
@@ -939,9 +940,32 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
 
   const handleInitialized = useCallback(
     (id: string) => {
+      const session = allSessions.find((s) => s.id === id);
+      if (!session) return;
+
+      // Update initialized state
       updateSession(id, { initialized: true });
+
+      // Send pending command if exists (from todo task launch)
+      if (session.pendingCommand) {
+        const write = useTerminalWriteStore.getState().write;
+        if (write) {
+          const command = session.pendingCommand;
+          // Use bracketed paste mode for multi-line content
+          if (command.includes('\n')) {
+            write(id, `\x1b[200~${command}\x1b[201~`);
+          } else {
+            write(id, command);
+          }
+          // Send Enter after a short delay
+          setTimeout(() => write(id, '\r'), 100);
+
+          // Clear pending command after sending
+          updateSession(id, { pendingCommand: undefined });
+        }
+      }
     },
-    [updateSession]
+    [allSessions, updateSession]
   );
 
   const handleActivated = useCallback(

--- a/src/renderer/components/chat/SessionBar.tsx
+++ b/src/renderer/components/chat/SessionBar.tsx
@@ -45,6 +45,7 @@ export interface Session {
   displayOrder?: number; // order in SessionBar (lower = first), used for drag reorder
   terminalTitle?: string; // current terminal title from OSC escape sequence
   userRenamed?: boolean; // true when user has manually renamed this session
+  pendingCommand?: string; // command to send after agent is ready (e.g., from todo task)
 }
 
 interface SessionBarProps {

--- a/src/renderer/components/settings/AISettings.tsx
+++ b/src/renderer/components/settings/AISettings.tsx
@@ -804,6 +804,29 @@ export function AISettings() {
               </div>
             )}
 
+            {/* Timeout */}
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Timeout')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={String(todoPolish.timeout)}
+                  onValueChange={(v) => setTodoPolish({ timeout: Number(v) })}
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue>{todoPolish.timeout}s</SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {[30, 60, 120, 180].map((sec) => (
+                      <SelectItem key={sec} value={String(sec)}>
+                        {sec}s
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">{t('Timeout in seconds')}</p>
+              </div>
+            </div>
+
             {/* Prompt */}
             <div className="space-y-1.5">
               <span className="text-sm font-medium">{t('Prompt')}</span>

--- a/src/renderer/components/settings/AISettings.tsx
+++ b/src/renderer/components/settings/AISettings.tsx
@@ -16,6 +16,8 @@ import {
   defaultCodeReviewPromptZh,
   defaultCommitPromptEn,
   defaultCommitPromptZh,
+  defaultTodoPolishPromptEn,
+  defaultTodoPolishPromptZh,
   type ReasoningEffort,
   useSettingsStore,
   validateCodeReviewPrompt,
@@ -78,6 +80,8 @@ export function AISettings() {
     setCodeReview,
     branchNameGenerator,
     setBranchNameGenerator,
+    todoPolish,
+    setTodoPolish,
   } = useSettingsStore();
 
   // Validation state for code review prompt
@@ -118,6 +122,13 @@ export function AISettings() {
 
   const handleBranchProviderChange = (provider: AIProvider) => {
     setBranchNameGenerator({
+      provider,
+      model: getDefaultModel(provider),
+    });
+  };
+
+  const handleTodoPolishProviderChange = (provider: AIProvider) => {
+    setTodoPolish({
       provider,
       model: getDefaultModel(provider),
     });
@@ -667,6 +678,161 @@ export function AISettings() {
                       ) {
                         setBranchNameGenerator({
                           prompt: defaultBranchNameGeneratorSettings.prompt,
+                        });
+                      }
+                    }}
+                    className="text-xs text-muted-foreground hover:text-primary underline"
+                  >
+                    {t('Restore default prompt')}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Todo AI Polish Section */}
+      <div className="border-t pt-6">
+        <div>
+          <h4 className="text-base font-medium">{t('Todo AI Polish')}</h4>
+          <p className="text-sm text-muted-foreground">
+            {t('Use AI to generate a title and description from raw requirement text')}
+          </p>
+        </div>
+
+        <div className="mt-4 flex items-center justify-between">
+          <div className="space-y-0.5">
+            <span className="text-sm font-medium">{t('Enable AI Polish')}</span>
+            <p className="text-xs text-muted-foreground">
+              {t('Show AI polish button when creating or editing tasks')}
+            </p>
+          </div>
+          <Switch
+            checked={todoPolish.enabled}
+            onCheckedChange={(checked) => setTodoPolish({ enabled: checked })}
+          />
+        </div>
+
+        {todoPolish.enabled && (
+          <div className="mt-4 space-y-4 border-t pt-4">
+            {/* Provider */}
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Provider')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={todoPolish.provider ?? 'claude-code'}
+                  onValueChange={(v) => handleTodoPolishProviderChange(v as AIProvider)}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue>
+                      {PROVIDERS.find((p) => p.value === todoPolish.provider)?.label ??
+                        'Claude Code'}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {PROVIDERS.map((p) => (
+                      <SelectItem key={p.value} value={p.value}>
+                        {p.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">{t('AI provider to use')}</p>
+              </div>
+            </div>
+
+            {/* Model */}
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Model')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={todoPolish.model}
+                  onValueChange={(v) => v && setTodoPolish({ model: v })}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue>
+                      {MODELS_BY_PROVIDER[todoPolish.provider ?? 'claude-code']?.find(
+                        (m) => m.value === todoPolish.model
+                      )?.label ?? todoPolish.model}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {MODELS_BY_PROVIDER[todoPolish.provider ?? 'claude-code']?.map((m) => (
+                      <SelectItem key={m.value} value={m.value}>
+                        {m.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {t('Model for polishing task content')}
+                </p>
+              </div>
+            </div>
+
+            {/* Reasoning Level - Only for Codex CLI */}
+            {todoPolish.provider === 'codex-cli' && (
+              <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+                <span className="text-sm font-medium">{t('Reasoning Level')}</span>
+                <div className="space-y-1.5">
+                  <Select
+                    value={todoPolish.reasoningEffort ?? 'medium'}
+                    onValueChange={(v) =>
+                      v && setTodoPolish({ reasoningEffort: v as ReasoningEffort })
+                    }
+                  >
+                    <SelectTrigger className="w-40">
+                      <SelectValue>
+                        {REASONING_EFFORTS.find(
+                          (r) => r.value === (todoPolish.reasoningEffort ?? 'medium')
+                        )?.label ?? 'Medium'}
+                      </SelectValue>
+                    </SelectTrigger>
+                    <SelectPopup>
+                      {REASONING_EFFORTS.map((r) => (
+                        <SelectItem key={r.value} value={r.value}>
+                          {r.label}
+                        </SelectItem>
+                      ))}
+                    </SelectPopup>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {t('Reasoning depth for Codex CLI')}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {/* Prompt */}
+            <div className="space-y-1.5">
+              <span className="text-sm font-medium">{t('Prompt')}</span>
+              <div className="space-y-1.5">
+                <textarea
+                  value={todoPolish.prompt}
+                  onChange={(e) => setTodoPolish({ prompt: e.target.value })}
+                  className="w-full h-40 rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                  placeholder={t(
+                    'Enter a prompt template.\nAvailable variables:\n• {text} - Raw requirement text'
+                  )}
+                />
+                <div className="flex items-center justify-between">
+                  <p className="text-xs text-muted-foreground">
+                    {t('Customize the AI prompt for polishing tasks')}
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (
+                        window.confirm(
+                          t(
+                            'This will restore the default AI prompt for todo polish. Your custom prompt will be lost.'
+                          )
+                        )
+                      ) {
+                        setTodoPolish({
+                          prompt:
+                            locale === 'zh' ? defaultTodoPolishPromptZh : defaultTodoPolishPromptEn,
                         });
                       }
                     }}

--- a/src/renderer/components/todo/TaskCard.tsx
+++ b/src/renderer/components/todo/TaskCard.tsx
@@ -3,6 +3,7 @@ import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Pencil, Play, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { normalizePath } from '@/App/storage';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
 import { useAgentSessionsStore } from '@/stores/agentSessions';
@@ -69,8 +70,10 @@ export function TaskCard({
     const handleClick = (e: MouseEvent) => {
       const target = e.target as Node;
       if (
-        menuRef.current && !menuRef.current.contains(target) &&
-        portalRef.current && !portalRef.current.contains(target)
+        menuRef.current &&
+        !menuRef.current.contains(target) &&
+        portalRef.current &&
+        !portalRef.current.contains(target)
       ) {
         setShowAgentMenu(false);
       }
@@ -93,28 +96,48 @@ export function TaskCard({
     (agent: ResolvedAgent) => {
       if (!worktreePath) return;
 
-      const { addSession, setEnhancedInputContent, setEnhancedInputOpen } =
-        useAgentSessionsStore.getState();
-
       const id = crypto.randomUUID();
-      addSession({
-        id,
-        sessionId: id,
-        name: `Task: ${task.title}`,
-        agentId: agent.agentId,
-        agentCommand: agent.command,
-        customPath: agent.customPath,
-        customArgs: agent.customArgs,
-        initialized: false,
-        repoPath,
-        cwd: worktreePath,
-        environment: agent.environment,
-      });
+      // Build task context for sending to agent
+      const taskContext = task.description ? `${task.title}\n\n${task.description}` : task.title;
 
-      // Pre-fill task context into enhanced input
-      const context = task.description ? `${task.title}\n\n${task.description}` : task.title;
-      setEnhancedInputContent(id, context);
-      setEnhancedInputOpen(id, true);
+      // Use setState callback to ensure all updates happen in the same batch
+      useAgentSessionsStore.setState((state) => {
+        // Calculate displayOrder: max order in same worktree + 1
+        const worktreeSessions = state.sessions.filter(
+          (s) => s.repoPath === repoPath && s.cwd === worktreePath
+        );
+        const maxOrder = worktreeSessions.reduce(
+          (max, s) => Math.max(max, s.displayOrder ?? 0),
+          -1
+        );
+
+        const newSession = {
+          id,
+          sessionId: id,
+          name: `Task: ${task.title}`,
+          agentId: agent.agentId,
+          agentCommand: agent.command,
+          customPath: agent.customPath,
+          customArgs: agent.customArgs,
+          initialized: false,
+          repoPath,
+          cwd: worktreePath,
+          environment: agent.environment,
+          displayOrder: maxOrder + 1,
+          // Store command to send after agent is ready
+          pendingCommand: taskContext,
+        };
+
+        return {
+          sessions: [...state.sessions, newSession],
+          activeIds: { ...state.activeIds, [normalizePath(worktreePath)]: id },
+          // Initialize enhanced input state (closed)
+          enhancedInputStates: {
+            ...state.enhancedInputStates,
+            [id]: { open: false, content: '', imagePaths: [] },
+          },
+        };
+      });
 
       // Move task to in-progress
       if (task.status === 'todo') {
@@ -169,14 +192,18 @@ export function TaskCard({
 
       {/* Actions */}
       <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
-        {worktreePath && onSwitchToAgent && task.status !== 'done' && (
+        {task.status !== 'done' && onSwitchToAgent && (
           <div className="relative" ref={menuRef}>
             <button
               ref={triggerRef}
               type="button"
-              onClick={() => setShowAgentMenu((v) => !v)}
-              className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
-              title={t('Launch Agent')}
+              onClick={() => {
+                if (!worktreePath) return;
+                setShowAgentMenu((v) => !v);
+              }}
+              disabled={!worktreePath}
+              className="flex h-6 w-6 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-foreground transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+              title={worktreePath ? t('Launch Agent') : t('Please select a worktree first')}
             >
               <Play className="h-3 w-3" />
             </button>

--- a/src/renderer/components/todo/TaskDialog.tsx
+++ b/src/renderer/components/todo/TaskDialog.tsx
@@ -43,6 +43,7 @@ export function TaskDialog({ open, onOpenChange, task, defaultStatus, repoPath }
 
   useEffect(() => {
     if (open) {
+      setIsPolishing(false);
       if (task) {
         setTitle(task.title);
         setDescription(task.description);

--- a/src/renderer/components/todo/TaskDialog.tsx
+++ b/src/renderer/components/todo/TaskDialog.tsx
@@ -1,3 +1,4 @@
+import { Loader2, Sparkles } from 'lucide-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import {
@@ -9,7 +10,9 @@ import {
   DialogPopup,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { toastManager } from '@/components/ui/toast';
 import { useI18n } from '@/i18n';
+import { useSettingsStore } from '@/stores/settings';
 import { useTodoStore } from '@/stores/todo';
 import type { TaskPriority, TaskStatus, TodoTask } from './types';
 
@@ -31,10 +34,12 @@ export function TaskDialog({ open, onOpenChange, task, defaultStatus, repoPath }
   const { t } = useI18n();
   const addTask = useTodoStore((s) => s.addTask);
   const updateTask = useTodoStore((s) => s.updateTask);
+  const todoPolish = useSettingsStore((s) => s.todoPolish);
 
   const [title, setTitle] = useState('');
   const [description, setDescription] = useState('');
   const [priority, setPriority] = useState<TaskPriority>('medium');
+  const [isPolishing, setIsPolishing] = useState(false);
 
   useEffect(() => {
     if (open) {
@@ -91,6 +96,47 @@ export function TaskDialog({ open, onOpenChange, task, defaultStatus, repoPath }
     [handleSubmit]
   );
 
+  const handlePolish = useCallback(async () => {
+    // Use description as raw input; fall back to title if description is empty
+    const rawText = description.trim() || title.trim();
+    if (!rawText || isPolishing) return;
+
+    setIsPolishing(true);
+    try {
+      const result = await window.electronAPI.todo.aiPolish({
+        text: rawText,
+        timeout: todoPolish.timeout,
+        provider: todoPolish.provider,
+        model: todoPolish.model,
+        reasoningEffort: todoPolish.reasoningEffort,
+        prompt: todoPolish.prompt,
+      });
+
+      if (result.success && result.title && result.description !== undefined) {
+        setTitle(result.title);
+        setDescription(result.description);
+      } else {
+        toastManager.add({
+          title: t('Failed to polish task'),
+          description: result.error === 'timeout' ? t('Generation timed out') : result.error,
+          type: 'error',
+          timeout: 5000,
+        });
+      }
+    } catch (error) {
+      toastManager.add({
+        title: t('Failed to polish task'),
+        description: error instanceof Error ? error.message : String(error),
+        type: 'error',
+        timeout: 5000,
+      });
+    } finally {
+      setIsPolishing(false);
+    }
+  }, [description, title, isPolishing, todoPolish, t]);
+
+  const hasContent = description.trim().length > 0 || title.trim().length > 0;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogPopup className="max-w-md">
@@ -115,7 +161,23 @@ export function TaskDialog({ open, onOpenChange, task, defaultStatus, repoPath }
 
             {/* Description */}
             <div className="flex flex-col gap-1.5">
-              <label className="text-sm font-medium text-foreground">{t('Task description')}</label>
+              <div className="flex items-center justify-between">
+                <label className="text-sm font-medium text-foreground">
+                  {t('Task description')}
+                </label>
+                {todoPolish.enabled && (
+                  <Button
+                    size="xs"
+                    variant="ghost"
+                    onClick={handlePolish}
+                    disabled={isPolishing || !hasContent}
+                    title={t('Polish with AI')}
+                  >
+                    {isPolishing ? <Loader2 className="animate-spin" /> : <Sparkles />}
+                    {t('AI Polish')}
+                  </Button>
+                )}
+              </div>
               <textarea
                 className="min-h-[80px] w-full resize-none rounded-md border bg-transparent px-3 py-2 text-sm outline-none ring-ring focus:ring-2 placeholder:text-muted-foreground"
                 placeholder={t('Enter task description...')}

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -15,6 +15,7 @@ import type {
   SearchKeybindings,
   SourceControlKeybindings,
   StatusLineFieldSettings,
+  TodoPolishSettings,
   WorkspaceKeybindings,
   XtermKeybindings,
 } from './types';
@@ -178,6 +179,38 @@ export const defaultBranchNameGeneratorSettings: BranchNameGeneratorSettings = {
   model: 'haiku',
   prompt:
     '你是 Git 分支命名助手（不可用工具）。输入含 desc 可含 date/branch_style。任务：从 desc 判定 type、提取 ticket、生成 slug，按模板渲染分支名。只输出一行分支名，无解释无标点。\n\n约束：仅允许 a-z0-9-/.；全小写；词用 -；禁空格/中文/下划线/其他符号。渲染后：-// 连续压缩为 1；去掉首尾 - / .；空变量不产生多余分隔符。\n\nticket：识别 ABC-123/#456/issue 789 等 → 小写，去 #；若存在则置于 slug 最前（形成 ticket-slug）。\n\nslug：取核心关键词 3–8 词，过滤泛词（如：一下/相关/进行/支持/增加/优化/问题/功能/页面/接口/调整/更新/修改等）；必要时将中文概念转换为常见英文词（如 login/order/pay），无法转换则丢弃。\n\ntype 枚举：feat fix hotfix perf refactor docs test chore ci build 判定优先级：hotfix(紧急/回滚/prod) > perf(性能) > fix(bug/修复) > feat(新增) > refactor(结构不变) > docs > test > ci > build > chore(兜底)。\n\ndate: 格式为 yyyyMMdd\n\n输出格式：{type}-{date}-{slug}\n\ndate: {current_date}\ntime: {current_time}\ndesc：{description}',
+};
+
+// Default todo AI polish prompts
+export const defaultTodoPolishPromptZh = `你是一个任务管理助手。将以下原始需求文本转换为结构化的待办任务。
+
+输出一个包含以下两个字段的 JSON 对象：
+- "title": 简洁的、以行动为导向的标题（最多 60 个字符）
+- "description": 清晰、详细的描述，对 AI Agent 友好。包含上下文、验收标准以及输入中的技术细节。确保 AI 编程助手可以直接理解并执行该任务。
+
+重要：只输出 JSON 对象，不要解释，不要使用 markdown 代码块。
+
+原始需求：
+{text}`;
+
+export const defaultTodoPolishPromptEn = `You are a task management assistant. Convert the following raw requirement text into a structured todo task.
+
+Output a JSON object with exactly two fields:
+- "title": A concise, action-oriented title (max 60 characters)
+- "description": A clear, detailed description that is AI-agent-friendly. Include context, acceptance criteria, and any technical details from the input. Write it so an AI coding agent can understand and execute the task directly.
+
+Important: Output ONLY the JSON object, no explanation, no markdown fences.
+
+Raw requirement:
+{text}`;
+
+// Default todo polish settings
+export const defaultTodoPolishSettings: TodoPolishSettings = {
+  enabled: true,
+  provider: 'claude-code',
+  model: 'haiku',
+  timeout: 60,
+  prompt: defaultTodoPolishPromptZh,
 };
 
 // Default code review settings

--- a/src/renderer/stores/settings/index.ts
+++ b/src/renderer/stores/settings/index.ts
@@ -23,6 +23,7 @@ import {
   defaultQuickTerminalSettings,
   defaultSearchKeybindings,
   defaultSourceControlKeybindings,
+  defaultTodoPolishSettings,
   defaultWorkspaceKeybindings,
   defaultXtermKeybindings,
   getDefaultLocale,
@@ -140,6 +141,7 @@ function getInitialState() {
     commitMessageGenerator: defaultCommitMessageGeneratorSettings,
     codeReview: defaultCodeReviewSettings,
     branchNameGenerator: defaultBranchNameGeneratorSettings,
+    todoPolish: defaultTodoPolishSettings,
 
     // App Settings
     autoUpdateEnabled: true,
@@ -440,6 +442,11 @@ export const useSettingsStore = create<SettingsState>()(
       setBranchNameGenerator: (settings) =>
         set((state) => ({
           branchNameGenerator: { ...state.branchNameGenerator, ...settings },
+        })),
+
+      setTodoPolish: (settings) =>
+        set((state) => ({
+          todoPolish: { ...state.todoPolish, ...settings },
         })),
 
       // App Setters

--- a/src/renderer/stores/settings/migration.ts
+++ b/src/renderer/stores/settings/migration.ts
@@ -186,6 +186,10 @@ export function migrateSettings(
       ...currentState.branchNameGenerator,
       ...persisted.branchNameGenerator,
     },
+    todoPolish: {
+      ...currentState.todoPolish,
+      ...persisted.todoPolish,
+    },
     hapiSettings: {
       ...currentState.hapiSettings,
       ...persisted.hapiSettings,

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -205,6 +205,16 @@ export interface CommitMessageGeneratorSettings {
   prompt: string; // Custom prompt template
 }
 
+// Todo AI polish settings
+export interface TodoPolishSettings {
+  enabled: boolean;
+  provider: AIProvider;
+  model: string; // Dynamic based on provider
+  reasoningEffort?: ReasoningEffort; // For Codex CLI
+  timeout: number; // in seconds
+  prompt: string; // Custom prompt template (with {text} placeholder)
+}
+
 // Branch name generator settings
 export interface BranchNameGeneratorSettings {
   enabled: boolean;
@@ -313,6 +323,7 @@ export interface SettingsState {
   commitMessageGenerator: CommitMessageGeneratorSettings;
   codeReview: CodeReviewSettings;
   branchNameGenerator: BranchNameGeneratorSettings;
+  todoPolish: TodoPolishSettings;
 
   // App Settings
   autoUpdateEnabled: boolean;
@@ -431,6 +442,7 @@ export interface SettingsState {
   setCommitMessageGenerator: (settings: Partial<CommitMessageGeneratorSettings>) => void;
   setCodeReview: (settings: Partial<CodeReviewSettings>) => void;
   setBranchNameGenerator: (settings: Partial<BranchNameGeneratorSettings>) => void;
+  setTodoPolish: (settings: Partial<TodoPolishSettings>) => void;
 
   // Setters - App
   setAutoUpdateEnabled: (enabled: boolean) => void;

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1307,6 +1307,20 @@ export const zhTranslations: Record<string, string> = {
   'Launch Agent': '启动 Agent',
   'No tasks yet': '暂无任务',
   'Create your first task to get started': '创建第一个任务开始使用',
+  'AI Polish': 'AI 润色',
+  'Polish with AI': '使用 AI 润色',
+  'Failed to polish task': 'AI 润色失败',
+  'Todo AI Polish': '待办 AI 润色',
+  'Use AI to generate a title and description from raw requirement text':
+    '通过 AI 将原始需求文本生成简洁标题和 Agent 友好的内容',
+  'Enable AI Polish': '启用 AI 润色',
+  'Show AI polish button when creating or editing tasks': '新建或编辑任务时显示 AI 润色按钮',
+  'Model for polishing task content': '用于润色任务内容的模型',
+  'Customize the AI prompt for polishing tasks': '自定义任务润色的 AI 提示词',
+  'This will restore the default AI prompt for todo polish. Your custom prompt will be lost.':
+    '这将恢复待办润色的默认 AI 提示词，自定义提示词将会丢失。',
+  'Enter a prompt template.\nAvailable variables:\n• {text} - Raw requirement text':
+    '输入提示词模板。\n可用变量：\n• {text} - 原始需求文本',
 };
 
 export function normalizeLocale(input?: string): Locale {

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -259,6 +259,7 @@ export const IPC_CHANNELS = {
   TODO_MOVE_TASK: 'todo:moveTask',
   TODO_REORDER_TASKS: 'todo:reorderTasks',
   TODO_MIGRATE: 'todo:migrate',
+  TODO_AI_POLISH: 'todo:aiPolish',
 
   // Logging
   LOG_UPDATE_CONFIG: 'log:update-config',


### PR DESCRIPTION
## 功能概述

### 1. 任务卡片启动 Agent 时自动发送任务内容
启动 Agent 时，自动将任务标题和描述作为 `pendingCommand` 发送到终端，无需手动复制粘贴。

### 2. 新建/编辑待办支持 AI 润色
在任务对话框中新增 **AI 润色** 按钮，将原始需求文本发送给 AI，自动生成：
- 简洁的任务标题（≤60字）
- Agent 友好的任务描述（含上下文、验收标准、技术细节）

## 变更内容

- `TaskDialog` — 描述标签旁新增 `✨ AI 润色` 按钮，有内容时激活，生成中显示加载动画
- `TodoPolishSettings` — 新增设置项，支持配置 Provider、模型、超时、自定义提示词
- `AISettings` — 新增 "Todo AI Polish" 设置区域，可还原默认提示词
- `todo-polish.ts` — 新增 AI 服务，复用现有 `spawnCLI` 模式，输出解析为 `{ title, description }` JSON
- `IPC` — 新增 `todo:aiPolish` 通道
- `i18n` — 补全所有相关中文词条

## 配置

Settings → AI → **Todo AI Polish**，可自定义提示词（变量：`{text}`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)