### PR TITLE
fix(editor): 修复 Java 符号解析无法识别嵌套泛型和注解括号的方法

### DIFF
--- a/src/renderer/components/files/monacoSetup.ts
+++ b/src/renderer/components/files/monacoSetup.ts
@@ -218,7 +218,7 @@ monaco.languages.registerDocumentSymbolProvider('java', {
     // from being misread as the return type when the modifiers group matches zero times.
     // Without this, `public VerifySymbols()` would be parsed as: returnType=public, name=VerifySymbols.
     const methodRe =
-      /^\s*((?:(?:public|private|protected|static|final|abstract|synchronized|native)\s+)*)(<[^>]+>\s+)?(?!(?:public|private|protected|static|final|abstract|synchronized|native)\b)(\w+(?:\[\])*(?:<[^>]*>)?(?:\[\])*)\s+(\w+)\s*\(([^)]*)\)\s*(?:throws\s+\w+(?:\s*,\s*\w+)*)?\s*(?:\{|;)/gm;
+      /^\s*((?:(?:public|private|protected|static|final|abstract|synchronized|native)\s+)*)(<[^>]+>\s+)?(?!(?:public|private|protected|static|final|abstract|synchronized|native)\b)(\w+(?:\[\])*(?:<(?:[^<>]|<[^<>]*>)*>)?(?:\[\])*)\s+(\w+)\s*\(((?:[^)(]|\([^)]*\))*)\)\s*(?:throws\s+\w+(?:\s*,\s*\w+)*)?\s*(?:\{|;)/gm;
     let methodMatch: RegExpExecArray | null = methodRe.exec(text);
     while (methodMatch !== null) {
       const modifiers = methodMatch[1].trim();


### PR DESCRIPTION
## 问题

Ctrl+O 符号列表无法识别带有注解参数或嵌套泛型返回类型的 Java 方法（如 `getById`、`findList`）。

## 根本原因

`monacoSetup.ts` 中 Java 方法解析正则 `methodRe` 存在两处缺陷：

1. **返回类型** `(?:<[^>]*>)?` 只支持单层泛型，遇到 `ReturnDto<List<SalesFollowUpDto>>` 这类嵌套泛型时匹配失败
2. **参数列表** `([^)]*)` 不支持括号嵌套，遇到 `@ApiParam(name = "id", ...)` 这类带括号的注解时在注解内部提前终止匹配

## 修复

| 位置 | 修改前 | 修改后 |
|------|--------|--------|
| 返回类型泛型 | `(?:<[^>]*>)?` | `(?:<(?:[^<>]\|<[^<>]*>)*>)?` |
| 参数嵌套括号 | `([^)]*)` | `((?:[^)(]\|\([^)]*\))*)` |

## 影响范围

仅影响 Java 文件的 Ctrl+O 符号列表，不影响其他语言和功能。