### PR TITLE
fix(source-control): 修复提交后 diff 视图无法关闭的问题

### DIFF
--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -588,6 +588,18 @@ export function SourceControlPanel({
   // All files in order: staged first, then unstaged
   const allFiles = useMemo(() => [...staged, ...unstaged], [staged, unstaged]);
 
+  // Clear selected file when it no longer exists in the file list
+  // (e.g., after commit, discard, or external changes)
+  useEffect(() => {
+    if (!selectedFile) return;
+    const stillExists = allFiles.some(
+      (f) => f.path === selectedFile.path && f.staged === selectedFile.staged
+    );
+    if (!stillExists) {
+      setSelectedFile(null);
+    }
+  }, [allFiles, selectedFile, setSelectedFile]);
+
   // Panel resize hooks
   const { width: panelWidth, isResizing, containerRef, handleMouseDown } = usePanelResize();
 


### PR DESCRIPTION
## Summary
- 修复版本管理中查看文件 diff 后，所有文件提交完成后 diff 视图无法关闭的问题
- 添加 `useEffect` 监听 `allFiles` 变化，当 `selectedFile` 不再存在于变更列表时自动清除
- 覆盖 UI 提交、终端提交、discard、stash 等所有导致文件从变更列表消失的场景

## Test plan
- [ ] 打开版本管理面板，选择一个文件查看 diff
- [ ] 提交所有文件，验证 diff 视图自动关闭并显示空状态
- [ ] 通过终端执行 `git commit`，验证 diff 视图同样自动关闭
- [ ] 选择一个文件查看 diff，然后 discard 该文件，验证 diff 视图自动关闭

🤖 Generated with [Claude Code](https://claude.com/claude-code)