### PR TITLE
fix(git): 增强克隆仓库的 URL 解析和可靠性

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,17 @@
+# pnpm registry - use Taobao mirror for faster downloads in China
+registry=https://registry.npmmirror.com
+
+# Electron mirrors - essential for Chinese users
+electron_mirror=https://npmmirror.com/mirrors/electron/
+electron_builder_binaries_mirror=https://npmmirror.com/mirrors/electron-builder-binaries/
+
+# Cloudflared binary mirror
+cloudflared_dist_base_url=https://npmmirror.com/mirrors/cloudflared/
+
+# Node.js prebuilt binaries mirror
+sharp_binary_host=https://npmmirror.com/mirrors/sharp/
+sharp_libvips_binary_host=https://npmmirror.com/mirrors/sharp-libvips/
+
+# Other common binary mirrors
+puppeteer_download_host=https://npmmirror.com/mirrors/
+selenium_cdn=https://npmmirror.com/mirrors/selenium

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -1,5 +1,5 @@
 import { exec } from 'node:child_process';
-import { existsSync, promises as fs } from 'node:fs';
+import { existsSync, promises as fs, mkdirSync } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type {
@@ -1403,12 +1403,20 @@ export class GitService {
    * - SSH with optional port and multi-level paths
    */
   static isValidGitUrl(url: string): boolean {
-    // HTTPS: supports port, username, multi-level paths
-    // e.g., https://github.com/user/repo.git
-    //       https://git.example.com:8443/user/repo
-    //       https://user@github.com/user/repo.git
-    //       https://gitlab.com/group/subgroup/repo
-    const httpsPattern = /^https?:\/\/(?:[\w-]+@)?[\w.-]+(?::\d+)?(?:\/[\w.-]+)+(?:\.git)?$/;
+    // Use URL constructor for HTTP/HTTPS — handles ports, auth, encoded chars, etc.
+    if (/^https?:\/\//i.test(url)) {
+      try {
+        const parsed = new URL(url);
+        const segments = parsed.pathname
+          .replace(/^\/+|\/+$/g, '')
+          .split('/')
+          .filter(Boolean);
+        return segments.length > 0;
+      } catch {
+        return false;
+      }
+    }
+
     // SSH: supports port, multi-level paths
     // e.g., git@github.com:user/repo.git
     //       ssh://git@github.com:22/user/repo.git
@@ -1416,7 +1424,7 @@ export class GitService {
     const sshPattern =
       /^(?:ssh:\/\/)?(?:[\w-]+@)?[\w.-]+(?::\d+)?[:/](?:[\w.-]+\/)+[\w.-]+(?:\.git)?$/;
 
-    return httpsPattern.test(url) || sshPattern.test(url);
+    return sshPattern.test(url);
   }
 
   /**
@@ -1451,8 +1459,14 @@ export class GitService {
     const cloneBaseDir = path.dirname(targetPath);
     const cloneTarget = toGitPath(cloneBaseDir, targetPath);
 
-    // Create simple-git instance with progress callback
+    // Ensure parent directory exists before cloning
+    if (!existsSync(cloneBaseDir)) {
+      mkdirSync(cloneBaseDir, { recursive: true });
+    }
+
+    // Create simple-git instance with progress callback and extended timeout
     const git = createSimpleGit(cloneBaseDir, {
+      timeout: { block: 300_000 },
       progress: ({ method, stage, progress }) => {
         if (method === 'clone' && onProgress) {
           onProgress({ stage, progress });

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -1,5 +1,5 @@
 import { exec } from 'node:child_process';
-import { existsSync, promises as fs, mkdirSync } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import type {
@@ -1411,7 +1411,7 @@ export class GitService {
           .replace(/^\/+|\/+$/g, '')
           .split('/')
           .filter(Boolean);
-        return segments.length > 0;
+        return segments.length >= 2;
       } catch {
         return false;
       }
@@ -1460,9 +1460,7 @@ export class GitService {
     const cloneTarget = toGitPath(cloneBaseDir, targetPath);
 
     // Ensure parent directory exists before cloning
-    if (!existsSync(cloneBaseDir)) {
-      mkdirSync(cloneBaseDir, { recursive: true });
-    }
+    await fs.mkdir(cloneBaseDir, { recursive: true });
 
     // Create simple-git instance with progress callback and extended timeout
     const git = createSimpleGit(cloneBaseDir, {

--- a/src/renderer/components/git/AddRepositoryDialog.tsx
+++ b/src/renderer/components/git/AddRepositoryDialog.tsx
@@ -347,9 +347,16 @@ export function AddRepositoryDialog({
           if (!targetDirUserModifiedRef.current) {
             setTargetDir(autoTargetDir);
           }
+        } else {
+          setRepoName('');
+          setTargetDir('');
+          targetDirUserModifiedRef.current = false;
         }
       } catch {
         setIsValidUrl(false);
+        setRepoName('');
+        setTargetDir('');
+        targetDirUserModifiedRef.current = false;
       }
     }, 300);
 

--- a/src/renderer/components/git/AddRepositoryDialog.tsx
+++ b/src/renderer/components/git/AddRepositoryDialog.tsx
@@ -328,6 +328,12 @@ export function AddRepositoryDialog({
       return;
     }
 
+    const resetCloneFields = () => {
+      setRepoName('');
+      setTargetDir('');
+      targetDirUserModifiedRef.current = false;
+    };
+
     const timer = setTimeout(async () => {
       try {
         const result = await window.electronAPI.git.validateUrl(remoteUrl.trim());
@@ -348,15 +354,11 @@ export function AddRepositoryDialog({
             setTargetDir(autoTargetDir);
           }
         } else {
-          setRepoName('');
-          setTargetDir('');
-          targetDirUserModifiedRef.current = false;
+          resetCloneFields();
         }
       } catch {
         setIsValidUrl(false);
-        setRepoName('');
-        setTargetDir('');
-        targetDirUserModifiedRef.current = false;
+        resetCloneFields();
       }
     }, 300);
 

--- a/src/renderer/lib/gitClone.ts
+++ b/src/renderer/lib/gitClone.ts
@@ -33,15 +33,20 @@ export function parseGitUrl(url: string): ParsedGitUrl | null {
     let owner = '';
     let repo = '';
 
-    // Check for HTTPS URL
-    const httpsMatch = url.match(/^https?:\/\/(?:[\w-]+@)?([\w.-]+)(?::\d+)?\/(.+?)(?:\.git)?$/);
-    if (httpsMatch) {
-      protocol = 'https';
-      host = httpsMatch[1];
-      const path = httpsMatch[2];
-      pathSegments = path.split('/');
-      owner = pathSegments[0] || '';
-      repo = pathSegments[pathSegments.length - 1] || '';
+    // Check for HTTPS/HTTP URL — use URL constructor for robust parsing
+    if (/^https?:\/\//i.test(url)) {
+      try {
+        const parsed = new URL(url);
+        protocol = 'https';
+        host = parsed.hostname;
+        const path = parsed.pathname.replace(/^\/+|\.git$/g, '').replace(/\/+$/, '');
+        pathSegments = path.split('/').filter(Boolean);
+        if (pathSegments.length === 0) return null;
+        owner = pathSegments[0] || '';
+        repo = pathSegments[pathSegments.length - 1] || '';
+      } catch {
+        return null;
+      }
     } else {
       // Check for SSH URL
       // Format: git@github.com:user/repo.git or ssh://git@github.com:22/user/repo.git

--- a/src/renderer/lib/gitClone.ts
+++ b/src/renderer/lib/gitClone.ts
@@ -39,7 +39,10 @@ export function parseGitUrl(url: string): ParsedGitUrl | null {
         const parsed = new URL(url);
         protocol = 'https';
         host = parsed.hostname;
-        const path = parsed.pathname.replace(/^\/+|\.git$/g, '').replace(/\/+$/, '');
+        const path = parsed.pathname
+          .replace(/\/+$/, '')
+          .replace(/\.git$/, '')
+          .replace(/^\/+/, '');
         pathSegments = path.split('/').filter(Boolean);
         if (pathSegments.length === 0) return null;
         owner = pathSegments[0] || '';


### PR DESCRIPTION
用 `URL` 构造器替代正则表达式解析 HTTPS Git URL，更健壮地处理端口、认证信息和编码字符等边界情况。

正则表达式在处理包含端口号、用户名认证、URL 编码等复杂 URL 时容易出错。`URL` 构造器是浏览器/Node.js 原生 API，能正确处理这些场景。

**变更内容：**

- **URL 解析**：`GitService.isValidGitUrl()` 和 `parseGitUrl()` 统一使用 `URL` 构造器，替代原有正则
- **目录预创建**：克隆前自动创建父目录，避免目标路径不存在导致 `simple-git` 报错
- **克隆超时**：添加 300s 超时，防止大仓库克隆被意外中断
- **对话框状态**：URL 无效时正确重置 `repoName`/`targetDir`，避免残留旧值干扰用户
- **镜像配置**：添加 `.npmrc` 国内镜像源，加速中国用户下载依赖和二进制文件