### PR TITLE
fix: 修复 Windows 终端与 Agent 检测异常

### DIFF
--- a/docs/windows-terminal-agent-fix.md
+++ b/docs/windows-terminal-agent-fix.md
@@ -1,0 +1,160 @@
+# Windows 终端与 Agent 检测修复说明
+
+## 背景
+
+在 Windows 环境下，项目出现了两个关联问题：
+
+1. 打开应用后，终端页报错：`session:create -> File not found`
+2. 设置页中的 `Claude`、`Codex` 显示“未安装”，即使本机命令实际可正常使用
+
+这两个现象本质上来自同一条链路：**Windows Shell 解析错误，导致终端创建和 Agent CLI 检测都使用了错误的 shell**。
+
+## 问题根因
+
+### 1. `pwsh.exe` 被误判为可用
+
+原来的 Windows Shell 检测逻辑中，只要配置项是 `powershell7`，就可能直接返回 `pwsh.exe` 这个命令名。
+
+但在部分 Windows 机器上：
+
+- 没有安装 PowerShell 7
+- 系统只有 Windows PowerShell 5.x，即 `powershell.exe`
+
+此时项目仍会把 `pwsh.exe` 当作可用 shell，最终传给 `node-pty`。`node-pty` 在创建 Windows 终端时找不到这个文件，就会抛出：
+
+`Error: File not found`
+
+### 2. Agent 检测依赖同一套 shell 逻辑
+
+`Claude`、`Codex` 的检测逻辑会执行：
+
+- `claude --version`
+- `codex --version`
+
+这些命令同样依赖 shell 解析与 PATH 注入。如果 shell 选错了，检测就会失败，界面上表现为“未安装”。
+
+### 3. 设置里缓存了错误状态
+
+即使系统环境已经正确，只要本地缓存中仍保留了旧的检测结果，设置页也可能继续显示“未安装”。
+
+## 修复内容
+
+### 一、修复 Windows Shell 检测与回退
+
+修改文件：`src/main/services/terminal/ShellDetector.ts`
+
+主要修复点：
+
+1. **新增真实 PATH 查找逻辑**
+   - 读取 Windows 注册表中的用户 PATH 和系统 PATH
+   - 与当前进程 PATH 合并后再进行命令查找
+
+2. **不再把纯命令名直接当作“可用路径”**
+   - 例如 `pwsh.exe`、`powershell.exe`、`cmd.exe`
+   - 现在会真正去 PATH 中解析它们是否存在
+
+3. **修复 `powershell7` 的自动回退**
+   - 若机器没有 `pwsh.exe`
+   - 自动回退到 `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+
+4. **修复 Windows 默认 shell 选择**
+   - 以前默认偏向 `pwsh.exe`
+   - 现在优先选择真实存在的 `pwsh`
+   - 若不存在，则稳定回退到系统 PowerShell
+
+### 二、修复设置页 Agent 状态刷新
+
+修改文件：`src/renderer/components/settings/AgentSettings.tsx`
+
+修复点：
+
+- 设置页打开时，自动刷新内置 Agent 的检测状态
+- 避免旧缓存导致 `Claude` / `Codex` 一直显示“未安装”
+
+### 三、修复安装包中 `sqlite3` 原生模块缺失
+
+修改文件：`package.json`
+
+修复点：
+
+- 去掉对 `sqlite3` 构建的忽略配置
+- 确保安装包内包含 `node_sqlite3.node`
+
+否则 EXE 运行时会出现主进程报错，导致应用无法正常启动。
+
+## 实际验证结果
+
+本次修复完成后，已进行以下验证：
+
+### 1. 类型检查
+
+- `pnpm typecheck` 通过
+
+### 2. 构建验证
+
+- `pnpm build` 通过
+
+### 3. Shell 解析验证
+
+在本机环境中确认：
+
+- `pwsh` 不存在
+- `powershell.exe` 存在
+- `claude` 可从 npm 全局目录解析
+- `codex` 可从 npm 全局目录解析
+
+修复后，`powershell7` 配置最终会正确解析为：
+
+`C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
+
+### 4. PTY 终端创建验证
+
+通过 Electron 直接调用构建产物中的 `PtyManager` 验证：
+
+- 能成功创建 PTY 会话
+- 能正常执行 PowerShell 命令
+- 终端输出正常返回
+
+### 5. Agent CLI 检测验证
+
+通过实际执行验证：
+
+- `claude --version` 可返回版本号
+- `codex --version` 可返回版本号
+
+### 6. 安装包级验证
+
+不仅验证了源码构建结果，还直接从已安装应用目录中的：
+
+`D:\Program Files\EnsoAI\resources\app.asar`
+
+导入实际运行代码进行验证，确认：
+
+- 已安装版本也能正确解析 shell
+- 已安装版本也能成功创建 PTY
+- 已安装版本也能检测 Claude / Codex
+
+## 最终结果
+
+本次修复后，Windows 环境下以下问题已解决：
+
+1. 终端页 `File not found` 报错
+2. `session:create` 失败
+3. `Claude` / `Codex` 被错误识别为“未安装”
+4. EXE 因 `sqlite3` 原生模块缺失导致的启动报错
+
+## 涉及文件
+
+- `src/main/services/terminal/ShellDetector.ts`
+- `src/renderer/components/settings/AgentSettings.tsx`
+- `package.json`
+
+## 备注
+
+如果后续再遇到类似问题，优先检查以下几点：
+
+1. 当前设置中选中的 shell 是否真实存在
+2. GUI 进程是否继承到了正确的 PATH
+3. npm 全局命令目录是否在用户 PATH 中
+4. 安装包中的原生模块是否已正确打入 `app.asar.unpacked`
+

--- a/package.json
+++ b/package.json
@@ -116,9 +116,6 @@
       "dmg-builder": "26.4.0",
       "app-builder-lib": "26.4.0",
       "electron-builder-squirrel-windows": "26.4.0"
-    },
-    "ignoredBuiltDependencies": [
-      "sqlite3"
-    ]
+    }
   }
 }

--- a/src/main/services/terminal/PtyManager.ts
+++ b/src/main/services/terminal/PtyManager.ts
@@ -90,6 +90,21 @@ function getWindowsRegistryEnvVars(): Record<string, string> {
   return envVars;
 }
 
+function lookupEnvVar(varName: string, registryEnvVars: Record<string, string>): string | null {
+  const upperVarName = varName.toUpperCase();
+  for (const [key, value] of Object.entries(registryEnvVars)) {
+    if (key.toUpperCase() === upperVarName) {
+      return value;
+    }
+  }
+  for (const [key, value] of Object.entries(process.env)) {
+    if (key.toUpperCase() === upperVarName && value) {
+      return value;
+    }
+  }
+  return null;
+}
+
 /**
  * Expand Windows environment variables in a string (e.g., %PATH% -> actual value)
  * Reads variable values from registry (GUI apps don't inherit shell environment)
@@ -99,15 +114,39 @@ function expandWindowsEnvVars(str: string): string {
 
   // Replace %VAR% patterns with their values from registry
   return str.replace(/%([^%]+)%/g, (match, varName) => {
-    const upperVarName = varName.toUpperCase();
-    for (const [key, value] of Object.entries(registryEnvVars)) {
-      if (key.toUpperCase() === upperVarName) {
-        return value;
-      }
-    }
-    // Keep original if not found
-    return match;
+    const resolved = lookupEnvVar(varName, registryEnvVars);
+    return resolved ?? match;
   });
+}
+
+function splitPathEntries(pathValue: string): string[] {
+  return pathValue
+    .split(delimiter)
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+export function mergePathLists(primary: string, secondary?: string): string {
+  const merged = new Set<string>();
+  for (const entry of splitPathEntries(primary)) {
+    merged.add(entry);
+  }
+  for (const entry of splitPathEntries(secondary ?? '')) {
+    if (!merged.has(entry)) {
+      merged.add(entry);
+    }
+  }
+  return [...merged].join(delimiter);
+}
+
+function applyEnhancedPath(env: Record<string, string>): void {
+  const enhancedPath = getEnhancedPath();
+  const currentPath = env.PATH || env.Path || '';
+  const mergedPath = mergePathLists(enhancedPath, currentPath);
+  env.PATH = mergedPath;
+  if (isWindows) {
+    env.Path = mergedPath;
+  }
 }
 
 /**
@@ -373,6 +412,17 @@ export class PtyManager {
     }
 
     let ptyProcess: pty.IPty;
+    const baseEnv: Record<string, string> = {
+      ...process.env,
+      ...getProxyEnvVars(),
+      ...options.env,
+      TERM: 'xterm-256color',
+      COLORTERM: 'truecolor',
+      // Ensure proper locale for UTF-8 support (GUI apps may not inherit LANG)
+      LANG: process.env.LANG || 'en_US.UTF-8',
+      LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
+    } as Record<string, string>;
+    applyEnhancedPath(baseEnv);
 
     try {
       ptyProcess = pty.spawn(shell, args, {
@@ -380,16 +430,7 @@ export class PtyManager {
         cols: options.cols || 80,
         rows: options.rows || 24,
         cwd: spawnCwd,
-        env: {
-          ...process.env,
-          ...getProxyEnvVars(),
-          ...options.env,
-          TERM: 'xterm-256color',
-          COLORTERM: 'truecolor',
-          // Ensure proper locale for UTF-8 support (GUI apps may not inherit LANG)
-          LANG: process.env.LANG || 'en_US.UTF-8',
-          LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
-        } as Record<string, string>,
+        env: baseEnv,
       });
     } catch (error) {
       if (!isWindows) {

--- a/src/main/services/terminal/ShellDetector.ts
+++ b/src/main/services/terminal/ShellDetector.ts
@@ -1,5 +1,6 @@
-import { exec } from 'node:child_process';
+import { exec, execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
+import { delimiter, join } from 'node:path';
 import { promisify } from 'node:util';
 import type { ShellConfig, ShellInfo } from '@shared/types';
 
@@ -19,7 +20,11 @@ const WINDOWS_SHELLS: ShellDefinition[] = [
   {
     id: 'powershell7',
     name: 'PowerShell 7',
-    paths: ['pwsh.exe'],
+    paths: [
+      'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      'C:\\Program Files\\PowerShell\\7-preview\\pwsh.exe',
+      'pwsh.exe',
+    ],
     args: ['-NoLogo'],
     // -Login loads user profile (for version managers like vfox, nvm-windows, etc.)
     // -ExecutionPolicy Bypass allows running .ps1 scripts (npm global packages use them)
@@ -28,7 +33,11 @@ const WINDOWS_SHELLS: ShellDefinition[] = [
   {
     id: 'powershell',
     name: 'PowerShell',
-    paths: ['powershell.exe'],
+    paths: [
+      'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe',
+      'powershell.exe',
+    ],
     args: ['-NoLogo'],
     // -ExecutionPolicy Bypass allows running .ps1 scripts (npm global packages use them)
     execArgs: ['-NoLogo', '-ExecutionPolicy', 'Bypass', '-Command'],
@@ -36,7 +45,7 @@ const WINDOWS_SHELLS: ShellDefinition[] = [
   {
     id: 'cmd',
     name: 'Command Prompt',
-    paths: ['cmd.exe'],
+    paths: ['C:\\Windows\\System32\\cmd.exe', 'C:\\Windows\\SysWOW64\\cmd.exe', 'cmd.exe'],
     args: [],
     execArgs: ['/c'],
   },
@@ -61,7 +70,7 @@ const WINDOWS_SHELLS: ShellDefinition[] = [
   {
     id: 'wsl',
     name: 'WSL',
-    paths: ['wsl.exe'],
+    paths: ['C:\\Windows\\System32\\wsl.exe', 'wsl.exe'],
     args: [],
     execArgs: ['--', 'bash', '-ilc'],
     isWsl: true,
@@ -109,6 +118,97 @@ const UNIX_SHELLS: ShellDefinition[] = [
 class ShellDetector {
   private cachedShells: ShellInfo[] | null = null;
   private wslAvailable: boolean | null = null;
+  private windowsPathCache: string | null = null;
+
+  private getWindowsPath(): string {
+    if (!isWindows) {
+      return process.env.PATH || '';
+    }
+    if (this.windowsPathCache !== null) {
+      return this.windowsPathCache;
+    }
+
+    const parseRegistryValue = (output: string): string => {
+      const match = output.match(/Path\s+REG_(?:EXPAND_)?SZ\s+(.+)/i);
+      return match ? match[1].trim() : '';
+    };
+
+    const expandEnvVars = (value: string): string =>
+      value.replace(/%([^%]+)%/g, (match, varName) => process.env[varName] || match);
+
+    try {
+      let userPath = '';
+      let systemPath = '';
+
+      try {
+        userPath = parseRegistryValue(
+          execSync('reg query "HKCU\\Environment" /v Path 2>nul', {
+            encoding: 'utf8',
+            timeout: 3000,
+          })
+        );
+      } catch {
+        // Ignore missing user PATH
+      }
+
+      try {
+        systemPath = parseRegistryValue(
+          execSync(
+            'reg query "HKLM\\SYSTEM\\CurrentControlSet\\Control\\Session Manager\\Environment" /v Path 2>nul',
+            {
+              encoding: 'utf8',
+              timeout: 3000,
+            }
+          )
+        );
+      } catch {
+        // Ignore missing system PATH
+      }
+
+      const combined = [systemPath, userPath, process.env.Path, process.env.PATH]
+        .filter(Boolean)
+        .join(delimiter);
+      this.windowsPathCache = expandEnvVars(combined);
+      return this.windowsPathCache;
+    } catch {
+      this.windowsPathCache = process.env.Path || process.env.PATH || '';
+      return this.windowsPathCache;
+    }
+  }
+
+  private resolveCommandOnPath(command: string): string | null {
+    const pathValue = isWindows ? this.getWindowsPath() : process.env.PATH || '';
+    const directories = pathValue.split(delimiter).filter(Boolean);
+
+    if (isWindows) {
+      const hasKnownExtension = /\.(exe|cmd|bat|com)$/i.test(command);
+      const extensions = hasKnownExtension
+        ? ['']
+        : (process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD')
+            .split(';')
+            .filter(Boolean)
+            .map((ext) => ext.toLowerCase());
+
+      for (const directory of directories) {
+        for (const extension of extensions) {
+          const candidate = join(directory, hasKnownExtension ? command : `${command}${extension}`);
+          if (existsSync(candidate)) {
+            return candidate;
+          }
+        }
+      }
+      return null;
+    }
+
+    for (const directory of directories) {
+      const candidate = join(directory, command);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+
+    return null;
+  }
 
   private async isWslAvailable(): Promise<boolean> {
     if (this.wslAvailable !== null) {
@@ -118,8 +218,15 @@ class ShellDetector {
       this.wslAvailable = false;
       return false;
     }
+
+    const wslPath = this.findAvailablePath(['C:\\Windows\\System32\\wsl.exe', 'wsl.exe']);
+    if (!wslPath) {
+      this.wslAvailable = false;
+      return false;
+    }
+
     try {
-      await execAsync('wsl --status', { timeout: 3000 });
+      await execAsync(`"${wslPath}" --status`, { timeout: 3000 });
       this.wslAvailable = true;
       return true;
     } catch {
@@ -135,7 +242,10 @@ class ShellDetector {
           return p;
         }
       } else {
-        return p;
+        const resolved = this.resolveCommandOnPath(p);
+        if (resolved) {
+          return resolved;
+        }
       }
     }
     return null;
@@ -147,10 +257,11 @@ class ShellDetector {
     for (const def of WINDOWS_SHELLS) {
       if (def.isWsl) {
         if (await this.isWslAvailable()) {
+          const resolvedPath = this.findAvailablePath(def.paths) || def.paths[0];
           shells.push({
             id: def.id,
             name: def.name,
-            path: 'wsl.exe',
+            path: resolvedPath,
             args: def.args,
             available: true,
             isWsl: true,
@@ -214,9 +325,20 @@ class ShellDetector {
 
   resolveShellConfig(config: ShellConfig): { shell: string; args: string[] } {
     if (config.shellType === 'custom') {
+      const customPath = config.customShellPath?.trim();
+      const customArgs = config.customShellArgs || [];
+      if (customPath) {
+        if (customPath.includes('\\') || customPath.startsWith('/')) {
+          if (existsSync(customPath)) {
+            return { shell: customPath, args: customArgs };
+          }
+        } else {
+          return { shell: customPath, args: customArgs };
+        }
+      }
       return {
-        shell: config.customShellPath || (isWindows ? 'powershell.exe' : '/bin/sh'),
-        args: config.customShellArgs || [],
+        shell: isWindows ? 'powershell.exe' : '/bin/sh',
+        args: isWindows ? ['-NoLogo'] : [],
       };
     }
 
@@ -260,10 +382,22 @@ class ShellDetector {
    */
   resolveShellForCommand(config: ShellConfig): { shell: string; execArgs: string[] } {
     if (config.shellType === 'custom') {
-      const shell = config.customShellPath || (isWindows ? 'powershell.exe' : '/bin/sh');
-      // For custom shell, try to infer execArgs based on shell name
-      const execArgs = this.inferExecArgs(shell, config.customShellArgs);
-      return { shell, execArgs };
+      const customPath = config.customShellPath?.trim();
+      const customArgs = config.customShellArgs || [];
+      if (customPath) {
+        if (customPath.includes('\\') || customPath.startsWith('/')) {
+          if (existsSync(customPath)) {
+            const execArgs = this.inferExecArgs(customPath, customArgs);
+            return { shell: customPath, execArgs };
+          }
+        } else {
+          const execArgs = this.inferExecArgs(customPath, customArgs);
+          return { shell: customPath, execArgs };
+        }
+      }
+      const fallbackShell = isWindows ? 'powershell.exe' : '/bin/sh';
+      const execArgs = this.inferExecArgs(fallbackShell, customArgs);
+      return { shell: fallbackShell, execArgs };
     }
 
     const definitions = isWindows ? WINDOWS_SHELLS : UNIX_SHELLS;
@@ -339,8 +473,20 @@ class ShellDetector {
 
   getDefaultShell(): string {
     if (isWindows) {
-      // Try pwsh.exe (PowerShell 7) from PATH first
-      return 'pwsh.exe';
+      const pwshPath = this.findAvailablePath(['C:\\Program Files\\PowerShell\\7\\pwsh.exe', 'pwsh.exe']);
+      if (pwshPath) {
+        return pwshPath;
+      }
+
+      const powershellPath = this.findAvailablePath([
+        'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe',
+        'powershell.exe',
+      ]);
+      if (powershellPath) {
+        return powershellPath;
+      }
+
+      return 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';
     }
 
     const shell = process.env.SHELL;

--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -6,7 +6,7 @@
 import type { ShellConfig } from '@shared/types';
 import * as pty from 'node-pty';
 import { readSettings } from '../ipc/settings';
-import { findLoginShell, getEnhancedPath } from '../services/terminal/PtyManager';
+import { findLoginShell, getEnhancedPath, mergePathLists } from '../services/terminal/PtyManager';
 import { shellDetector } from '../services/terminal/ShellDetector';
 import { killProcessTree } from './processUtils';
 
@@ -133,13 +133,19 @@ export function getShellForCommand(): { shell: string; args: string[] } {
  * Includes enhanced PATH and proper locale settings.
  */
 export function getEnvForCommand(additionalEnv?: Record<string, string>): Record<string, string> {
-  return {
+  const env = {
     ...process.env,
-    PATH: getEnhancedPath(),
-    LANG: process.env.LANG || 'en_US.UTF-8',
-    LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
     ...additionalEnv,
   } as Record<string, string>;
+  const currentPath = env.PATH || env.Path || '';
+  const mergedPath = mergePathLists(getEnhancedPath(), currentPath);
+  env.PATH = mergedPath;
+  if (process.platform === 'win32') {
+    env.Path = mergedPath;
+  }
+  env.LANG = process.env.LANG || 'en_US.UTF-8';
+  env.LC_ALL = process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8';
+  return env;
 }
 
 export interface ExecInPtyOptions {

--- a/src/renderer/components/settings/AgentSettings.tsx
+++ b/src/renderer/components/settings/AgentSettings.tsx
@@ -267,6 +267,10 @@ export function AgentSettings({ repoPath }: { repoPath?: string }) {
     }
   }, [agentSettings, customAgents, repoPath, setAgentDetectionStatus, setAgentEnabled]);
 
+  React.useEffect(() => {
+    void Promise.allSettled(BUILTIN_AGENTS.map((agentId) => detectSingleAgent(agentId)));
+  }, [detectSingleAgent]);
+
   const handleEnabledChange = (agentId: string, enabled: boolean) => {
     setAgentEnabled(agentId, enabled);
     if (!enabled) {


### PR DESCRIPTION
## 问题

Windows 环境下存在两个关联问题：

1. 终端页会报 `session:create -> File not found`
2. 设置页中的 Claude / Codex 即使本机已安装，也会显示“未安装”

## 根因

`ShellDetector` 在 Windows 上会把 `pwsh.exe` 这种命令名直接当成可用 shell。

如果机器没有安装 PowerShell 7，但设置里仍是 `powershell7`，项目最终会把不存在的 `pwsh.exe` 传给 `node-pty`，从而触发终端创建失败；同时 Agent CLI 检测也会走同一套错误 shell，导致 Claude / Codex 误报未安装。

## 修改

- 修复 Windows shell 检测逻辑，真实扫描 PATH / 注册表，不再把命令名直接视为可用路径
- 为 `powershell7` 增加可靠回退，缺少 `pwsh.exe` 时自动回退到系统 `powershell.exe`
- 统一 PTY / CLI 检测环境下的 PATH 合并逻辑，确保 GUI 进程也能找到用户 PATH 中的 CLI
- 设置页打开时自动刷新内置 Agent 检测状态，避免旧缓存导致持续显示“未安装”
- 恢复 `sqlite3` 原生模块构建，避免安装包运行时因缺少 `node_sqlite3.node` 崩溃
- 补充中文修复文档：`docs/windows-terminal-agent-fix.md`

## 验证

- `pnpm typecheck`
- `pnpm build`
- 通过 Electron 直接验证构建产物：
  - `powershell7` 能正确回退到 `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe`
  - `claude --version` 可正常返回版本
  - `codex --version` 可正常返回版本
  - PTY 会话可成功创建并执行 PowerShell 命令
- 通过已安装包 `D:\Program Files\EnsoAI\resources\app.asar` 再次验证上述链路全部通过
