### PR TITLE
feat: add external session focus api

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import { readSettings } from './ipc/settings';
 import { registerWindowHandlers } from './ipc/window';
 import { registerClaudeBridgeIpcHandlers } from './services/claude/ClaudeIdeBridge';
 import { unwatchClaudeSettings } from './services/claude/ClaudeProviderManager';
+import { externalSessionApiServer } from './services/externalSession/ExternalSessionApiServer';
 import {
   isAllowedLocalFilePath,
   registerAllowedLocalFileRoot,
@@ -626,6 +627,10 @@ app.whenReady().then(async () => {
   // Default open or close DevTools by F12 in development
   // Also intercept Cmd+- for all windows to bypass Monaco Editor interception
   app.on('browser-window-created', (_, window) => {
+    window.on('closed', () => {
+      externalSessionApiServer.clearWindow(window.id);
+    });
+
     // Snapshot listeners before the optimizer adds its own, only needed in production.
     const listenersBefore = app.isPackaged
       ? new Set(window.webContents.listeners('before-input-event'))
@@ -680,6 +685,7 @@ app.whenReady().then(async () => {
 
   // Auto-start Hapi server if enabled in settings
   await autoStartHapi();
+  await externalSessionApiServer.start();
 
   setCurrentLocale(readStoredLanguage());
 
@@ -761,6 +767,7 @@ app.on('will-quit', (event) => {
   cleanupWindowHandlers = null;
   unwatchClaudeSettings();
   gitAutoFetchService.cleanup();
+  void externalSessionApiServer.stop();
 
   // Guard against double-cleanup: sync cleanup in the force-exit path must be
   // skipped if async cleanup already finished, otherwise both paths would
@@ -807,6 +814,7 @@ function handleShutdownSignal(signal: string): void {
   // Sync cleanup: kill child processes immediately
   unwatchClaudeSettings();
   gitAutoFetchService.cleanup();
+  void externalSessionApiServer.stop();
   cleanupAllResourcesSync();
   // Use app.exit() to bypass will-quit handler (already cleaned up)
   app.exit(0);

--- a/src/main/ipc/externalSession.ts
+++ b/src/main/ipc/externalSession.ts
@@ -1,0 +1,16 @@
+import { type ExternalSessionSnapshot, IPC_CHANNELS } from '@shared/types';
+import { BrowserWindow, ipcMain } from 'electron';
+import { externalSessionApiServer } from '../services/externalSession/ExternalSessionApiServer';
+
+export function registerExternalSessionHandlers(): void {
+  ipcMain.handle(
+    IPC_CHANNELS.EXTERNAL_SESSION_SYNC,
+    async (event, snapshot: ExternalSessionSnapshot) => {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (!window || window.isDestroyed()) {
+        throw new Error('Window is not available');
+      }
+      externalSessionApiServer.updateSnapshot(window.id, snapshot);
+    }
+  );
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -13,6 +13,7 @@ import { registerClaudeConfigHandlers } from './claudeConfig';
 import { registerClaudeProviderHandlers } from './claudeProvider';
 import { registerCliHandlers } from './cli';
 import { registerDialogHandlers } from './dialog';
+import { registerExternalSessionHandlers } from './externalSession';
 import {
   cleanupTempFiles,
   cleanupTempFilesSync,
@@ -49,6 +50,7 @@ export function registerIpcHandlers(): void {
   registerGitHandlers();
   registerWorktreeHandlers();
   registerFileHandlers();
+  registerExternalSessionHandlers();
   registerSessionHandlers();
   registerSessionStorageHandlers();
   registerAgentHandlers();

--- a/src/main/services/externalSession/ExternalSessionApiServer.ts
+++ b/src/main/services/externalSession/ExternalSessionApiServer.ts
@@ -1,0 +1,222 @@
+import http from 'node:http';
+import {
+  type ExternalSessionApiItem,
+  type ExternalSessionFocusPayload,
+  type ExternalSessionSnapshot,
+  IPC_CHANNELS,
+} from '@shared/types';
+import { BrowserWindow } from 'electron';
+
+const EXTERNAL_SESSION_API_PORT = 27124;
+const MAX_BODY_SIZE = 64 * 1024;
+
+interface WindowSnapshotEntry {
+  windowId: number;
+  snapshot: ExternalSessionSnapshot;
+}
+
+function json(res: http.ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function normalizePathname(url: string | undefined): string {
+  if (!url) {
+    return '/';
+  }
+
+  try {
+    return new URL(url, 'http://127.0.0.1').pathname;
+  } catch {
+    return '/';
+  }
+}
+
+export class ExternalSessionApiServer {
+  private server: http.Server | null = null;
+  private snapshots = new Map<number, WindowSnapshotEntry>();
+
+  start(): Promise<{ success: boolean; error?: string }> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        resolve({ success: true });
+        return;
+      }
+
+      this.server = http.createServer((req, res) => {
+        if (req.method === 'OPTIONS') {
+          json(res, 204, {});
+          return;
+        }
+
+        const pathname = normalizePathname(req.url);
+
+        if (req.method === 'GET' && pathname === '/health') {
+          json(res, 200, { ok: true, port: EXTERNAL_SESSION_API_PORT });
+          return;
+        }
+
+        if (req.method === 'GET' && pathname === '/api/sessions') {
+          json(res, 200, { sessions: this.listSessions() });
+          return;
+        }
+
+        if (req.method === 'GET' && pathname === '/api/sessions/active') {
+          json(res, 200, { session: this.getActiveSession() });
+          return;
+        }
+
+        if (req.method === 'POST' && pathname.startsWith('/api/sessions/')) {
+          const parts = pathname.split('/');
+          const sessionId = decodeURIComponent(parts[3] || '');
+          const action = parts[4] || '';
+
+          if (!sessionId || action !== 'focus') {
+            json(res, 404, { error: 'Not found' });
+            return;
+          }
+
+          let bodySize = 0;
+
+          req.on('data', (chunk: Buffer) => {
+            bodySize += chunk.length;
+            if (bodySize > MAX_BODY_SIZE) {
+              req.destroy();
+              return;
+            }
+          });
+
+          req.on('end', () => {
+            const payload = this.focusSession(sessionId);
+            if (!payload) {
+              json(res, 404, { error: 'Session not found' });
+              return;
+            }
+            json(res, 200, { ok: true, session: payload });
+          });
+
+          return;
+        }
+
+        json(res, 404, { error: 'Not found' });
+      });
+
+      this.server.on('error', (error: NodeJS.ErrnoException) => {
+        console.error('[external-session-api] Server error:', error);
+        if (error.code === 'EADDRINUSE') {
+          this.server = null;
+          resolve({
+            success: false,
+            error: `Port ${EXTERNAL_SESSION_API_PORT} is already in use`,
+          });
+        }
+      });
+
+      this.server.listen(EXTERNAL_SESSION_API_PORT, '127.0.0.1', () => {
+        console.log(`[external-session-api] Server started on port ${EXTERNAL_SESSION_API_PORT}`);
+        resolve({ success: true });
+      });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+
+      const server = this.server;
+      this.server = null;
+      server.close(() => resolve());
+    });
+  }
+
+  updateSnapshot(windowId: number, snapshot: ExternalSessionSnapshot): void {
+    this.snapshots.set(windowId, { windowId, snapshot });
+  }
+
+  clearWindow(windowId: number): void {
+    this.snapshots.delete(windowId);
+  }
+
+  listSessions(): ExternalSessionApiItem[] {
+    const items: ExternalSessionApiItem[] = [];
+
+    for (const entry of this.snapshots.values()) {
+      const window = BrowserWindow.fromId(entry.windowId);
+      if (!window || window.isDestroyed()) {
+        this.snapshots.delete(entry.windowId);
+        continue;
+      }
+
+      for (const session of entry.snapshot.sessions) {
+        items.push({
+          ...session,
+          windowId: entry.windowId,
+        });
+      }
+    }
+
+    return items.sort((left, right) => {
+      if (left.isSessionActive !== right.isSessionActive) {
+        return left.isSessionActive ? -1 : 1;
+      }
+      if (left.isGroupActive !== right.isGroupActive) {
+        return left.isGroupActive ? -1 : 1;
+      }
+      return right.updatedAt - left.updatedAt;
+    });
+  }
+
+  getActiveSession(): ExternalSessionApiItem | null {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    const sessions = this.listSessions();
+
+    if (focusedWindow) {
+      const focused = sessions.find(
+        (session) =>
+          session.windowId === focusedWindow.id && session.isGroupActive && session.isSessionActive
+      );
+      if (focused) {
+        return focused;
+      }
+    }
+
+    return sessions.find((session) => session.isGroupActive && session.isSessionActive) ?? null;
+  }
+
+  focusSession(sessionId: string): ExternalSessionFocusPayload | null {
+    const target = this.listSessions().find((session) => session.id === sessionId);
+    if (!target) {
+      return null;
+    }
+
+    const window = BrowserWindow.fromId(target.windowId);
+    if (!window || window.isDestroyed()) {
+      this.snapshots.delete(target.windowId);
+      return null;
+    }
+
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+
+    const payload: ExternalSessionFocusPayload = {
+      sessionId: target.id,
+      cwd: target.cwd,
+      groupId: target.groupId,
+    };
+    window.webContents.send(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, payload);
+    return payload;
+  }
+}
+
+export const externalSessionApiServer = new ExternalSessionApiServer();

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,8 @@ import type {
   ContentSearchResult,
   CustomAgent,
   DetectedApp,
+  ExternalSessionFocusPayload,
+  ExternalSessionSnapshot,
   FileChange,
   FileChangeEvent,
   FileChangesResult,
@@ -841,6 +843,16 @@ const electronAPI = {
       const handler = (_: unknown, data: Parameters<typeof callback>[0]) => callback(data);
       ipcRenderer.on(IPC_CHANNELS.AGENT_STATUS_UPDATE, handler);
       return () => ipcRenderer.off(IPC_CHANNELS.AGENT_STATUS_UPDATE, handler);
+    },
+  },
+
+  externalSession: {
+    syncSnapshot: (snapshot: ExternalSessionSnapshot): Promise<void> =>
+      ipcRenderer.invoke(IPC_CHANNELS.EXTERNAL_SESSION_SYNC, snapshot),
+    onFocusSession: (callback: (payload: ExternalSessionFocusPayload) => void): (() => void) => {
+      const handler = (_: unknown, payload: ExternalSessionFocusPayload) => callback(payload);
+      ipcRenderer.on(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
     },
   },
 

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import type { AIProvider } from '@shared/types';
+import type { AIProvider, ExternalSessionSnapshot } from '@shared/types';
 import { Plus, Settings, Sparkles } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TEMP_REPO_ID } from '@/App/constants';
@@ -100,6 +100,12 @@ function getDefaultAgentId(
   }
   // Ultimate fallback
   return 'claude';
+}
+
+function getProjectNameFromPath(input: string): string {
+  const trimmed = input.replace(/[\\/]+$/, '');
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) || trimmed;
 }
 
 function createSession(
@@ -816,19 +822,91 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
     [allSessions]
   );
 
-  // 监听通知点击，激活对应 session 并切换 worktree
-  useEffect(() => {
-    const unsubscribe = window.electronAPI.notification.onClick((sessionId) => {
-      const session = findSessionByNotificationId(sessionId);
-      if (session && !pathsEqual(session.cwd, cwd) && onSwitchWorktree) {
+  const selectSessionAcrossWorktrees = useCallback(
+    (incomingSessionId: string, incomingGroupId?: string | null) => {
+      const session = findSessionByNotificationId(incomingSessionId);
+      if (!session) {
+        return;
+      }
+
+      if (!pathsEqual(session.cwd, cwd) && onSwitchWorktree) {
         onSwitchWorktree(session.cwd);
       }
-      if (session) {
-        handleSelectSession(session.id);
-      }
+
+      const state = useAgentSessionsStore.getState();
+      state.setActiveId(session.cwd, session.id);
+      state.updateGroupState(session.cwd, (groupState) => {
+        const targetGroupId =
+          incomingGroupId ??
+          groupState.groups.find((group) => group.sessionIds.includes(session.id))?.id;
+        if (!targetGroupId) {
+          return groupState;
+        }
+
+        return {
+          ...groupState,
+          groups: groupState.groups.map((group) =>
+            group.id === targetGroupId ? { ...group, activeSessionId: session.id } : group
+          ),
+          activeGroupId: targetGroupId,
+        };
+      });
+    },
+    [cwd, findSessionByNotificationId, onSwitchWorktree]
+  );
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.notification.onClick((sessionId) => {
+      selectSessionAcrossWorktrees(sessionId);
     });
     return unsubscribe;
-  }, [handleSelectSession, findSessionByNotificationId, cwd, onSwitchWorktree]);
+  }, [selectSessionAcrossWorktrees]);
+
+  useEffect(() => {
+    return window.electronAPI.externalSession.onFocusSession(({ sessionId, groupId }) => {
+      selectSessionAcrossWorktrees(sessionId, groupId);
+    });
+  }, [selectSessionAcrossWorktrees]);
+
+  const externalSessionSnapshot = useMemo<ExternalSessionSnapshot>(() => {
+    const snapshotSessions = allSessions
+      .filter((session) => session.backendSessionId || session.sessionId || session.agentId)
+      .map((session) => {
+        const groupState =
+          worktreeGroupStates[normalizePath(session.cwd)] || createInitialGroupState();
+        const group = groupState.groups.find((item) => item.sessionIds.includes(session.id));
+        const isGroupActive = group != null && group.id === groupState.activeGroupId;
+        const isSessionActive = isGroupActive && group?.activeSessionId === session.id;
+
+        return {
+          id: session.id,
+          backendSessionId: session.backendSessionId,
+          sessionId: session.sessionId,
+          name: session.name,
+          displayName: session.terminalTitle || session.name,
+          agentId: session.agentId,
+          agentCommand: session.agentCommand,
+          repoPath: session.repoPath,
+          cwd: session.cwd,
+          projectName: getProjectNameFromPath(session.cwd),
+          groupId: group?.id ?? null,
+          terminalTitle: session.terminalTitle,
+          isGroupActive,
+          isSessionActive,
+          displayOrder: session.displayOrder ?? 0,
+          updatedAt: Date.now(),
+        };
+      });
+
+    return {
+      sessions: snapshotSessions,
+      syncedAt: Date.now(),
+    };
+  }, [allSessions, worktreeGroupStates]);
+
+  useEffect(() => {
+    void window.electronAPI.externalSession.syncSnapshot(externalSessionSnapshot);
+  }, [externalSessionSnapshot]);
 
   // Enhanced input sender ref (unchanged)
   const enhancedInputSenderRef = useRef<

--- a/src/shared/types/externalSession.ts
+++ b/src/shared/types/externalSession.ts
@@ -1,0 +1,33 @@
+export interface ExternalSessionRecord {
+  id: string;
+  backendSessionId?: string;
+  sessionId?: string;
+  name: string;
+  displayName: string;
+  agentId: string;
+  agentCommand: string;
+  repoPath: string;
+  cwd: string;
+  projectName: string;
+  groupId: string | null;
+  terminalTitle?: string;
+  isGroupActive: boolean;
+  isSessionActive: boolean;
+  displayOrder: number;
+  updatedAt: number;
+}
+
+export interface ExternalSessionSnapshot {
+  sessions: ExternalSessionRecord[];
+  syncedAt: number;
+}
+
+export interface ExternalSessionFocusPayload {
+  sessionId: string;
+  cwd: string;
+  groupId: string | null;
+}
+
+export interface ExternalSessionApiItem extends ExternalSessionRecord {
+  windowId: number;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@ export * from './ai';
 export * from './app';
 export * from './claude';
 export * from './cli';
+export * from './externalSession';
 export * from './file';
 export * from './git';
 export * from './ipc';

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -158,6 +158,8 @@ export const IPC_CHANNELS = {
   WINDOW_IS_FULLSCREEN: 'window:isFullScreen',
   WINDOW_FULLSCREEN_CHANGED: 'window:fullScreenChanged',
   WINDOW_GET_REPOSITORY_RUNTIME_CONTEXT: 'window:getRepositoryRuntimeContext',
+  EXTERNAL_SESSION_SYNC: 'externalSession:sync',
+  EXTERNAL_SESSION_FOCUS: 'externalSession:focus',
   // Dialog
   DIALOG_OPEN_DIRECTORY: 'dialog:openDirectory',
   DIALOG_OPEN_FILE: 'dialog:openFile',


### PR DESCRIPTION
## Summary
- add a localhost external session API for listing and focusing agent sessions
- sync renderer session and group state to the main process so focus requests can target the correct worktree, group, and session
- expose preload hooks for external session sync and focus events

## Testing
- pnpm exec tsc --noEmit
- pnpm exec biome check src/shared/types/externalSession.ts src/shared/types/index.ts src/shared/types/ipc.ts src/main/services/externalSession/ExternalSessionApiServer.ts src/main/ipc/externalSession.ts src/main/ipc/index.ts src/main/index.ts src/preload/index.ts src/renderer/components/chat/AgentPanel.tsx --max-diagnostics 100
- manual verification of GET /health, GET /api/sessions, and POST /api/sessions/:id/focus against a local EnsoAI dev instance

## Notes
- full pnpm test was not reliable in this local environment until the Windows native build tooling was repaired
