### PR TITLE
fix(tree-sidebar): 修复移动到分组时传入错误参数的问题

### DIFF
--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -1383,7 +1383,7 @@ export function TreeSidebar({
                 currentGroupId={repoMenuTarget?.groupId}
                 onMove={(groupId) => {
                   if (repoMenuTarget) {
-                    onMoveToGroup(repoMenuTarget.path, groupId);
+                    onMoveToGroup(repoMenuTarget.id, groupId);
                   }
                 }}
                 onClose={() => setRepoMenuOpen(false)}


### PR DESCRIPTION
将 onMoveToGroup 的第一个参数从 path 改为 id，避免移动操作失败。