### PR TITLE
fix(file-tree): 修复切换仓库/Worktree 时目录树展开状态丢失的问题

### DIFF
--- a/src/renderer/hooks/useFileTree.ts
+++ b/src/renderer/hooks/useFileTree.ts
@@ -116,13 +116,15 @@ export function useFileTree({ rootPath, enabled = true, isActive = true }: UseFi
 
     // Only restore once per rootPath switch (childrenRestoredRef resets on rootPath change)
     if (childrenRestoredRef.current) return;
-    childrenRestoredRef.current = true;
 
     // Read directly from localStorage to avoid stale ref when this effect fires
     // in the same flush as the rootPath effect (expandedPathsRef may still hold
     // the previous rootPath's paths before setExpandedPaths state update is applied)
     const restored = loadFileTreeExpandedPaths(rootPath);
-    if (restored.size === 0) return;
+    if (restored.size === 0) {
+      childrenRestoredRef.current = true;
+      return;
+    }
 
     // Sort shallow-first so parent nodes are populated before their children
     const sortedPaths = [...restored].sort((a, b) => a.split('/').length - b.split('/').length);
@@ -142,6 +144,10 @@ export function useFileTree({ rootPath, enabled = true, isActive = true }: UseFi
         } catch {
           // Silently skip paths that fail to load (e.g. deleted directories)
         }
+      }
+      // Only mark as restored after all children loaded successfully without cancellation
+      if (!cancelled) {
+        childrenRestoredRef.current = true;
       }
     };
 


### PR DESCRIPTION
## Summary

- 修复 `useFileTree.ts` 中 rootFiles effect 的竞态取消 bug：将 `childrenRestoredRef` 的锁定时机从「恢复开始前」改为「恢复完成后」，避免 React Query stale data 触发 effect 被 cleanup 取消后锁仍在，导致再次触发时跳过恢复逻辑

## Root Cause

切换到之前访问过的 worktree 时，React Query 的 stale data 让 effect 先触发一次（开始异步恢复 children），然后后台 refetch 完成后 rootFiles 更新导致 effect 被 cleanup 取消，再次触发时 `childrenRestoredRef.current` 已锁定为 `true`，跳过恢复逻辑，导致部分目录显示为展开但无子内容。

## Changes

- 移除恢复开始前的 `childrenRestoredRef.current = true`
- 在 `restoreChildren` 循环全部完成后、且未被取消时，才设置 `childrenRestoredRef.current = true`
- 当没有需要恢复的路径时（`restored.size === 0`），立即标记完成

## Test plan

- [ ] 展开 worktree A 多层目录 → 切换到 B → 切回 A → 展开状态完整保留
- [ ] 在 worktree A 中用外部工具创建文件触发文件变更 → 切到 B 再切回 A → 展开状态完整保留
- [ ] 关闭应用重新打开 → 展开状态从 localStorage 恢复