### PR TITLE
feat: 增加默认关闭的外部会话 API 配置能力

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -43,6 +43,7 @@ import { readSettings } from './ipc/settings';
 import { registerWindowHandlers } from './ipc/window';
 import { registerClaudeBridgeIpcHandlers } from './services/claude/ClaudeIdeBridge';
 import { unwatchClaudeSettings } from './services/claude/ClaudeProviderManager';
+import { externalSessionApiServer } from './services/externalSession/ExternalSessionApiServer';
 import {
   isAllowedLocalFilePath,
   registerAllowedLocalFileRoot,
@@ -626,6 +627,10 @@ app.whenReady().then(async () => {
   // Default open or close DevTools by F12 in development
   // Also intercept Cmd+- for all windows to bypass Monaco Editor interception
   app.on('browser-window-created', (_, window) => {
+    window.on('closed', () => {
+      externalSessionApiServer.clearWindow(window.id);
+    });
+
     // Snapshot listeners before the optimizer adds its own, only needed in production.
     const listenersBefore = app.isPackaged
       ? new Set(window.webContents.listeners('before-input-event'))
@@ -680,6 +685,7 @@ app.whenReady().then(async () => {
 
   // Auto-start Hapi server if enabled in settings
   await autoStartHapi();
+  await externalSessionApiServer.start();
 
   setCurrentLocale(readStoredLanguage());
 
@@ -761,6 +767,7 @@ app.on('will-quit', (event) => {
   cleanupWindowHandlers = null;
   unwatchClaudeSettings();
   gitAutoFetchService.cleanup();
+  void externalSessionApiServer.stop();
 
   // Guard against double-cleanup: sync cleanup in the force-exit path must be
   // skipped if async cleanup already finished, otherwise both paths would
@@ -807,6 +814,7 @@ function handleShutdownSignal(signal: string): void {
   // Sync cleanup: kill child processes immediately
   unwatchClaudeSettings();
   gitAutoFetchService.cleanup();
+  void externalSessionApiServer.stop();
   cleanupAllResourcesSync();
   // Use app.exit() to bypass will-quit handler (already cleaned up)
   app.exit(0);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -684,8 +684,21 @@ app.whenReady().then(async () => {
   await init();
 
   // Auto-start Hapi server if enabled in settings
+  const appSettings = readSettings();
   await autoStartHapi();
-  await externalSessionApiServer.start();
+  const persistedSettings = appSettings?.['enso-settings'] as
+    | { state?: Record<string, unknown> }
+    | undefined;
+  const externalSessionApiSettings = persistedSettings?.state?.externalSessionApi as
+    | Record<string, unknown>
+    | undefined;
+  if (externalSessionApiSettings?.enabled === true) {
+    const port = Number(externalSessionApiSettings?.port) || 27124;
+    const result = await externalSessionApiServer.start(port);
+    if (!result.success) {
+      console.error('[external-session-api] Failed to start:', result.error);
+    }
+  }
 
   setCurrentLocale(readStoredLanguage());
 
@@ -696,7 +709,6 @@ app.whenReady().then(async () => {
   webInspectorServer.setMainWindow(mainWindow);
 
   // Initialize Claude Provider Watcher (only when enableProviderWatcher is true)
-  const appSettings = readSettings();
   const providerWatcherEnabled =
     (appSettings?.claudeCodeIntegration as Record<string, unknown>)?.enableProviderWatcher !==
     false;

--- a/src/main/ipc/externalSession.ts
+++ b/src/main/ipc/externalSession.ts
@@ -1,0 +1,16 @@
+import { type ExternalSessionSnapshot, IPC_CHANNELS } from '@shared/types';
+import { BrowserWindow, ipcMain } from 'electron';
+import { externalSessionApiServer } from '../services/externalSession/ExternalSessionApiServer';
+
+export function registerExternalSessionHandlers(): void {
+  ipcMain.handle(
+    IPC_CHANNELS.EXTERNAL_SESSION_SYNC,
+    async (event, snapshot: ExternalSessionSnapshot) => {
+      const window = BrowserWindow.fromWebContents(event.sender);
+      if (!window || window.isDestroyed()) {
+        throw new Error('Window is not available');
+      }
+      externalSessionApiServer.updateSnapshot(window.id, snapshot);
+    }
+  );
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -13,6 +13,7 @@ import { registerClaudeConfigHandlers } from './claudeConfig';
 import { registerClaudeProviderHandlers } from './claudeProvider';
 import { registerCliHandlers } from './cli';
 import { registerDialogHandlers } from './dialog';
+import { registerExternalSessionHandlers } from './externalSession';
 import {
   cleanupTempFiles,
   cleanupTempFilesSync,
@@ -49,6 +50,7 @@ export function registerIpcHandlers(): void {
   registerGitHandlers();
   registerWorktreeHandlers();
   registerFileHandlers();
+  registerExternalSessionHandlers();
   registerSessionHandlers();
   registerSessionStorageHandlers();
   registerAgentHandlers();

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -1,5 +1,6 @@
 import { IPC_CHANNELS } from '@shared/types';
 import { app, ipcMain } from 'electron';
+import { externalSessionApiServer } from '../services/externalSession/ExternalSessionApiServer';
 import {
   readSharedSettings,
   writeSharedSettings,
@@ -15,6 +16,19 @@ let isDirty = false;
 
 const DEBOUNCE_MS = 500;
 const MAX_WAIT_MS = 5000;
+
+function getPersistedState(
+  data: Record<string, unknown> | null | undefined
+): Record<string, unknown> {
+  const persisted = data?.['enso-settings'];
+  if (persisted && typeof persisted === 'object') {
+    const state = (persisted as { state?: Record<string, unknown> }).state;
+    if (state && typeof state === 'object') {
+      return state;
+    }
+  }
+  return {};
+}
 
 /**
  * Read settings from disk (for use in main process)
@@ -84,6 +98,34 @@ export function registerSettingsHandlers(): void {
         ?.enableProviderWatcher;
       if (oldEnabled !== newEnabled) {
         toggleClaudeProviderWatcher(newEnabled !== false);
+      }
+
+      const oldState = getPersistedState(cachedSettings);
+      const newState = getPersistedState(newData);
+      const oldExternalSessionApiEnabled = (oldState.externalSessionApi as Record<string, unknown>)
+        ?.enabled;
+      const newExternalSessionApiEnabled = (newState.externalSessionApi as Record<string, unknown>)
+        ?.enabled;
+      const oldExternalSessionApiPort =
+        Number((oldState.externalSessionApi as Record<string, unknown>)?.port) || 27124;
+      const newExternalSessionApiPort =
+        Number((newState.externalSessionApi as Record<string, unknown>)?.port) || 27124;
+      if (
+        oldExternalSessionApiEnabled !== newExternalSessionApiEnabled ||
+        (newExternalSessionApiEnabled === true &&
+          oldExternalSessionApiPort !== newExternalSessionApiPort)
+      ) {
+        if (newExternalSessionApiEnabled === true) {
+          if (oldExternalSessionApiEnabled === true) {
+            await externalSessionApiServer.stop();
+          }
+          const result = await externalSessionApiServer.start(newExternalSessionApiPort);
+          if (!result.success) {
+            console.error('[external-session-api] Failed to start:', result.error);
+          }
+        } else {
+          await externalSessionApiServer.stop();
+        }
       }
 
       // 更新内存缓存

--- a/src/main/services/externalSession/ExternalSessionApiServer.ts
+++ b/src/main/services/externalSession/ExternalSessionApiServer.ts
@@ -7,7 +7,7 @@ import {
 } from '@shared/types';
 import { BrowserWindow } from 'electron';
 
-const EXTERNAL_SESSION_API_PORT = 27124;
+const DEFAULT_EXTERNAL_SESSION_API_PORT = 27124;
 const MAX_BODY_SIZE = 64 * 1024;
 
 interface WindowSnapshotEntry {
@@ -18,9 +18,6 @@ interface WindowSnapshotEntry {
 function json(res: http.ServerResponse, status: number, payload: unknown): void {
   res.writeHead(status, {
     'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type',
   });
   res.end(JSON.stringify(payload));
 }
@@ -40,13 +37,15 @@ function normalizePathname(url: string | undefined): string {
 export class ExternalSessionApiServer {
   private server: http.Server | null = null;
   private snapshots = new Map<number, WindowSnapshotEntry>();
+  private port = DEFAULT_EXTERNAL_SESSION_API_PORT;
 
-  start(): Promise<{ success: boolean; error?: string }> {
+  start(port = this.port): Promise<{ success: boolean; error?: string }> {
     return new Promise((resolve) => {
       if (this.server) {
         resolve({ success: true });
         return;
       }
+      this.port = port;
 
       this.server = http.createServer((req, res) => {
         if (req.method === 'OPTIONS') {
@@ -57,7 +56,7 @@ export class ExternalSessionApiServer {
         const pathname = normalizePathname(req.url);
 
         if (req.method === 'GET' && pathname === '/health') {
-          json(res, 200, { ok: true, port: EXTERNAL_SESSION_API_PORT });
+          json(res, 200, { ok: true, port: this.port });
           return;
         }
 
@@ -112,13 +111,18 @@ export class ExternalSessionApiServer {
           this.server = null;
           resolve({
             success: false,
-            error: `Port ${EXTERNAL_SESSION_API_PORT} is already in use`,
+            error: `Port ${this.port} is already in use`,
           });
         }
       });
 
-      this.server.listen(EXTERNAL_SESSION_API_PORT, '127.0.0.1', () => {
-        console.log(`[external-session-api] Server started on port ${EXTERNAL_SESSION_API_PORT}`);
+      this.server.listen(this.port, '127.0.0.1', () => {
+        console.log(`[external-session-api] Server started on port ${this.port}`);
+        for (const window of BrowserWindow.getAllWindows()) {
+          if (!window.isDestroyed()) {
+            window.webContents.send(IPC_CHANNELS.EXTERNAL_SESSION_RESYNC);
+          }
+        }
         resolve({ success: true });
       });
     });
@@ -133,16 +137,25 @@ export class ExternalSessionApiServer {
 
       const server = this.server;
       this.server = null;
-      server.close(() => resolve());
+      server.close(() => {
+        resolve();
+      });
     });
   }
 
   updateSnapshot(windowId: number, snapshot: ExternalSessionSnapshot): void {
+    if (!this.server) {
+      return;
+    }
     this.snapshots.set(windowId, { windowId, snapshot });
   }
 
   clearWindow(windowId: number): void {
     this.snapshots.delete(windowId);
+  }
+
+  getPort(): number {
+    return this.port;
   }
 
   listSessions(): ExternalSessionApiItem[] {
@@ -206,6 +219,7 @@ export class ExternalSessionApiServer {
     if (window.isMinimized()) {
       window.restore();
     }
+    window.moveTop();
     window.show();
     window.focus();
 

--- a/src/main/services/externalSession/ExternalSessionApiServer.ts
+++ b/src/main/services/externalSession/ExternalSessionApiServer.ts
@@ -1,0 +1,222 @@
+import http from 'node:http';
+import {
+  type ExternalSessionApiItem,
+  type ExternalSessionFocusPayload,
+  type ExternalSessionSnapshot,
+  IPC_CHANNELS,
+} from '@shared/types';
+import { BrowserWindow } from 'electron';
+
+const EXTERNAL_SESSION_API_PORT = 27124;
+const MAX_BODY_SIZE = 64 * 1024;
+
+interface WindowSnapshotEntry {
+  windowId: number;
+  snapshot: ExternalSessionSnapshot;
+}
+
+function json(res: http.ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+  });
+  res.end(JSON.stringify(payload));
+}
+
+function normalizePathname(url: string | undefined): string {
+  if (!url) {
+    return '/';
+  }
+
+  try {
+    return new URL(url, 'http://127.0.0.1').pathname;
+  } catch {
+    return '/';
+  }
+}
+
+export class ExternalSessionApiServer {
+  private server: http.Server | null = null;
+  private snapshots = new Map<number, WindowSnapshotEntry>();
+
+  start(): Promise<{ success: boolean; error?: string }> {
+    return new Promise((resolve) => {
+      if (this.server) {
+        resolve({ success: true });
+        return;
+      }
+
+      this.server = http.createServer((req, res) => {
+        if (req.method === 'OPTIONS') {
+          json(res, 204, {});
+          return;
+        }
+
+        const pathname = normalizePathname(req.url);
+
+        if (req.method === 'GET' && pathname === '/health') {
+          json(res, 200, { ok: true, port: EXTERNAL_SESSION_API_PORT });
+          return;
+        }
+
+        if (req.method === 'GET' && pathname === '/api/sessions') {
+          json(res, 200, { sessions: this.listSessions() });
+          return;
+        }
+
+        if (req.method === 'GET' && pathname === '/api/sessions/active') {
+          json(res, 200, { session: this.getActiveSession() });
+          return;
+        }
+
+        if (req.method === 'POST' && pathname.startsWith('/api/sessions/')) {
+          const parts = pathname.split('/');
+          const sessionId = decodeURIComponent(parts[3] || '');
+          const action = parts[4] || '';
+
+          if (!sessionId || action !== 'focus') {
+            json(res, 404, { error: 'Not found' });
+            return;
+          }
+
+          let bodySize = 0;
+
+          req.on('data', (chunk: Buffer) => {
+            bodySize += chunk.length;
+            if (bodySize > MAX_BODY_SIZE) {
+              req.destroy();
+              return;
+            }
+          });
+
+          req.on('end', () => {
+            const payload = this.focusSession(sessionId);
+            if (!payload) {
+              json(res, 404, { error: 'Session not found' });
+              return;
+            }
+            json(res, 200, { ok: true, session: payload });
+          });
+
+          return;
+        }
+
+        json(res, 404, { error: 'Not found' });
+      });
+
+      this.server.on('error', (error: NodeJS.ErrnoException) => {
+        console.error('[external-session-api] Server error:', error);
+        if (error.code === 'EADDRINUSE') {
+          this.server = null;
+          resolve({
+            success: false,
+            error: `Port ${EXTERNAL_SESSION_API_PORT} is already in use`,
+          });
+        }
+      });
+
+      this.server.listen(EXTERNAL_SESSION_API_PORT, '127.0.0.1', () => {
+        console.log(`[external-session-api] Server started on port ${EXTERNAL_SESSION_API_PORT}`);
+        resolve({ success: true });
+      });
+    });
+  }
+
+  stop(): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this.server) {
+        resolve();
+        return;
+      }
+
+      const server = this.server;
+      this.server = null;
+      server.close(() => resolve());
+    });
+  }
+
+  updateSnapshot(windowId: number, snapshot: ExternalSessionSnapshot): void {
+    this.snapshots.set(windowId, { windowId, snapshot });
+  }
+
+  clearWindow(windowId: number): void {
+    this.snapshots.delete(windowId);
+  }
+
+  listSessions(): ExternalSessionApiItem[] {
+    const items: ExternalSessionApiItem[] = [];
+
+    for (const entry of this.snapshots.values()) {
+      const window = BrowserWindow.fromId(entry.windowId);
+      if (!window || window.isDestroyed()) {
+        this.snapshots.delete(entry.windowId);
+        continue;
+      }
+
+      for (const session of entry.snapshot.sessions) {
+        items.push({
+          ...session,
+          windowId: entry.windowId,
+        });
+      }
+    }
+
+    return items.sort((left, right) => {
+      if (left.isSessionActive !== right.isSessionActive) {
+        return left.isSessionActive ? -1 : 1;
+      }
+      if (left.isGroupActive !== right.isGroupActive) {
+        return left.isGroupActive ? -1 : 1;
+      }
+      return right.updatedAt - left.updatedAt;
+    });
+  }
+
+  getActiveSession(): ExternalSessionApiItem | null {
+    const focusedWindow = BrowserWindow.getFocusedWindow();
+    const sessions = this.listSessions();
+
+    if (focusedWindow) {
+      const focused = sessions.find(
+        (session) =>
+          session.windowId === focusedWindow.id && session.isGroupActive && session.isSessionActive
+      );
+      if (focused) {
+        return focused;
+      }
+    }
+
+    return sessions.find((session) => session.isGroupActive && session.isSessionActive) ?? null;
+  }
+
+  focusSession(sessionId: string): ExternalSessionFocusPayload | null {
+    const target = this.listSessions().find((session) => session.id === sessionId);
+    if (!target) {
+      return null;
+    }
+
+    const window = BrowserWindow.fromId(target.windowId);
+    if (!window || window.isDestroyed()) {
+      this.snapshots.delete(target.windowId);
+      return null;
+    }
+
+    if (window.isMinimized()) {
+      window.restore();
+    }
+    window.show();
+    window.focus();
+
+    const payload: ExternalSessionFocusPayload = {
+      sessionId: target.id,
+      cwd: target.cwd,
+      groupId: target.groupId,
+    };
+    window.webContents.send(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, payload);
+    return payload;
+  }
+}
+
+export const externalSessionApiServer = new ExternalSessionApiServer();

--- a/src/main/services/externalSession/ExternalSessionApiServer.ts
+++ b/src/main/services/externalSession/ExternalSessionApiServer.ts
@@ -8,8 +8,6 @@ import {
 import { BrowserWindow } from 'electron';
 
 const DEFAULT_EXTERNAL_SESSION_API_PORT = 27124;
-const MAX_BODY_SIZE = 64 * 1024;
-
 interface WindowSnapshotEntry {
   windowId: number;
   snapshot: ExternalSessionSnapshot;
@@ -49,6 +47,8 @@ export class ExternalSessionApiServer {
 
       this.server = http.createServer((req, res) => {
         if (req.method === 'OPTIONS') {
+          // Intentionally do not emit CORS headers. This API is designed for local
+          // desktop integrations, not arbitrary browser pages.
           json(res, 204, {});
           return;
         }
@@ -79,26 +79,12 @@ export class ExternalSessionApiServer {
             json(res, 404, { error: 'Not found' });
             return;
           }
-
-          let bodySize = 0;
-
-          req.on('data', (chunk: Buffer) => {
-            bodySize += chunk.length;
-            if (bodySize > MAX_BODY_SIZE) {
-              req.destroy();
-              return;
-            }
-          });
-
-          req.on('end', () => {
-            const payload = this.focusSession(sessionId);
-            if (!payload) {
-              json(res, 404, { error: 'Session not found' });
-              return;
-            }
-            json(res, 200, { ok: true, session: payload });
-          });
-
+          const payload = this.focusSession(sessionId);
+          if (!payload) {
+            json(res, 404, { error: 'Session not found' });
+            return;
+          }
+          json(res, 200, { ok: true, session: payload });
           return;
         }
 
@@ -107,13 +93,12 @@ export class ExternalSessionApiServer {
 
       this.server.on('error', (error: NodeJS.ErrnoException) => {
         console.error('[external-session-api] Server error:', error);
-        if (error.code === 'EADDRINUSE') {
-          this.server = null;
-          resolve({
-            success: false,
-            error: `Port ${this.port} is already in use`,
-          });
-        }
+        this.server = null;
+        resolve({
+          success: false,
+          error:
+            error.code === 'EADDRINUSE' ? `Port ${this.port} is already in use` : error.message,
+        });
       });
 
       this.server.listen(this.port, '127.0.0.1', () => {
@@ -131,6 +116,7 @@ export class ExternalSessionApiServer {
   stop(): Promise<void> {
     return new Promise((resolve) => {
       if (!this.server) {
+        this.snapshots.clear();
         resolve();
         return;
       }
@@ -138,6 +124,7 @@ export class ExternalSessionApiServer {
       const server = this.server;
       this.server = null;
       server.close(() => {
+        this.snapshots.clear();
         resolve();
       });
     });
@@ -160,11 +147,12 @@ export class ExternalSessionApiServer {
 
   listSessions(): ExternalSessionApiItem[] {
     const items: ExternalSessionApiItem[] = [];
+    const staleWindowIds: number[] = [];
 
     for (const entry of this.snapshots.values()) {
       const window = BrowserWindow.fromId(entry.windowId);
       if (!window || window.isDestroyed()) {
-        this.snapshots.delete(entry.windowId);
+        staleWindowIds.push(entry.windowId);
         continue;
       }
 
@@ -174,6 +162,10 @@ export class ExternalSessionApiServer {
           windowId: entry.windowId,
         });
       }
+    }
+
+    for (const windowId of staleWindowIds) {
+      this.snapshots.delete(windowId);
     }
 
     return items.sort((left, right) => {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -854,6 +854,11 @@ const electronAPI = {
       ipcRenderer.on(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
       return () => ipcRenderer.off(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
     },
+    onResyncRequest: (callback: () => void): (() => void) => {
+      const handler = () => callback();
+      ipcRenderer.on(IPC_CHANNELS.EXTERNAL_SESSION_RESYNC, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.EXTERNAL_SESSION_RESYNC, handler);
+    },
   },
 
   // Updater

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -15,6 +15,8 @@ import type {
   ContentSearchResult,
   CustomAgent,
   DetectedApp,
+  ExternalSessionFocusPayload,
+  ExternalSessionSnapshot,
   FileChange,
   FileChangeEvent,
   FileChangesResult,
@@ -841,6 +843,16 @@ const electronAPI = {
       const handler = (_: unknown, data: Parameters<typeof callback>[0]) => callback(data);
       ipcRenderer.on(IPC_CHANNELS.AGENT_STATUS_UPDATE, handler);
       return () => ipcRenderer.off(IPC_CHANNELS.AGENT_STATUS_UPDATE, handler);
+    },
+  },
+
+  externalSession: {
+    syncSnapshot: (snapshot: ExternalSessionSnapshot): Promise<void> =>
+      ipcRenderer.invoke(IPC_CHANNELS.EXTERNAL_SESSION_SYNC, snapshot),
+    onFocusSession: (callback: (payload: ExternalSessionFocusPayload) => void): (() => void) => {
+      const handler = (_: unknown, payload: ExternalSessionFocusPayload) => callback(payload);
+      ipcRenderer.on(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.EXTERNAL_SESSION_FOCUS, handler);
     },
   },
 

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -249,6 +249,7 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
   ]);
 
   const bgImageEnabled = useSettingsStore((s) => s.backgroundImageEnabled);
+  const externalSessionApiEnabled = useSettingsStore((s) => s.externalSessionApi.enabled);
   const terminalBgColor = useMemo(() => {
     if (bgImageEnabled) return 'transparent';
     return getXtermTheme(terminalTheme)?.background ?? defaultDarkTheme.background;
@@ -863,10 +864,13 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
   }, [selectSessionAcrossWorktrees]);
 
   useEffect(() => {
+    if (!externalSessionApiEnabled) {
+      return undefined;
+    }
     return window.electronAPI.externalSession.onFocusSession(({ sessionId, groupId }) => {
       selectSessionAcrossWorktrees(sessionId, groupId);
     });
-  }, [selectSessionAcrossWorktrees]);
+  }, [externalSessionApiEnabled, selectSessionAcrossWorktrees]);
 
   const externalSessionSnapshot = useMemo<ExternalSessionSnapshot>(() => {
     const snapshotSessions = allSessions
@@ -905,8 +909,20 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
   }, [allSessions, worktreeGroupStates]);
 
   useEffect(() => {
+    if (!externalSessionApiEnabled) {
+      return;
+    }
     void window.electronAPI.externalSession.syncSnapshot(externalSessionSnapshot);
-  }, [externalSessionSnapshot]);
+  }, [externalSessionApiEnabled, externalSessionSnapshot]);
+
+  useEffect(() => {
+    if (!externalSessionApiEnabled) {
+      return undefined;
+    }
+    return window.electronAPI.externalSession.onResyncRequest(() => {
+      void window.electronAPI.externalSession.syncSnapshot(externalSessionSnapshot);
+    });
+  }, [externalSessionApiEnabled, externalSessionSnapshot]);
 
   // Enhanced input sender ref (unchanged)
   const enhancedInputSenderRef = useRef<

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -1,4 +1,4 @@
-import type { AIProvider } from '@shared/types';
+import type { AIProvider, ExternalSessionSnapshot } from '@shared/types';
 import { Plus, Settings, Sparkles } from 'lucide-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { TEMP_REPO_ID } from '@/App/constants';
@@ -100,6 +100,12 @@ function getDefaultAgentId(
   }
   // Ultimate fallback
   return 'claude';
+}
+
+function getProjectNameFromPath(input: string): string {
+  const trimmed = input.replace(/[\\/]+$/, '');
+  const parts = trimmed.split(/[\\/]/).filter(Boolean);
+  return parts.at(-1) || trimmed;
 }
 
 function createSession(
@@ -816,19 +822,91 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
     [allSessions]
   );
 
-  // 监听通知点击，激活对应 session 并切换 worktree
-  useEffect(() => {
-    const unsubscribe = window.electronAPI.notification.onClick((sessionId) => {
-      const session = findSessionByNotificationId(sessionId);
-      if (session && !pathsEqual(session.cwd, cwd) && onSwitchWorktree) {
+  const selectSessionAcrossWorktrees = useCallback(
+    (incomingSessionId: string, incomingGroupId?: string | null) => {
+      const session = findSessionByNotificationId(incomingSessionId);
+      if (!session) {
+        return;
+      }
+
+      if (!pathsEqual(session.cwd, cwd) && onSwitchWorktree) {
         onSwitchWorktree(session.cwd);
       }
-      if (session) {
-        handleSelectSession(session.id);
-      }
+
+      const state = useAgentSessionsStore.getState();
+      state.setActiveId(session.cwd, session.id);
+      state.updateGroupState(session.cwd, (groupState) => {
+        const targetGroupId =
+          incomingGroupId ??
+          groupState.groups.find((group) => group.sessionIds.includes(session.id))?.id;
+        if (!targetGroupId) {
+          return groupState;
+        }
+
+        return {
+          ...groupState,
+          groups: groupState.groups.map((group) =>
+            group.id === targetGroupId ? { ...group, activeSessionId: session.id } : group
+          ),
+          activeGroupId: targetGroupId,
+        };
+      });
+    },
+    [cwd, findSessionByNotificationId, onSwitchWorktree]
+  );
+
+  useEffect(() => {
+    const unsubscribe = window.electronAPI.notification.onClick((sessionId) => {
+      selectSessionAcrossWorktrees(sessionId);
     });
     return unsubscribe;
-  }, [handleSelectSession, findSessionByNotificationId, cwd, onSwitchWorktree]);
+  }, [selectSessionAcrossWorktrees]);
+
+  useEffect(() => {
+    return window.electronAPI.externalSession.onFocusSession(({ sessionId, groupId }) => {
+      selectSessionAcrossWorktrees(sessionId, groupId);
+    });
+  }, [selectSessionAcrossWorktrees]);
+
+  const externalSessionSnapshot = useMemo<ExternalSessionSnapshot>(() => {
+    const snapshotSessions = allSessions
+      .filter((session) => session.backendSessionId || session.sessionId || session.agentId)
+      .map((session) => {
+        const groupState =
+          worktreeGroupStates[normalizePath(session.cwd)] || createInitialGroupState();
+        const group = groupState.groups.find((item) => item.sessionIds.includes(session.id));
+        const isGroupActive = group != null && group.id === groupState.activeGroupId;
+        const isSessionActive = isGroupActive && group?.activeSessionId === session.id;
+
+        return {
+          id: session.id,
+          backendSessionId: session.backendSessionId,
+          sessionId: session.sessionId,
+          name: session.name,
+          displayName: session.terminalTitle || session.name,
+          agentId: session.agentId,
+          agentCommand: session.agentCommand,
+          repoPath: session.repoPath,
+          cwd: session.cwd,
+          projectName: getProjectNameFromPath(session.cwd),
+          groupId: group?.id ?? null,
+          terminalTitle: session.terminalTitle,
+          isGroupActive,
+          isSessionActive,
+          displayOrder: session.displayOrder ?? 0,
+          updatedAt: Date.now(),
+        };
+      });
+
+    return {
+      sessions: snapshotSessions,
+      syncedAt: Date.now(),
+    };
+  }, [allSessions, worktreeGroupStates]);
+
+  useEffect(() => {
+    void window.electronAPI.externalSession.syncSnapshot(externalSessionSnapshot);
+  }, [externalSessionSnapshot]);
 
   // Enhanced input sender ref (unchanged)
   const enhancedInputSenderRef = useRef<

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -30,7 +30,6 @@ import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   Dialog,
-  DialogClose,
   DialogDescription,
   DialogFooter,
   DialogHeader,
@@ -48,6 +47,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
+import { toastManager } from '@/components/ui/toast';
 import { useDetectedApps } from '@/hooks/useAppDetector';
 import { useI18n } from '@/i18n';
 import { cn } from '@/lib/utils';
@@ -101,6 +101,8 @@ export function GeneralSettings() {
   const {
     language,
     setLanguage,
+    externalSessionApi,
+    setExternalSessionApi,
     layoutMode,
     setLayoutMode,
     fileTreeDisplayMode,
@@ -453,6 +455,28 @@ export function GeneralSettings() {
   const shellArgsPlaceholder = isWindows
     ? '/k "C:\\Program Files\\init.bat"'
     : "-l -c '/usr/local/bin/app'";
+  const externalSessionApiPort = externalSessionApi.port || 27124;
+  const externalSessionApiBaseUrl = `http://127.0.0.1:${externalSessionApiPort}`;
+  const sessionListCommand = isWindows
+    ? `curl ${externalSessionApiBaseUrl}/api/sessions`
+    : `curl "${externalSessionApiBaseUrl}/api/sessions"`;
+  const focusCommand = isWindows
+    ? `curl -X POST ${externalSessionApiBaseUrl}/api/sessions/{sessionId}/focus`
+    : `curl -X POST "${externalSessionApiBaseUrl}/api/sessions/{sessionId}/focus"`;
+  const handleCopyText = React.useCallback(
+    async (value: string) => {
+      try {
+        await navigator.clipboard.writeText(value);
+        toastManager.add({
+          type: 'success',
+          title: t('Copied to clipboard'),
+        });
+      } catch {
+        // Ignore clipboard errors
+      }
+    },
+    [t]
+  );
 
   return (
     <div className="space-y-6">
@@ -1364,6 +1388,114 @@ export function GeneralSettings() {
           <Switch checked={autoUpdateEnabled} onCheckedChange={setAutoUpdateEnabled} />
         </div>
       </div>
+
+      <div className="pt-4 border-t">
+        <h3 className="text-lg font-medium">{t('External Session API')}</h3>
+        <p className="text-sm text-muted-foreground">
+          {t('Expose a localhost API for external desktop tools to list and focus sessions')}
+        </p>
+      </div>
+
+      <div className="grid grid-cols-[100px_1fr] items-center gap-4">
+        <span className="text-sm font-medium">{t('Enable')}</span>
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            {t(
+              'Disabled by default. Turn this on only if you need external tools to control sessions'
+            )}
+          </p>
+          <Switch
+            checked={externalSessionApi.enabled}
+            onCheckedChange={(checked) => setExternalSessionApi({ enabled: checked })}
+          />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-[100px_1fr] items-start gap-4">
+        <span className="text-sm font-medium mt-2">{t('Port')}</span>
+        <div className="space-y-1.5">
+          <Input
+            type="number"
+            min={1024}
+            max={65535}
+            value={String(externalSessionApiPort)}
+            onChange={(e) => {
+              const nextValue = Number(e.target.value);
+              if (Number.isFinite(nextValue)) {
+                setExternalSessionApi({
+                  port: Math.max(1024, Math.min(65535, nextValue)),
+                });
+              }
+            }}
+          />
+          <p className="text-xs text-muted-foreground">
+            {t('Choose a localhost port for the external session API')}
+          </p>
+        </div>
+      </div>
+
+      {externalSessionApi.enabled && (
+        <div className="grid grid-cols-[100px_1fr] items-start gap-4">
+          <span className="text-sm font-medium mt-2">{t('API Usage')}</span>
+          <div className="space-y-3">
+            <p className="text-sm text-muted-foreground">
+              {t('Use these localhost endpoints to inspect and focus sessions from external tools')}
+            </p>
+            <div className="space-y-2 rounded-lg border bg-muted/40 p-3">
+              <div>
+                <div className="text-xs font-medium text-muted-foreground">{t('API Base URL')}</div>
+                <div className="mt-1 flex items-center gap-2 rounded-md bg-background px-3 py-2">
+                  <div className="min-w-0 flex-1 font-mono text-xs break-all">
+                    {externalSessionApiBaseUrl}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopyText(externalSessionApiBaseUrl)}
+                  >
+                    {t('Copy')}
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t('List sessions')}
+                </div>
+                <div className="mt-1 flex items-center gap-2 rounded-md bg-background px-3 py-2">
+                  <div className="min-w-0 flex-1 font-mono text-xs break-all">
+                    {sessionListCommand}
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopyText(sessionListCommand)}
+                  >
+                    {t('Copy')}
+                  </Button>
+                </div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-muted-foreground">
+                  {t('Focus a session')}
+                </div>
+                <div className="mt-1 flex items-center gap-2 rounded-md bg-background px-3 py-2">
+                  <div className="min-w-0 flex-1 font-mono text-xs break-all">{focusCommand}</div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => handleCopyText(focusCommand)}
+                  >
+                    {t('Copy')}
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
 
       <AlertDialog open={tempPathDialogOpen} onOpenChange={setTempPathDialogOpen}>
         <AlertDialogPopup className="max-w-md">

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -463,6 +463,9 @@ export function GeneralSettings() {
   const focusCommand = isWindows
     ? `curl -X POST ${externalSessionApiBaseUrl}/api/sessions/{sessionId}/focus`
     : `curl -X POST "${externalSessionApiBaseUrl}/api/sessions/{sessionId}/focus"`;
+  const [externalSessionApiPortInput, setExternalSessionApiPortInput] = React.useState(() =>
+    String(externalSessionApiPort)
+  );
   const handleCopyText = React.useCallback(
     async (value: string) => {
       try {
@@ -477,6 +480,10 @@ export function GeneralSettings() {
     },
     [t]
   );
+
+  React.useEffect(() => {
+    setExternalSessionApiPortInput(String(externalSessionApiPort));
+  }, [externalSessionApiPort]);
 
   return (
     <div className="space-y-6">
@@ -1418,18 +1425,26 @@ export function GeneralSettings() {
             type="number"
             min={1024}
             max={65535}
-            value={String(externalSessionApiPort)}
+            value={externalSessionApiPortInput}
             onChange={(e) => {
-              const nextValue = Number(e.target.value);
-              if (Number.isFinite(nextValue)) {
-                setExternalSessionApi({
-                  port: Math.max(1024, Math.min(65535, nextValue)),
-                });
-              }
+              setExternalSessionApiPortInput(e.target.value);
+            }}
+            onBlur={() => {
+              const nextValue = Number(externalSessionApiPortInput);
+              setExternalSessionApi({
+                port: Number.isFinite(nextValue)
+                  ? Math.max(1024, Math.min(65535, nextValue))
+                  : 27124,
+              });
             }}
           />
           <p className="text-xs text-muted-foreground">
             {t('Choose a localhost port for the external session API')}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {t(
+              'This localhost API is intended for local desktop integrations. Keep it disabled if you do not need external control'
+            )}
           </p>
         </div>
       </div>

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -9,6 +9,7 @@ import type {
   CommitMessageGeneratorSettings,
   EditorKeybindings,
   EditorSettings,
+  ExternalSessionApiSettings,
   GitCloneSettings,
   GlobalKeybindings,
   HapiSettings,
@@ -163,6 +164,11 @@ export const defaultClaudeCodeIntegrationSettings: ClaudeCodeIntegrationSettings
   providers: [],
   enhancedInputEnabled: false, // Disable enhanced input by default
   enhancedInputAutoPopup: 'hideWhileRunning', // Hide while running by default
+};
+
+export const defaultExternalSessionApiSettings: ExternalSessionApiSettings = {
+  enabled: false,
+  port: 27124,
 };
 
 // Default commit message generator settings

--- a/src/renderer/stores/settings/index.ts
+++ b/src/renderer/stores/settings/index.ts
@@ -17,6 +17,7 @@ import {
   defaultCommitMessageGeneratorSettings,
   defaultEditorKeybindings,
   defaultEditorSettings,
+  defaultExternalSessionApiSettings,
   defaultGitCloneSettings,
   defaultGlobalKeybindings,
   defaultHapiSettings,
@@ -141,6 +142,7 @@ function getInitialState() {
 
     // Claude Code Integration
     claudeCodeIntegration: defaultClaudeCodeIntegrationSettings,
+    externalSessionApi: defaultExternalSessionApiSettings,
 
     // AI Features
     commitMessageGenerator: defaultCommitMessageGeneratorSettings,
@@ -389,6 +391,11 @@ export const useSettingsStore = create<SettingsState>()(
       setClaudeCodeIntegration: (settings) =>
         set((state) => ({
           claudeCodeIntegration: { ...state.claudeCodeIntegration, ...settings },
+        })),
+
+      setExternalSessionApi: (settings) =>
+        set((state) => ({
+          externalSessionApi: { ...state.externalSessionApi, ...settings },
         })),
 
       addClaudeProvider: (provider) =>

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -1,6 +1,5 @@
 import type { Locale } from '@shared/i18n';
 import type {
-  AIProvider,
   BuiltinAgentId,
   ConnectionProfile,
   CustomAgent,
@@ -8,10 +7,8 @@ import type {
   McpServer,
   PromptPreset,
   ProxySettings,
-  ReasoningEffort,
   ShellConfig,
 } from '@shared/types';
-import type { ClaudeEffort, CommonAISettings } from '@shared/types/ai';
 
 // Theme types
 export type Theme = 'light' | 'dark' | 'system' | 'sync-terminal';
@@ -205,6 +202,11 @@ export interface ClaudeCodeIntegrationSettings {
   enhancedInputAutoPopup: 'always' | 'hideWhileRunning' | 'manual'; // Enhanced input auto popup mode
 }
 
+export interface ExternalSessionApiSettings {
+  enabled: boolean;
+  port: number;
+}
+
 // Commit message generator settings
 export interface CommitMessageGeneratorSettings extends CommonAISettings {
   enabled: boolean;
@@ -333,6 +335,7 @@ export interface SettingsState {
 
   // Claude Code Integration
   claudeCodeIntegration: ClaudeCodeIntegrationSettings;
+  externalSessionApi: ExternalSessionApiSettings;
 
   // AI Features
   commitMessageGenerator: CommitMessageGeneratorSettings;
@@ -455,6 +458,7 @@ export interface SettingsState {
 
   // Setters - Claude Code Integration
   setClaudeCodeIntegration: (settings: Partial<ClaudeCodeIntegrationSettings>) => void;
+  setExternalSessionApi: (settings: Partial<ExternalSessionApiSettings>) => void;
   addClaudeProvider: (provider: import('@shared/types').ClaudeProvider) => void;
   updateClaudeProvider: (
     id: string,

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -208,6 +208,19 @@ export const zhTranslations: Record<string, string> = {
   Edit: '编辑',
   'Edit Agent': '编辑 Agent',
   'Enable notifications': '启用通知',
+  'External Session API': '外部会话 API',
+  'Expose a localhost API for external desktop tools to list and focus sessions':
+    '暴露本地 localhost API，供外部桌面工具列出并聚焦会话',
+  'Disabled by default. Turn this on only if you need external tools to control sessions':
+    '默认关闭。仅在你需要外部工具控制会话时再开启',
+  'API Usage': 'API 用法',
+  'Use these localhost endpoints to inspect and focus sessions from external tools':
+    '外部工具可使用以下 localhost 接口查看并聚焦会话',
+  'API Base URL': 'API 基础地址',
+  Port: '端口',
+  'Choose a localhost port for the external session API': '为外部会话 API 选择一个 localhost 端口',
+  'List sessions': '列出会话',
+  'Focus a session': '聚焦会话',
   'Edit Group': '编辑分组',
   English: '英语',
   'Enter delay': '启动延迟',

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -219,6 +219,8 @@ export const zhTranslations: Record<string, string> = {
   'API Base URL': 'API 基础地址',
   Port: '端口',
   'Choose a localhost port for the external session API': '为外部会话 API 选择一个 localhost 端口',
+  'This localhost API is intended for local desktop integrations. Keep it disabled if you do not need external control':
+    '这个 localhost API 面向本地桌面集成使用。如果你不需要外部控制，请保持关闭',
   'List sessions': '列出会话',
   'Focus a session': '聚焦会话',
   'Edit Group': '编辑分组',

--- a/src/shared/types/externalSession.ts
+++ b/src/shared/types/externalSession.ts
@@ -1,0 +1,33 @@
+export interface ExternalSessionRecord {
+  id: string;
+  backendSessionId?: string;
+  sessionId?: string;
+  name: string;
+  displayName: string;
+  agentId: string;
+  agentCommand: string;
+  repoPath: string;
+  cwd: string;
+  projectName: string;
+  groupId: string | null;
+  terminalTitle?: string;
+  isGroupActive: boolean;
+  isSessionActive: boolean;
+  displayOrder: number;
+  updatedAt: number;
+}
+
+export interface ExternalSessionSnapshot {
+  sessions: ExternalSessionRecord[];
+  syncedAt: number;
+}
+
+export interface ExternalSessionFocusPayload {
+  sessionId: string;
+  cwd: string;
+  groupId: string | null;
+}
+
+export interface ExternalSessionApiItem extends ExternalSessionRecord {
+  windowId: number;
+}

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -3,6 +3,7 @@ export * from './ai';
 export * from './app';
 export * from './claude';
 export * from './cli';
+export * from './externalSession';
 export * from './file';
 export * from './git';
 export * from './ipc';

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -158,6 +158,8 @@ export const IPC_CHANNELS = {
   WINDOW_IS_FULLSCREEN: 'window:isFullScreen',
   WINDOW_FULLSCREEN_CHANGED: 'window:fullScreenChanged',
   WINDOW_GET_REPOSITORY_RUNTIME_CONTEXT: 'window:getRepositoryRuntimeContext',
+  EXTERNAL_SESSION_SYNC: 'externalSession:sync',
+  EXTERNAL_SESSION_FOCUS: 'externalSession:focus',
   // Dialog
   DIALOG_OPEN_DIRECTORY: 'dialog:openDirectory',
   DIALOG_OPEN_FILE: 'dialog:openFile',

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -160,6 +160,7 @@ export const IPC_CHANNELS = {
   WINDOW_GET_REPOSITORY_RUNTIME_CONTEXT: 'window:getRepositoryRuntimeContext',
   EXTERNAL_SESSION_SYNC: 'externalSession:sync',
   EXTERNAL_SESSION_FOCUS: 'externalSession:focus',
+  EXTERNAL_SESSION_RESYNC: 'externalSession:resync',
   // Dialog
   DIALOG_OPEN_DIRECTORY: 'dialog:openDirectory',
   DIALOG_OPEN_FILE: 'dialog:openFile',


### PR DESCRIPTION
## 变更说明

这次将外部会话 API 调整为默认关闭的可选功能，并补充了更适合通用场景使用的配置能力。

主要改动：
- 将外部会话 API 改为设置中默认关闭，避免影响不需要该能力的用户
- 将配置入口移动到通用设置页末尾，便于集中管理
- 增加中英文文案适配
- 增加端口自定义配置，避免固定端口被占用导致功能不可用
- 在启用时展示 API 调用示例，并提供复制按钮
- 修复主进程读取持久化设置层级错误，确保重启后能正确自动启动服务
- 修复切换端口后会话列表丢失的问题，服务启动后会主动请求重新同步快照
- 强化 session focus 时的窗口前置行为

## 设计考虑

这版刻意避免了平台专属依赖：
- API 服务基于 Node HTTP 与 Electron 通用窗口能力实现
- 设置与展示逻辑基于现有 React/Zustand/i18n 体系接入
- 默认关闭，减少对原有功能路径的影响

## 测试情况

已完成手动验证：
- 默认关闭时，本地 API 不可访问
- 开启后可以正常访问 `GET /health`、`GET /api/sessions`、`POST /api/sessions/:id/focus`
- 同项目/不同项目会话都可以正确列出
- 切换自定义端口后，新的端口可以继续访问，且会话列表会重新同步
- 中文/英文模式下设置文案与示例展示正常

## 风险说明

本次改动不改变原有默认行为；只有用户在设置中显式开启后才会启动该功能。
窗口前置行为仍受各操作系统窗口管理策略影响，但实现上没有引入平台专属 API。
