### PR TITLE
fix(terminal): 修复终端无法输入空格的问题

### DIFF
--- a/src/renderer/components/terminal/TerminalPanel.tsx
+++ b/src/renderer/components/terminal/TerminalPanel.tsx
@@ -929,7 +929,8 @@ export function TerminalPanel({ repoPath, cwd, isActive = false }: TerminalPanel
                     tabIndex={0}
                     onClick={() => handleGroupClick(info.group.id)}
                     onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
+                      // Only handle when the div itself has focus, not child elements (xterm)
+                      if (e.currentTarget === e.target && (e.key === 'Enter' || e.key === ' ')) {
                         e.preventDefault();
                         handleGroupClick(info.group.id);
                       }


### PR DESCRIPTION
## Summary

- 修复终端中无法输入空格的问题，由 `ecdd3c9` (#359) 引入
- `onKeyDown` 处理器无条件拦截空格键事件（包括从 xterm 冒泡的事件），添加 `e.currentTarget === e.target` 检查，仅在 div 自身聚焦时处理

## Test plan

- [ ] 在终端中输入包含空格的命令（如 `ls -la`），验证空格可正常输入
- [ ] 通过 Tab 键聚焦终端容器 div，按空格/Enter 验证分组点击仍可用

🤖 Generated with [Claude Code](https://claude.com/claude-code)