### PR TITLE
fix(source-control): 工作区文件变更时同步 Git 状态与 Diff 视图

### DIFF
--- a/src/renderer/components/source-control/DiffReviewModal.tsx
+++ b/src/renderer/components/source-control/DiffReviewModal.tsx
@@ -356,7 +356,8 @@ export function DiffReviewModal({ open, onOpenChange, rootPath, onSend }: DiffRe
     rootPath ?? null,
     selectedFile?.submodulePath ?? null,
     selectedFile?.submodulePath ? selectedFile.path : null,
-    selectedFile?.staged ?? false
+    selectedFile?.staged ?? false,
+    { enabled: open, isActive: open }
   );
 
   // 合并 diff 数据

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -1021,6 +1021,7 @@ export function DiffViewer({
     hasAutoNavigatedRef.current = false;
     setIsEditing(false);
     setEditedContent(null);
+    diffContentRef.current = '';
   }, [file?.path, file?.staged]);
 
   if (!file) {

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -1,8 +1,17 @@
-import { getDisplayPathBasename, joinPath } from '@shared/utils/path';
+import {
+  getDisplayPathBasename,
+  getPathBasename,
+  joinPath,
+  normalizePath,
+} from '@shared/utils/path';
 import { useQueryClient } from '@tanstack/react-query';
 import { ChevronDown, GitBranch, GripVertical, History, PanelLeft } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { getStoredBoolean, STORAGE_KEYS } from '@/App/storage';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  getStoredBoolean,
+  normalizePath as normalizePathForCompare,
+  STORAGE_KEYS,
+} from '@/App/storage';
 import { GitSyncButton } from '@/components/git/GitSyncButton';
 import {
   AlertDialog,
@@ -31,6 +40,7 @@ import {
 } from '@/hooks/useGit';
 import { useCommitDiff, useCommitFiles, useGitHistoryInfinite } from '@/hooks/useGitHistory';
 import { useGitSync } from '@/hooks/useGitSync';
+import { useSharedFileWatch } from '@/hooks/useSharedFileWatch';
 import {
   useFileChanges,
   useGitCommit,
@@ -243,7 +253,8 @@ export function SourceControlPanel({
     rootPath ?? null,
     selectedSubmoduleFile?.submodulePath ?? null,
     selectedSubmoduleFile?.path ?? null,
-    selectedSubmoduleFile?.staged ?? false
+    selectedSubmoduleFile?.staged ?? false,
+    { enabled: isActive, isActive }
   );
 
   const {
@@ -264,6 +275,10 @@ export function SourceControlPanel({
     }
   }, [repositories.length, selectedRepo]);
 
+  // Get the working directory for the selected repo
+  const selectedRepoPath =
+    selectedSubmodulePath && rootPath ? joinPath(rootPath, selectedSubmodulePath) : rootPath;
+
   // Refetch immediately when tab becomes active
   useEffect(() => {
     if (isActive && rootPath) {
@@ -273,8 +288,13 @@ export function SourceControlPanel({
       // Also refresh submodules data
       queryClient.invalidateQueries({ queryKey: ['git', 'submodules', rootPath] });
       queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'changes', rootPath] });
+      // Worktree / submodule file diffs are separate queries; refresh so diff viewer matches disk
+      queryClient.invalidateQueries({
+        queryKey: ['git', 'file-diff', selectedRepoPath ?? rootPath],
+      });
+      queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'diff', rootPath] });
     }
-  }, [isActive, rootPath, refetch, refetchCommits, refetchStatus, queryClient]);
+  }, [isActive, rootPath, selectedRepoPath, refetch, refetchCommits, refetchStatus, queryClient]);
 
   // Wrap sync handlers to add additional refetch calls for SourceControlPanel
   const handleSync = useCallback(
@@ -606,9 +626,130 @@ export function SourceControlPanel({
   // Panel resize hooks
   const { width: panelWidth, isResizing, containerRef, handleMouseDown } = usePanelResize();
 
-  // Get the working directory for the selected repo
-  const selectedRepoPath =
-    selectedSubmodulePath && rootPath ? joinPath(rootPath, selectedSubmodulePath) : rootPath;
+  const normalizeFsPathForCompare = useCallback((p: string) => {
+    // 1) Normalize slashes using shared util
+    // 2) Apply renderer-level comparison normalization (trim + case normalization by platform)
+    return normalizePathForCompare(normalizePath(p));
+  }, []);
+
+  const expectedBulkNormalized = useMemo(() => {
+    if (!rootPath) return null;
+    return normalizeFsPathForCompare(joinPath(rootPath, '.enso-bulk'));
+  }, [rootPath, normalizeFsPathForCompare]);
+
+  const rootPathRef = useRef(rootPath);
+  useEffect(() => {
+    rootPathRef.current = rootPath;
+  }, [rootPath]);
+
+  const invalidateTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleGitListInvalidate = useCallback(() => {
+    const currentRoot = rootPathRef.current;
+    if (!currentRoot) return;
+    if (invalidateTimerRef.current) return;
+    invalidateTimerRef.current = setTimeout(() => {
+      invalidateTimerRef.current = null;
+      const latestRoot = rootPathRef.current;
+      if (!latestRoot) return;
+      queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', latestRoot] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'status', latestRoot] });
+      queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'changes', latestRoot] });
+    }, 200);
+  }, [queryClient]);
+
+  // If rootPath changes mid-flight, cancel any pending invalidation targeting the old root.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally cancel on rootPath change only
+  useEffect(() => {
+    if (invalidateTimerRef.current) {
+      clearTimeout(invalidateTimerRef.current);
+      invalidateTimerRef.current = null;
+    }
+  }, [rootPath]);
+
+  // Always keep git state (including diff) in sync with disk changes.
+  // This covers modifications made from anywhere (editor, terminal, external tools).
+  useSharedFileWatch(
+    rootPath ?? null,
+    (event) => {
+      if (!rootPath) return;
+
+      const eventPathNormalized = normalizeFsPathForCompare(event.path);
+      const eventBasename = getPathBasename(normalizePath(event.path));
+
+      // Bulk marker (too many events) — just refresh all git data.
+      if (
+        eventBasename === '.enso-bulk' &&
+        expectedBulkNormalized &&
+        eventPathNormalized === expectedBulkNormalized
+      ) {
+        if (invalidateTimerRef.current) {
+          clearTimeout(invalidateTimerRef.current);
+          invalidateTimerRef.current = null;
+        }
+        queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', rootPath] });
+        queryClient.invalidateQueries({ queryKey: ['git', 'status', rootPath] });
+        queryClient.invalidateQueries({
+          queryKey: ['git', 'file-diff', selectedRepoPath ?? rootPath],
+        });
+        queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'diff', rootPath] });
+        queryClient.invalidateQueries({ queryKey: ['git', 'submodule', 'changes', rootPath] });
+        return;
+      }
+
+      // Keep list/status fresh, but coalesce frequent file events to avoid UI/IPC thrash.
+      scheduleGitListInvalidate();
+
+      // Refresh currently selected diff (main repo).
+      if (selectedFile && selectedRepoPath) {
+        const expectedAbs = joinPath(selectedRepoPath, selectedFile.path);
+        const expectedNormalized = normalizeFsPathForCompare(expectedAbs);
+        if (eventPathNormalized === expectedNormalized) {
+          queryClient.invalidateQueries({
+            queryKey: [
+              'git',
+              'file-diff',
+              selectedRepoPath,
+              selectedFile.path,
+              selectedFile.staged,
+            ],
+          });
+        }
+      }
+
+      // Refresh currently selected diff (submodule file view).
+      if (selectedSubmoduleFile) {
+        const expectedAbs = joinPath(
+          rootPath,
+          selectedSubmoduleFile.submodulePath,
+          selectedSubmoduleFile.path
+        );
+        const expectedNormalized = normalizeFsPathForCompare(expectedAbs);
+        if (eventPathNormalized === expectedNormalized) {
+          queryClient.invalidateQueries({
+            queryKey: [
+              'git',
+              'submodule',
+              'diff',
+              rootPath,
+              selectedSubmoduleFile.submodulePath,
+              selectedSubmoduleFile.path,
+              selectedSubmoduleFile.staged,
+            ],
+          });
+        }
+      }
+    },
+    { enabled: !!rootPath }
+  );
+
+  useEffect(() => {
+    return () => {
+      if (invalidateTimerRef.current) {
+        clearTimeout(invalidateTimerRef.current);
+        invalidateTimerRef.current = null;
+      }
+    };
+  }, []);
 
   // Git mutations
   const stageMutation = useGitStage();
@@ -704,7 +845,7 @@ export function SourceControlPanel({
           await Promise.all([
             queryClient.invalidateQueries({ queryKey: ['git', 'file-changes', rootPath] }),
             queryClient.invalidateQueries({ queryKey: ['git', 'status', rootPath] }),
-            queryClient.invalidateQueries({ queryKey: ['git', 'file-diff', rootPath] }),
+            queryClient.invalidateQueries({ queryKey: ['git', 'file-diff', selectedRepoPath] }),
           ]);
         }
       }
@@ -1012,11 +1153,22 @@ export function SourceControlPanel({
                     if (selectedSubmodulePath) {
                       refetchSubmoduleChanges();
                       refetchSubmoduleCommits();
+                      if (rootPath) {
+                        queryClient.invalidateQueries({
+                          queryKey: ['git', 'submodule', 'diff', rootPath],
+                        });
+                      }
                     } else if (rootPath) {
                       await fetchMutation.mutateAsync({ workdir: rootPath });
                       refetch();
                       refetchCommits();
                       refetchStatus();
+                      queryClient.invalidateQueries({
+                        queryKey: ['git', 'file-diff', selectedRepoPath ?? rootPath],
+                      });
+                      queryClient.invalidateQueries({
+                        queryKey: ['git', 'submodule', 'diff', rootPath],
+                      });
                     }
                   }}
                   isRefreshing={
@@ -1094,6 +1246,14 @@ export function SourceControlPanel({
                     refetch();
                     refetchCommits();
                     refetchStatus();
+                    if (rootPath) {
+                      queryClient.invalidateQueries({
+                        queryKey: ['git', 'file-diff', selectedRepoPath ?? rootPath],
+                      });
+                      queryClient.invalidateQueries({
+                        queryKey: ['git', 'submodule', 'diff', rootPath],
+                      });
+                    }
                   }}
                 />
               </div>

--- a/src/renderer/hooks/useSharedFileWatch.ts
+++ b/src/renderer/hooks/useSharedFileWatch.ts
@@ -1,0 +1,78 @@
+import { getPathBasename, normalizePath, trimTrailingPathSeparators } from '@shared/utils/path';
+import { useEffect, useMemo, useRef } from 'react';
+
+type FileChangeEvent = {
+  type: 'create' | 'update' | 'delete';
+  path: string;
+};
+
+type WatchEntry = {
+  dirPath: string;
+  normalizedDirPath: string;
+  refCount: number;
+  stop?: () => void;
+};
+
+const watches = new Map<string, WatchEntry>();
+
+function normalizeWatchedPath(p: string) {
+  return trimTrailingPathSeparators(normalizePath(p));
+}
+
+export function useSharedFileWatch(
+  dirPath: string | null,
+  onChange: (event: FileChangeEvent) => void,
+  options?: { enabled?: boolean }
+) {
+  const enabled = options?.enabled ?? true;
+
+  const normalizedDirPath = useMemo(
+    () => (dirPath ? normalizeWatchedPath(dirPath) : null),
+    [dirPath]
+  );
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useEffect(() => {
+    if (!dirPath || !normalizedDirPath || !enabled) return;
+
+    const key = normalizedDirPath;
+    let entry = watches.get(key);
+    if (!entry) {
+      entry = { dirPath, normalizedDirPath, refCount: 0 };
+      watches.set(key, entry);
+    }
+    entry.refCount += 1;
+
+    if (!entry.stop) {
+      void window.electronAPI.file.watchStart(dirPath);
+      const unsubscribe = window.electronAPI.file.onChange((event) => {
+        const eventPath = normalizeWatchedPath(event.path);
+        // Deliver only events under the watched dir (or the bulk marker inside it)
+        if (eventPath === key || eventPath.startsWith(`${key}/`)) {
+          onChangeRef.current(event);
+          return;
+        }
+
+        // Bulk marker: allow delivery even if the watcher reports a different prefix.
+        if (getPathBasename(eventPath) === '.enso-bulk') {
+          onChangeRef.current(event);
+        }
+      });
+      entry.stop = () => {
+        unsubscribe();
+        void window.electronAPI.file.watchStop(dirPath);
+      };
+    }
+
+    return () => {
+      const current = watches.get(key);
+      if (!current) return;
+      current.refCount -= 1;
+      if (current.refCount <= 0) {
+        current.stop?.();
+        watches.delete(key);
+      }
+    };
+  }, [dirPath, normalizedDirPath, enabled]);
+}

--- a/src/renderer/hooks/useSubmodules.ts
+++ b/src/renderer/hooks/useSubmodules.ts
@@ -217,15 +217,30 @@ export function useSubmoduleFileDiff(
   workdir: string | null,
   submodulePath: string | null,
   filePath: string | null,
-  staged: boolean
+  staged: boolean,
+  options?: { enabled?: boolean; isActive?: boolean }
 ) {
+  const shouldPoll = useShouldPoll();
+
   return useQuery({
     queryKey: ['git', 'submodule', 'diff', workdir, submodulePath, filePath, staged],
     queryFn: async () => {
       if (!workdir || !submodulePath || !filePath) return null;
       return window.electronAPI.git.getSubmoduleFileDiff(workdir, submodulePath, filePath, staged);
     },
-    enabled: !!workdir && !!submodulePath && !!filePath,
+    enabled: (options?.enabled ?? true) && !!workdir && !!submodulePath && !!filePath,
+    staleTime: 0,
+    // Prefer event-driven refresh; polling is a lightweight fallback only while active.
+    refetchInterval: shouldPoll && (options?.isActive ?? true) ? 5000 : false,
+    refetchIntervalInBackground: false,
+    // When not active, avoid passive refetches (e.g. focus/mount) to reduce git diff pressure.
+    ...(options?.isActive === false
+      ? {
+          refetchOnMount: false as const,
+          refetchOnWindowFocus: false as const,
+          refetchOnReconnect: false as const,
+        }
+      : {}),
   });
 }
 


### PR DESCRIPTION
- 新增 useSharedFileWatch，复用目录 watcher 并合并失效 file-changes/status 等查询
- 面板激活与刷新时补充 file-diff、submodule diff 查询失效；支持 .enso-bulk 批量标记
- 子模块文件 Diff 支持 enabled/isActive，激活时轻量轮询兜底，非激活时减少被动 refetch
- DiffViewer 切换文件时清空 diff 内容缓存