### PR TITLE
fix(todo): 修复待办面板无法正确识别已选 worktree 的问题

### DIFF
--- a/src/renderer/components/layout/MainContent.tsx
+++ b/src/renderer/components/layout/MainContent.tsx
@@ -553,7 +553,8 @@ export function MainContent({
             )}
           >
             <TodoPanel
-              worktreePath={worktreePath}
+              repoPath={effectiveRepoPath ?? undefined}
+              worktreePath={effectiveWorktreePath ?? undefined}
               isActive={activeTab === 'todo'}
               onSwitchToAgent={() => onTabChange('chat')}
             />


### PR DESCRIPTION
TodoPanel 组件之前未接收 `repoPath` 参数，导致无法正确判断 worktree 是否已选择。

修复内容：
- 给 `TodoPanel` 传递 `repoPath={effectiveRepoPath ?? undefined}`
- 将 `worktreePath` 改为使用 `effectiveWorktreePath`，确保即使切换时也能保持有效上下文

这样当用户选择了 worktree 后，待办面板能正确识别并启用 "Auto Execute" 功能。