### PR TITLE
fix(source-control): 修复新增文件夹时更改列表显示问题

### DIFF
--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -211,7 +211,7 @@ export class GitService {
     return new Promise((resolve, reject) => {
       const proc = spawnGit(
         this.workdir,
-        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'],
+        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'],
         { cwd: this.workdir, env: this.getGitEnv() }
       );
 
@@ -579,7 +579,7 @@ export class GitService {
     await new Promise<void>((resolve, reject) => {
       const proc = spawnGit(
         this.workdir,
-        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'],
+        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'],
         { cwd: this.workdir, env }
       );
 

--- a/src/renderer/components/source-control/ChangesTree.tsx
+++ b/src/renderer/components/source-control/ChangesTree.tsx
@@ -66,12 +66,17 @@ function buildTree(files: FileChange[]): TreeNode[] {
   const root: TreeNode[] = [];
 
   for (const file of files) {
-    const parts = file.path.split('/');
+    // Git returns folder paths ending with '/' when using --untracked-files=normal
+    // Remove trailing slash for consistent processing
+    const normalizedPath = file.path.endsWith('/') ? file.path.slice(0, -1) : file.path;
+    const isFolder = file.path.endsWith('/');
+
+    const parts = normalizedPath.split('/');
     let currentLevel = root;
 
     for (let i = 0; i < parts.length; i++) {
       const part = parts[i];
-      const isFile = i === parts.length - 1;
+      const isFile = !isFolder && i === parts.length - 1;
       const currentPath = parts.slice(0, i + 1).join('/');
 
       let node = currentLevel.find((n) => n.name === part);


### PR DESCRIPTION
修复版本管理中新增文件夹时的问题：

## 问题描述
当新增一个包含多个文件的文件夹到版本控制时：
- 文件夹下的所有文件不会显示在更改列表中
- 文件夹本身被错误地识别为文件

## 根本原因
1. **Git 命令问题**：使用 `--untracked-files=normal` 时，Git 只返回文件夹路径（如 `testfolder/`），不返回子文件
2. **文件夹识别错误**：`buildTree()` 函数无法正确识别以 `/` 结尾的路径为文件夹

## 解决方案
1. **GitService.ts**: 将 `--untracked-files=normal` 改为 `--untracked-files=all`
   - 确保 Git 返回所有未跟踪文件，包括文件夹下的子文件
   - 匹配 VS Code 等编辑器的默认行为

2. **ChangesTree.tsx**: 修复 `buildTree()` 函数的文件夹识别逻辑
   - 检测路径末尾的 `/` 来正确识别文件夹
   - 标准化路径处理，避免空字符串导致的类型判断错误