### PR TITLE
feat(source-control): 支持 Diff 视图二进制文件检测与提示

### DIFF
--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -19,7 +19,7 @@ import type {
   SubmoduleStatus,
 } from '@shared/types';
 import type { SimpleGit, StatusResult } from 'simple-git';
-import { decodeBuffer, gitShow } from './encoding';
+import { decodeBuffer, detectBinaryFile, gitShow } from './encoding';
 import {
   createGitEnv,
   createSimpleGit,
@@ -668,6 +668,11 @@ export class GitService {
       throw new Error('Invalid file path: path traversal detected');
     }
 
+    // 3. Detect binary files to avoid rendering garbage in Monaco
+    if (await detectBinaryFile(absolutePath, this.workdir, `:${filePath}`)) {
+      return { path: filePath, original: '', modified: '', isBinary: true };
+    }
+
     let original = '';
     let modified = '';
 
@@ -815,6 +820,17 @@ export class GitService {
     submodulePath?: string
   ): Promise<FileDiff> {
     const git = this.getGitInstance(submodulePath);
+
+    // Detect binary using git diff --numstat (binary files show "-" for insertions/deletions)
+    try {
+      const numstat = await git.diff(['--numstat', `${hash}^..${hash}`, '--', filePath]);
+      if (numstat.startsWith('-\t-\t')) {
+        return { path: filePath, original: '', modified: '', isBinary: true };
+      }
+    } catch {
+      // If detection fails (e.g., root commit without parent), continue with text diff
+    }
+
     let originalContent = '';
     let modifiedContent = '';
 
@@ -1342,6 +1358,11 @@ export class GitService {
     const relativeFilePath = path.relative(fullSubPath, fullFilePath);
     if (relativeFilePath.startsWith('..') || path.isAbsolute(relativeFilePath)) {
       throw new Error('Invalid file path: path traversal detected');
+    }
+
+    // Detect binary files
+    if (await detectBinaryFile(fullFilePath, fullSubPath, `:${filePath}`)) {
+      return { path: filePath, original: '', modified: '', isBinary: true };
     }
 
     let original = '';

--- a/src/main/services/git/encoding.ts
+++ b/src/main/services/git/encoding.ts
@@ -1,4 +1,5 @@
 import iconv from 'iconv-lite';
+import { isBinaryFile } from 'isbinaryfile';
 import jschardet from 'jschardet';
 import { spawnGit } from './runtime';
 
@@ -7,6 +8,35 @@ export function decodeBuffer(buffer: Buffer): string {
   const detected = jschardet.detect(buffer);
   const encoding = detected?.encoding || 'utf-8';
   return iconv.decode(buffer, encoding);
+}
+
+/**
+ * Detect if a file is binary by checking the file on disk or its git content.
+ * Tries disk file first; on ENOENT falls back to git content inspection.
+ * Returns false (text) on any detection failure.
+ */
+export async function detectBinaryFile(
+  filePath: string,
+  gitWorkdir: string,
+  gitRef: string
+): Promise<boolean> {
+  try {
+    return await isBinaryFile(filePath);
+  } catch (err: unknown) {
+    // File not on disk (deleted/renamed), fall through to git content
+    if (
+      !(err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT')
+    ) {
+      return false;
+    }
+  }
+  try {
+    const buffer = await gitShowBuffer(gitWorkdir, gitRef);
+    if (buffer.length === 0) return false;
+    return await isBinaryFile(buffer, buffer.length);
+  } catch {
+    return false;
+  }
 }
 
 export function gitShowBuffer(workdir: string, ref: string): Promise<Buffer> {

--- a/src/renderer/components/source-control/CommitDiffViewer.tsx
+++ b/src/renderer/components/source-control/CommitDiffViewer.tsx
@@ -35,6 +35,7 @@ export function CommitDiffViewer({
       path: filePath ?? '',
       original: fileDiff?.original ?? '',
       modified: fileDiff?.modified ?? '',
+      isBinary: fileDiff?.isBinary,
     }),
     [filePath, fileDiff]
   );

--- a/src/renderer/components/source-control/DiffReviewModal.tsx
+++ b/src/renderer/components/source-control/DiffReviewModal.tsx
@@ -5,6 +5,7 @@ import {
   ChevronRight,
   Expand,
   FileCode,
+  FileX2,
   FolderGit2,
   FoldVertical,
   Loader2,
@@ -27,6 +28,7 @@ import {
   DialogPopup,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia } from '@/components/ui/empty';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { useFileChanges, useFileDiff } from '@/hooks/useSourceControl';
 import { useSubmoduleChanges, useSubmoduleFileDiff, useSubmodules } from '@/hooks/useSubmodules';
@@ -1187,6 +1189,17 @@ export function DiffReviewModal({ open, onOpenChange, rootPath, onSend }: DiffRe
                 <div className="flex items-center justify-center h-full text-muted-foreground">
                   {t('Select a file to view diff')}
                 </div>
+              ) : diff?.isBinary ? (
+                <Empty className="h-full">
+                  <EmptyMedia variant="icon">
+                    <FileX2 className="h-4.5 w-4.5" />
+                  </EmptyMedia>
+                  <EmptyHeader>
+                    <EmptyDescription>
+                      {t('Binary file not supported for diff preview')}
+                    </EmptyDescription>
+                  </EmptyHeader>
+                </Empty>
               ) : diff && isThemeReady ? (
                 <DiffEditor
                   key={`${selectedFile.path}-${selectedFile.staged}`}

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -1,10 +1,12 @@
 import { DiffEditor } from '@monaco-editor/react';
+import type { FileDiff } from '@shared/types';
 import { useQueryClient } from '@tanstack/react-query';
 import {
   ChevronDown,
   ChevronUp,
   ExternalLink,
   FileCode,
+  FileX2,
   FoldVertical,
   MessageSquare,
   Pencil,
@@ -109,7 +111,7 @@ interface DiffViewerProps {
   onNextFile?: () => void;
   hasPrevFile?: boolean;
   hasNextFile?: boolean;
-  diff?: { path: string; original: string; modified: string };
+  diff?: FileDiff;
   skipFetch?: boolean;
   isCommitView?: boolean; // Add flag to indicate commit history view
 }
@@ -1047,6 +1049,20 @@ export function DiffViewer({
       <div className="flex h-full items-center justify-center text-muted-foreground">
         <p className="text-sm">{t('Failed to load diff')}</p>
       </div>
+    );
+  }
+
+  if (diff.isBinary) {
+    return (
+      <Empty className="h-full">
+        <EmptyMedia variant="icon">
+          <FileX2 className="h-4.5 w-4.5" />
+        </EmptyMedia>
+        <EmptyHeader>
+          <EmptyTitle>{file.path}</EmptyTitle>
+          <EmptyDescription>{t('Binary file not supported for diff preview')}</EmptyDescription>
+        </EmptyHeader>
+      </Empty>
     );
   }
 

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -52,6 +52,7 @@ export const zhTranslations: Record<string, string> = {
   'Size Mode': '填充模式',
   'Select Image': '选择图片',
   'Beta Features': 'Beta 功能',
+  'Binary file not supported for diff preview': '二进制文件不支持差异预览',
   'Temp Session': '临时会话',
   'Temp Session settings': '临时会话设置',
   'Show Temp Session entry for quick scratch sessions': '显示临时会话入口，用于快速临时会话',

--- a/src/shared/types/git.ts
+++ b/src/shared/types/git.ts
@@ -76,6 +76,7 @@ export interface FileDiff {
   path: string;
   original: string; // HEAD version (empty for new files)
   modified: string; // working tree version (empty for deleted files)
+  isBinary?: boolean; // true if file is binary (images, PDFs, executables, etc.)
 }
 
 // Commit history detail types


### PR DESCRIPTION
## Summary
- 在 Diff 视图中添加二进制文件（图片、PDF、可执行文件等）的检测逻辑，避免 Monaco 编辑器渲染乱码，改为显示友好的占位提示
- 在 `encoding.ts` 中封装 `detectBinaryFile` 统一二进制检测逻辑，消除重复代码
- `DiffViewer`、`DiffReviewModal`、`CommitDiffViewer` 三个 diff 场景均已覆盖

## Changes
- **`src/main/services/git/encoding.ts`**: 新增 `detectBinaryFile()`，磁盘文件优先用 `isbinaryfile` 库检测，文件不存在时回退到 git 内容检测
- **`src/main/services/git/GitService.ts`**: `getFileDiff`/`getCommitDiff`/`getSubmoduleFileDiff` 添加二进制检测，返回 `isBinary: true`
- **`src/shared/types/git.ts`**: `FileDiff` 新增 `isBinary?: boolean` 字段
- **`src/renderer/.../DiffViewer.tsx`**: 二进制文件显示 Empty 组件占位提示
- **`src/renderer/.../DiffReviewModal.tsx`**: 同上，使用 Empty 组件保持一致
- **`src/renderer/.../CommitDiffViewer.tsx`**: 透传 `isBinary` 字段
- **`src/shared/i18n.ts`**: 添加中文翻译词条

## Test plan
- [ ] 修改一个二进制文件（如图片、PDF），在 Source Control 面板查看 diff，应显示"二进制文件不支持差异预览"提示
- [ ] 在 Commit 历史中查看包含二进制文件的 commit diff，应显示同样的提示
- [ ] 在 Diff Review 弹窗中查看二进制文件，应显示占位提示
- [ ] 子模块中的二进制文件也应正确检测
- [ ] 普通文本文件的 diff 功能不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)