### PR TITLE
feat(ai): 添加 CI/CD 优化选项支持 (--bare, --effort)

### DIFF
--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -1,6 +1,7 @@
 import { existsSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { type FileChangeStatus, IPC_CHANNELS } from '@shared/types';
+import type { ClaudeEffort } from '@shared/types/ai';
 import { ipcMain } from 'electron';
 import {
   type AIProvider,
@@ -317,6 +318,8 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
         prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> => {
@@ -331,6 +334,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bare,
+        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
         prompt: options.prompt,
       });
     }
@@ -346,6 +351,8 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
         language?: string;
         reviewId: string;
         sessionId?: string; // Support sessionId for "Continue Conversation"
@@ -363,6 +370,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bare,
+        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
         language: options.language ?? '中文',
         reviewId: options.reviewId,
         sessionId: options.sessionId, // Pass sessionId for session preservation
@@ -457,6 +466,8 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
       }
     ): Promise<{ success: boolean; branchName?: string; error?: string }> => {
       if (isRemoteWorkdir(workdir)) {
@@ -469,6 +480,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bare,
+        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
       });
     }
   );

--- a/src/main/ipc/todo.ts
+++ b/src/main/ipc/todo.ts
@@ -1,4 +1,5 @@
 import { IPC_CHANNELS } from '@shared/types';
+import type { ClaudeEffort } from '@shared/types/ai';
 import { ipcMain } from 'electron';
 import type { AIProvider, ModelId, ReasoningEffort } from '../services/ai';
 import { polishTodoTask } from '../services/ai';
@@ -86,6 +87,8 @@ export function registerTodoHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
         prompt?: string;
       }
     ): Promise<{ success: boolean; title?: string; description?: string; error?: string }> => {
@@ -95,6 +98,8 @@ export function registerTodoHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bare,
+        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
         prompt: options.prompt,
       });
     }

--- a/src/main/services/ai/branch-name.ts
+++ b/src/main/services/ai/branch-name.ts
@@ -1,12 +1,10 @@
-import type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
+import type { AIProvider, ModelId } from '@shared/types';
+import type { CommonAICLIOptions } from '@shared/types/ai';
 import { parseCLIOutput, spawnCLI } from './providers';
 
-export interface BranchNameOptions {
+export interface BranchNameOptions extends CommonAICLIOptions {
   workdir: string;
   prompt: string;
-  provider: AIProvider;
-  model: ModelId;
-  reasoningEffort?: ReasoningEffort;
   timeout?: number;
 }
 
@@ -17,12 +15,19 @@ export interface BranchNameResult {
 }
 
 export async function generateBranchName(options: BranchNameOptions): Promise<BranchNameResult> {
-  const { workdir, prompt, provider, model, reasoningEffort, timeout = 120 } = options;
+  const {
+    workdir,
+    prompt,
+    provider,
+    model,
+    reasoningEffort,
+    bare,
+    claudeEffort,
+    timeout = 120,
+  } = options;
 
   return new Promise((resolve) => {
     const timeoutMs = timeout * 1000;
-
-    console.log(`[branch-name] Starting with provider=${provider}, model=${model}, cwd=${workdir}`);
 
     const { proc, kill } = spawnCLI({
       provider,
@@ -30,6 +35,8 @@ export async function generateBranchName(options: BranchNameOptions): Promise<Br
       prompt,
       cwd: workdir,
       reasoningEffort,
+      bare,
+      claudeEffort,
       outputFormat: 'json',
     });
 
@@ -59,7 +66,6 @@ export async function generateBranchName(options: BranchNameOptions): Promise<Br
       }
 
       const result = parseCLIOutput(provider, stdout);
-      console.log(`[branch-name] Parse result:`, result);
 
       if (result.success && result.text) {
         resolve({ success: true, branchName: result.text.trim() });

--- a/src/main/services/ai/code-review.ts
+++ b/src/main/services/ai/code-review.ts
@@ -1,13 +1,11 @@
 import type { ChildProcess } from 'node:child_process';
-import type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
+import type { AIProvider, ModelId } from '@shared/types';
+import type { CommonAICLIOptions } from '@shared/types/ai';
 import { spawnGit } from '../git/runtime';
 import { spawnCLI, stripAnsi } from './providers';
 
-export interface CodeReviewOptions {
+export interface CodeReviewOptions extends CommonAICLIOptions {
   workdir: string;
-  provider: AIProvider;
-  model: ModelId;
-  reasoningEffort?: ReasoningEffort;
   language: string;
   reviewId: string;
   sessionId?: string; // Support session preservation for "Continue Conversation"
@@ -305,6 +303,8 @@ export async function startCodeReview(options: CodeReviewOptions): Promise<void>
     provider,
     model,
     reasoningEffort,
+    bare,
+    claudeEffort,
     language,
     reviewId,
     prompt: customPrompt,
@@ -339,6 +339,8 @@ export async function startCodeReview(options: CodeReviewOptions): Promise<void>
     prompt,
     cwd: workdir,
     reasoningEffort,
+    bare,
+    claudeEffort,
     outputFormat,
     // Claude CLI honors this; Cursor CLI does not (see providers.buildCursorArgs). Cursor may edit/run git.
     disallowedTools: ['"Bash(git:*)"', 'Edit'],

--- a/src/main/services/ai/commit-message.ts
+++ b/src/main/services/ai/commit-message.ts
@@ -1,15 +1,13 @@
 import { execSync } from 'node:child_process';
-import type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
+import type { AIProvider, ModelId } from '@shared/types';
+import type { CommonAICLIOptions } from '@shared/types/ai';
 import { isWslGitRepository, spawnGit } from '../git/runtime';
-import { parseCLIOutput, spawnCLI } from './providers';
+import { parseCLIOutput, spawnCLI, stripCodeFence } from './providers';
 
-export interface CommitMessageOptions {
+export interface CommitMessageOptions extends CommonAICLIOptions {
   workdir: string;
   maxDiffLines: number;
   timeout: number;
-  provider: AIProvider;
-  model: ModelId;
-  reasoningEffort?: ReasoningEffort;
   prompt?: string; // Custom prompt template
 }
 
@@ -17,23 +15,6 @@ export interface CommitMessageResult {
   success: boolean;
   message?: string;
   error?: string;
-}
-
-/** Strip markdown code fence (e.g. ``` or ```text) from start/end when CLI returns wrapped message */
-function stripCodeFence(text: string): string {
-  const trimmed = text.trim();
-
-  // Match a fenced block anywhere in the text (handles leading explanation text)
-  const fenceMatch = trimmed.match(/```\w*\s*[\r\n]+([\s\S]*?)[\r\n]+\s*```\s*$/);
-  if (fenceMatch) {
-    return fenceMatch[1].trim();
-  }
-
-  // Fallback: strip leading/trailing fences when only one side is present
-  return trimmed
-    .replace(/^```\w*\s*[\r\n]*/, '')
-    .replace(/[\r\n]*\s*```\s*$/, '')
-    .trim();
 }
 
 function runGit(args: string[], cwd: string): Promise<string> {
@@ -95,6 +76,8 @@ export async function generateCommitMessage(
     provider,
     model,
     reasoningEffort,
+    bare,
+    claudeEffort,
     prompt: customPrompt,
   } = options;
 
@@ -134,14 +117,14 @@ ${truncatedDiff}`;
   return new Promise((resolve) => {
     const timeoutMs = timeout * 1000;
 
-    console.log(`[commit-msg] Starting with provider=${provider}, model=${model}, cwd=${workdir}`);
-
     const { proc, kill } = spawnCLI({
       provider,
       model,
       prompt,
       cwd: workdir,
       reasoningEffort,
+      bare,
+      claudeEffort,
       outputFormat: 'json',
     });
 
@@ -171,7 +154,6 @@ ${truncatedDiff}`;
       }
 
       const result = parseCLIOutput(provider, stdout);
-      console.log(`[commit-msg] Parse result:`, result);
 
       if (result.success && result.text) {
         resolve({ success: true, message: stripCodeFence(result.text) });

--- a/src/main/services/ai/index.ts
+++ b/src/main/services/ai/index.ts
@@ -11,6 +11,7 @@ export {
   generateCommitMessage,
 } from './commit-message';
 export type { AIProvider, ModelId, ReasoningEffort } from './providers';
+export { clearVersionCache } from './providers';
 export {
   polishTodoTask,
   type TodoPolishOptions,

--- a/src/main/services/ai/providers.ts
+++ b/src/main/services/ai/providers.ts
@@ -2,6 +2,7 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn, spawnSync } from 'node:child_process';
 import type {
   AIProvider,
+  ClaudeEffort,
   ClaudeModelId,
   CodexModelId,
   CursorModelId,
@@ -9,16 +10,96 @@ import type {
   ModelId,
   ReasoningEffort,
 } from '@shared/types';
+import type { CommonAICLIOptions } from '@shared/types/ai';
 import { getEnvForCommand, getShellForCommand } from '../../utils/shell';
 
-export type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
+export type {
+  AIProvider,
+  ClaudeEffort,
+  CommonAICLIOptions,
+  ModelId,
+  ReasoningEffort,
+} from '@shared/types';
 
-export interface CLISpawnOptions {
-  provider: AIProvider;
-  model: ModelId;
+// Version constants for Claude CLI feature flags
+const CLAUDE_VERSION = {
+  MAJOR: 2,
+  MINOR: 1,
+  BARE_FLAG_PATCH: 81,
+  EFFORT_FLAG_PATCH: 60,
+  VERSION_TIMEOUT_MS: 5000,
+} as const;
+
+// Version cache for Claude CLI - parsed version numbers
+let cachedParsedVersion: [number, number, number] | null = null;
+
+/**
+ * Parse and cache Claude CLI version
+ * Returns parsed version numbers [major, minor, patch] or null if detection fails
+ */
+function getParsedClaudeVersion(): [number, number, number] | null {
+  if (cachedParsedVersion) {
+    return cachedParsedVersion;
+  }
+
+  try {
+    const { shell, args: shellArgs } = getShellForCommand();
+    const result = spawnSync(shell, [...shellArgs, 'claude', '--version'], {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+      timeout: CLAUDE_VERSION.VERSION_TIMEOUT_MS,
+    });
+
+    const output = result.stdout || result.stderr || '';
+    const match = output.match(/(\d+)\.(\d+)\.(\d+)/);
+    if (match) {
+      cachedParsedVersion = [
+        parseInt(match[1], 10),
+        parseInt(match[2], 10),
+        parseInt(match[3], 10),
+      ];
+      return cachedParsedVersion;
+    }
+  } catch (error) {
+    console.warn('[providers] Failed to detect Claude CLI version:', error);
+  }
+
+  return null;
+}
+
+/**
+ * Check if Claude CLI supports a feature flag at a specific patch version
+ */
+function supportsVersionFlag(minPatch: number): boolean {
+  const version = getParsedClaudeVersion();
+  if (!version) return false;
+
+  const [major, minor, patch] = version;
+  if (major > CLAUDE_VERSION.MAJOR) return true;
+  if (major === CLAUDE_VERSION.MAJOR && minor > CLAUDE_VERSION.MINOR) return true;
+  return major === CLAUDE_VERSION.MAJOR && minor === CLAUDE_VERSION.MINOR && patch >= minPatch;
+}
+
+/**
+ * Check if Claude CLI supports --bare flag (2.1.81+)
+ */
+const supportsBareFlag = () => supportsVersionFlag(CLAUDE_VERSION.BARE_FLAG_PATCH);
+
+/**
+ * Check if Claude CLI supports --effort flag (2.1.60+)
+ */
+const supportsEffortFlag = () => supportsVersionFlag(CLAUDE_VERSION.EFFORT_FLAG_PATCH);
+
+/**
+ * Clear cached version (for testing or when CLI is updated during runtime)
+ */
+export function clearVersionCache(): void {
+  cachedParsedVersion = null;
+}
+
+export interface CLISpawnOptions extends CommonAICLIOptions {
   prompt: string;
   cwd: string;
-  reasoningEffort?: ReasoningEffort;
   outputFormat?: 'json' | 'stream-json';
   timeout?: number;
   disallowedTools?: string[];
@@ -39,6 +120,18 @@ function buildClaudeArgs(options: CLISpawnOptions): string[] {
     '--model',
     options.model as ClaudeModelId,
   ];
+
+  // Add --bare flag for CI/CD optimization (skips hooks, LSP, plugins, skills, etc.)
+  // Only add if the CLI version supports it (2.1.81+)
+  if (options.bare && supportsBareFlag()) {
+    args.push('--bare');
+  }
+
+  // Add --effort flag for CI/CD optimization (controls token usage vs quality)
+  // Only add if the CLI version supports it (2.1.60+)
+  if (options.claudeEffort && supportsEffortFlag()) {
+    args.push('--effort', options.claudeEffort);
+  }
 
   // Support session ID for preserving conversation
   if (options.sessionId) {
@@ -195,6 +288,24 @@ const ANSI_REGEX = new RegExp(
 
 export function stripAnsi(str: string): string {
   return str.replace(ANSI_REGEX, '');
+}
+
+/**
+ * Strip markdown code fence from AI output
+ * Handles cases like ```text\ncontent\n``` or ```json\n{...}\n```
+ */
+export function stripCodeFence(text: string): string {
+  const trimmed = text.trim();
+  // Match complete fenced block: ```lang\ncontent\n```
+  const fenceMatch = trimmed.match(/```\w*\s*[\r\n]+([\s\S]*?)[\r\n]+\s*```\s*$/);
+  if (fenceMatch) {
+    return fenceMatch[1].trim();
+  }
+  // Fallback: strip leading/trailing fences when only one side is present
+  return trimmed
+    .replace(/^```\w*\s*[\r\n]*/, '')
+    .replace(/[\r\n]*\s*```\s*$/, '')
+    .trim();
 }
 
 export function parseClaudeJsonOutput(stdout: string): ParsedCLIResult {

--- a/src/main/services/ai/todo-polish.ts
+++ b/src/main/services/ai/todo-polish.ts
@@ -1,12 +1,10 @@
-import type { AIProvider, ModelId, ReasoningEffort } from '@shared/types';
-import { parseCLIOutput, spawnCLI } from './providers';
+import type { AIProvider, ModelId } from '@shared/types';
+import type { CommonAICLIOptions } from '@shared/types/ai';
+import { parseCLIOutput, spawnCLI, stripCodeFence } from './providers';
 
-export interface TodoPolishOptions {
+export interface TodoPolishOptions extends CommonAICLIOptions {
   text: string; // Raw requirement text to polish
   timeout: number; // in seconds
-  provider: AIProvider;
-  model: ModelId;
-  reasoningEffort?: ReasoningEffort;
   prompt?: string; // Custom prompt template (with {text} placeholder)
 }
 
@@ -15,19 +13,6 @@ export interface TodoPolishResult {
   title?: string;
   description?: string;
   error?: string;
-}
-
-/** Strip markdown code fence from AI output */
-function stripCodeFence(text: string): string {
-  const trimmed = text.trim();
-  const fenceMatch = trimmed.match(/```\w*\s*[\r\n]+([\s\S]*?)[\r\n]+\s*```\s*$/);
-  if (fenceMatch) {
-    return fenceMatch[1].trim();
-  }
-  return trimmed
-    .replace(/^```\w*\s*[\r\n]*/, '')
-    .replace(/[\r\n]*\s*```\s*$/, '')
-    .trim();
 }
 
 /** Parse JSON output from AI (expects { title, description } format) */
@@ -59,7 +44,16 @@ function parsePolishOutput(raw: string): { title: string; description: string } 
 }
 
 export async function polishTodoTask(options: TodoPolishOptions): Promise<TodoPolishResult> {
-  const { text, timeout, provider, model, reasoningEffort, prompt: customPrompt } = options;
+  const {
+    text,
+    timeout,
+    provider,
+    model,
+    reasoningEffort,
+    bare,
+    claudeEffort,
+    prompt: customPrompt,
+  } = options;
 
   const defaultPrompt = `You are a task management assistant. Convert the following raw requirement text into a structured todo task.
 
@@ -78,14 +72,14 @@ Raw requirement:
   return new Promise((resolve) => {
     const timeoutMs = timeout * 1000;
 
-    console.log(`[todo-polish] Starting with provider=${provider}, model=${model}`);
-
     const { proc, kill } = spawnCLI({
       provider,
       model,
       prompt,
       cwd: process.cwd(),
       reasoningEffort,
+      bare,
+      claudeEffort,
       outputFormat: 'json',
     });
 
@@ -119,7 +113,6 @@ Raw requirement:
       }
 
       const result = parseCLIOutput(provider, stdout);
-      console.log(`[todo-polish] Parse result:`, result);
 
       if (result.success && result.text) {
         const parsed = parsePolishOutput(result.text);

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,13 +162,22 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
         prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG, workdir, options),
     generateBranchName: (
       workdir: string,
-      options: { prompt: string; provider: string; model: string; reasoningEffort?: string }
+      options: {
+        prompt: string;
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
+      }
     ): Promise<{ success: boolean; branchName?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_BRANCH_NAME, workdir, options),
     startCodeReview: (
@@ -177,6 +186,8 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
+        bare?: boolean;
+        claudeEffort?: string;
         reviewId: string;
         language?: string;
         sessionId?: string; // Restore this parameter for "Continue Conversation"
@@ -694,6 +705,8 @@ const electronAPI = {
       provider: string;
       model: string;
       reasoningEffort?: string;
+      bare?: boolean;
+      claudeEffort?: string;
       prompt?: string;
     }): Promise<{ success: boolean; title?: string; description?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.TODO_AI_POLISH, options),

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -51,6 +51,8 @@ export function CommitBox({
         provider: commitMessageGenerator.provider,
         model: commitMessageGenerator.model,
         reasoningEffort: commitMessageGenerator.reasoningEffort,
+        bare: commitMessageGenerator.bare,
+        claudeEffort: commitMessageGenerator.claudeEffort,
         prompt: commitMessageGenerator.prompt,
       });
 

--- a/src/renderer/components/todo/TaskDialog.tsx
+++ b/src/renderer/components/todo/TaskDialog.tsx
@@ -110,6 +110,8 @@ export function TaskDialog({ open, onOpenChange, task, defaultStatus, repoPath }
         provider: todoPolish.provider,
         model: todoPolish.model,
         reasoningEffort: todoPolish.reasoningEffort,
+        bare: todoPolish.bare,
+        claudeEffort: todoPolish.claudeEffort,
         prompt: todoPolish.prompt,
       });
 

--- a/src/renderer/components/worktree/CreateWorktreeDialog.tsx
+++ b/src/renderer/components/worktree/CreateWorktreeDialog.tsx
@@ -340,6 +340,8 @@ export function CreateWorktreeDialog({
         provider: branchNameGenerator.provider,
         model: branchNameGenerator.model,
         reasoningEffort: branchNameGenerator.reasoningEffort,
+        bare: branchNameGenerator.bare,
+        claudeEffort: branchNameGenerator.claudeEffort,
       });
 
       if (result.success && result.branchName) {

--- a/src/renderer/hooks/useCodeReview.ts
+++ b/src/renderer/hooks/useCodeReview.ts
@@ -31,6 +31,8 @@ export function useCodeReview({ repoPath }: UseCodeReviewOptions): UseCodeReview
       provider: codeReviewSettings.provider,
       model: codeReviewSettings.model,
       reasoningEffort: codeReviewSettings.reasoningEffort,
+      bare: codeReviewSettings.bare,
+      claudeEffort: codeReviewSettings.claudeEffort,
       language: codeReviewSettings.language ?? '中文',
       prompt: codeReviewSettings.prompt,
     });
@@ -39,6 +41,8 @@ export function useCodeReview({ repoPath }: UseCodeReviewOptions): UseCodeReview
     codeReviewSettings.provider,
     codeReviewSettings.model,
     codeReviewSettings.reasoningEffort,
+    codeReviewSettings.bare,
+    codeReviewSettings.claudeEffort,
     codeReviewSettings.language,
     codeReviewSettings.prompt,
   ]);

--- a/src/renderer/stores/codeReviewContinue.ts
+++ b/src/renderer/stores/codeReviewContinue.ts
@@ -132,6 +132,8 @@ export async function startCodeReview(
     provider: AIProvider;
     model: string;
     reasoningEffort?: string;
+    bare?: boolean;
+    claudeEffort?: string;
     language: string;
     prompt?: string;
   }
@@ -199,6 +201,8 @@ export async function startCodeReview(
       provider: settings.provider,
       model: settings.model,
       reasoningEffort: settings.reasoningEffort,
+      bare: settings.bare,
+      claudeEffort: settings.claudeEffort,
       language: settings.language ?? '中文',
       reviewId,
       sessionId, // Pass sessionId for Claude session persistence

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -172,6 +172,8 @@ export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettin
   timeout: 120,
   provider: 'claude-code',
   model: 'haiku',
+  bare: true,
+  claudeEffort: 'low',
   prompt: defaultCommitPromptZh,
 };
 
@@ -180,6 +182,8 @@ export const defaultBranchNameGeneratorSettings: BranchNameGeneratorSettings = {
   enabled: false,
   provider: 'claude-code',
   model: 'haiku',
+  bare: true,
+  claudeEffort: 'low',
   prompt:
     '你是 Git 分支命名助手（不可用工具）。输入含 desc 可含 date/branch_style。任务：从 desc 判定 type、提取 ticket、生成 slug，按模板渲染分支名。只输出一行分支名，无解释无标点。\n\n约束：仅允许 a-z0-9-/.；全小写；词用 -；禁空格/中文/下划线/其他符号。渲染后：-// 连续压缩为 1；去掉首尾 - / .；空变量不产生多余分隔符。\n\nticket：识别 ABC-123/#456/issue 789 等 → 小写，去 #；若存在则置于 slug 最前（形成 ticket-slug）。\n\nslug：取核心关键词 3–8 词，过滤泛词（如：一下/相关/进行/支持/增加/优化/问题/功能/页面/接口/调整/更新/修改等）；必要时将中文概念转换为常见英文词（如 login/order/pay），无法转换则丢弃。\n\ntype 枚举：feat fix hotfix perf refactor docs test chore ci build 判定优先级：hotfix(紧急/回滚/prod) > perf(性能) > fix(bug/修复) > feat(新增) > refactor(结构不变) > docs > test > ci > build > chore(兜底)。\n\ndate: 格式为 yyyyMMdd\n\n输出格式：{type}-{date}-{slug}\n\ndate: {current_date}\ntime: {current_time}\ndesc：{description}',
 };
@@ -212,6 +216,8 @@ export const defaultTodoPolishSettings: TodoPolishSettings = {
   enabled: true,
   provider: 'claude-code',
   model: 'haiku',
+  bare: true,
+  claudeEffort: 'low',
   timeout: 60,
   prompt: defaultTodoPolishPromptZh,
 };
@@ -221,6 +227,8 @@ export const defaultCodeReviewSettings: CodeReviewSettings = {
   enabled: true,
   provider: 'claude-code',
   model: 'haiku',
+  bare: true,
+  claudeEffort: 'high',
   language: '中文',
   prompt: defaultCodeReviewPromptZh,
 };

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -11,6 +11,7 @@ import type {
   ReasoningEffort,
   ShellConfig,
 } from '@shared/types';
+import type { ClaudeEffort, CommonAISettings } from '@shared/types/ai';
 
 // Theme types
 export type Theme = 'light' | 'dark' | 'system' | 'sync-terminal';
@@ -205,41 +206,29 @@ export interface ClaudeCodeIntegrationSettings {
 }
 
 // Commit message generator settings
-export interface CommitMessageGeneratorSettings {
+export interface CommitMessageGeneratorSettings extends CommonAISettings {
   enabled: boolean;
   maxDiffLines: number;
   timeout: number; // in seconds
-  provider: AIProvider;
-  model: string; // Dynamic based on provider
-  reasoningEffort?: ReasoningEffort; // For Codex CLI
   prompt: string; // Custom prompt template
 }
 
 // Todo AI polish settings
-export interface TodoPolishSettings {
+export interface TodoPolishSettings extends CommonAISettings {
   enabled: boolean;
-  provider: AIProvider;
-  model: string; // Dynamic based on provider
-  reasoningEffort?: ReasoningEffort; // For Codex CLI
   timeout: number; // in seconds
   prompt: string; // Custom prompt template (with {text} placeholder)
 }
 
 // Branch name generator settings
-export interface BranchNameGeneratorSettings {
+export interface BranchNameGeneratorSettings extends CommonAISettings {
   enabled: boolean;
-  provider: AIProvider;
-  model: string; // Dynamic based on provider
-  reasoningEffort?: ReasoningEffort; // For Codex CLI
   prompt: string;
 }
 
 // Code review settings
-export interface CodeReviewSettings {
+export interface CodeReviewSettings extends CommonAISettings {
   enabled: boolean;
-  provider: AIProvider;
-  model: string; // Dynamic based on provider
-  reasoningEffort?: ReasoningEffort; // For Codex CLI
   language: string;
   prompt: string; // Custom prompt template
 }
@@ -568,7 +557,7 @@ export interface SettingsState {
 }
 
 // Re-export types from @shared/types
-export type { AIProvider, ReasoningEffort } from '@shared/types';
+export type { AIProvider, ClaudeEffort, CommonAISettings, ReasoningEffort } from '@shared/types';
 
 // Builtin agent IDs
 export const BUILTIN_AGENT_IDS: BuiltinAgentId[] = [

--- a/src/shared/types/ai.ts
+++ b/src/shared/types/ai.ts
@@ -8,3 +8,28 @@ export type GeminiModelId = 'gemini-3-pro-preview' | 'gemini-3-flash-preview';
 export type ModelId = ClaudeModelId | CodexModelId | CursorModelId | GeminiModelId;
 
 export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+
+// Claude Code effort parameter for CI/CD optimization
+// Controls how much effort Claude spends on reasoning (token usage vs quality)
+// Requires Claude CLI 2.1.60+ for full support
+export type ClaudeEffort = 'low' | 'medium' | 'high' | 'max' | 'auto';
+
+// Common AI optimization options shared across settings and CLI operations
+export interface AIOptimizationOptions {
+  bare?: boolean;
+  claudeEffort?: ClaudeEffort;
+}
+
+// Common AI settings interface for renderer store settings
+export interface CommonAISettings extends AIOptimizationOptions {
+  provider: AIProvider;
+  model: string;
+  reasoningEffort?: ReasoningEffort;
+}
+
+// Common AI CLI options for main process services
+export interface CommonAICLIOptions extends AIOptimizationOptions {
+  provider: AIProvider;
+  model: ModelId;
+  reasoningEffort?: ReasoningEffort;
+}


### PR DESCRIPTION
为 Claude CLI 添加两个优化标志支持，提升自动化场景下的性能和成本效率。

## 新增功能

**`--bare` 标志 (Claude CLI 2.1.81+)**
跳过 hooks、LSP、插件、skills 等交互式功能，适用于 CI/CD 和自动化脚本场景。

**`--effort` 标志 (Claude CLI 2.1.60+)**
控制推理力度，平衡 token 消耗与输出质量：
- `low`: 快速响应，低 token 消耗
- `medium`: 平衡模式
- `high`: 高质量输出
- `max`: 最大推理力度

## 重构改进

- 创建 `CommonAISettings` / `CommonAICLIOptions` 共享接口，消除各 AI 服务中重复的属性声明
- 统一 `stripCodeFence` 函数实现（从 commit-message/todo-polish 移至 providers.ts）
- 添加 Claude CLI 版本检测，仅在支持时启用特性标志
- 移除调试用的 console.log 语句

## 默认配置

| 功能 | bare | effort |
|------|------|--------|
| 提交消息生成 | true | low |
| 分支名生成 | true | low |
| Todo 润色 | true | low |
| 代码审查 | true | high |

代码审查使用 `high` effort 以保证审查质量，其他功能使用 `low` 以优化响应速度和成本。

🤖 Generated with [Claude Code](https://claude.com/claude-code)