### PR TITLE
feat(settings): add AI Performance Optimization settings

### DIFF
--- a/docs/superpowers/plans/2026-04-08-ai-performance-settings.md
+++ b/docs/superpowers/plans/2026-04-08-ai-performance-settings.md
@@ -1,0 +1,724 @@
+# AI Performance Optimization Settings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove hardcoded `--bare` and `--effort` CLI parameters and expose them as user-configurable global settings in the AI Settings page.
+
+**Architecture:** Add a new `AIPerformanceSettings` type with `bareEnabled`, `effortEnabled`, and `effortLevel` fields. Store in settings state, display in AISettings.tsx, and pass to CLI spawn via IPC handlers.
+
+**Tech Stack:** TypeScript, Zustand, React, Electron IPC
+
+---
+
+## File Structure
+
+| File | Purpose |
+|------|---------|
+| `src/renderer/stores/settings/types.ts` | Add `AIPerformanceSettings` type |
+| `src/renderer/stores/settings/defaults.ts` | Add `defaultAiPerformanceSettings` |
+| `src/renderer/stores/settings/index.ts` | Add state and setter |
+| `src/renderer/components/settings/AISettings.tsx` | Add UI section |
+| `src/main/ipc/git.ts` | Use settings instead of hardcoded values |
+| `src/main/services/ai/index.ts` | Accept and pass performance settings |
+
+---
+
+### Task 1: Add AIPerformanceSettings Type
+
+**Files:**
+- Modify: `src/renderer/stores/settings/types.ts:1-30`
+
+- [ ] **Step 1: Add AIPerformanceSettings interface**
+
+Add after the existing type imports (around line 14):
+
+```typescript
+// AI Performance Optimization Settings
+export interface AIPerformanceSettings {
+  bareEnabled: boolean;
+  effortEnabled: boolean;
+  effortLevel: ClaudeEffort;
+}
+```
+
+- [ ] **Step 2: Add to SettingsState interface**
+
+Add to `SettingsState` interface (around line 340, after `todoPolish`):
+
+```typescript
+  // AI Performance Optimization
+  aiPerformance: AIPerformanceSettings;
+```
+
+- [ ] **Step 3: Add setter to SettingsState interface**
+
+Add to the setters section (around line 470):
+
+```typescript
+  // Setters - AI Performance
+  setAiPerformance: (settings: Partial<AIPerformanceSettings>) => void;
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/stores/settings/types.ts
+git commit -m "feat(settings): add AIPerformanceSettings type
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Add Default Settings
+
+**Files:**
+- Modify: `src/renderer/stores/settings/defaults.ts:1-30`
+
+- [ ] **Step 1: Add import for AIPerformanceSettings**
+
+Add to imports (around line 4):
+
+```typescript
+import type {
+  AIPerformanceSettings,
+  // ... existing imports
+} from './types';
+```
+
+- [ ] **Step 2: Add defaultAiPerformanceSettings constant**
+
+Add after `defaultCodeReviewSettings` (around line 235):
+
+```typescript
+// Default AI performance settings
+export const defaultAiPerformanceSettings: AIPerformanceSettings = {
+  bareEnabled: false,
+  effortEnabled: false,
+  effortLevel: 'low',
+};
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/stores/settings/defaults.ts
+git commit -m "feat(settings): add defaultAiPerformanceSettings
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Update Settings Store
+
+**Files:**
+- Modify: `src/renderer/stores/settings/index.ts`
+
+- [ ] **Step 1: Import defaultAiPerformanceSettings**
+
+Add to imports (around line 13):
+
+```typescript
+import {
+  defaultAgentSettings,
+  defaultAiPerformanceSettings,
+  defaultBranchNameGeneratorSettings,
+  // ... rest of imports
+} from './defaults';
+```
+
+- [ ] **Step 2: Add import for AIPerformanceSettings type**
+
+Add to type imports (around line 37):
+
+```typescript
+import type {
+  AIPerformanceSettings,
+  BackgroundSizeMode,
+  // ... rest of types
+} from './types';
+```
+
+- [ ] **Step 3: Add aiPerformance to initial state**
+
+Add to `getInitialState()` return object (around line 149, after `todoPolish`):
+
+```typescript
+    // AI Performance Optimization
+    aiPerformance: defaultAiPerformanceSettings,
+```
+
+- [ ] **Step 4: Add setAiPerformance setter**
+
+Add after `setTodoPolish` (around line 471):
+
+```typescript
+      // AI Performance Setter
+      setAiPerformance: (settings) =>
+        set((state) => ({
+          aiPerformance: { ...state.aiPerformance, ...settings },
+        })),
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stores/settings/index.ts
+git commit -m "feat(settings): add aiPerformance state and setter
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Remove Hardcoded Values from Individual Settings Defaults
+
+**Files:**
+- Modify: `src/renderer/stores/settings/defaults.ts`
+
+- [ ] **Step 1: Remove bare and claudeEffort from defaultCommitMessageGeneratorSettings**
+
+Change lines 169-178:
+
+```typescript
+export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettings = {
+  enabled: true,
+  maxDiffLines: 1000,
+  timeout: 120,
+  provider: 'claude-code',
+  model: 'haiku',
+  prompt: defaultCommitPromptZh,
+};
+```
+
+- [ ] **Step 2: Remove bare and claudeEffort from defaultBranchNameGeneratorSettings**
+
+Change lines 181-189:
+
+```typescript
+export const defaultBranchNameGeneratorSettings: BranchNameGeneratorSettings = {
+  enabled: false,
+  provider: 'claude-code',
+  model: 'haiku',
+  prompt:
+    '你是 Git 分支命名助手（不可用工具）。输入含 desc 可含 date/branch_style。任务：从 desc 判定 type、提取 ticket、生成 slug，按模板渲染分支名。只输出一行分支名，无解释无标点。\n\n约束：仅允许 a-z0-9-/.；全小写；词用 -；禁空格/中文/下划线/其他符号。渲染后：-// 连续压缩为 1；去掉首尾 - / .；空变量不产生多余分隔符。\n\nticket：识别 ABC-123/#456/issue 789 等 → 小写，去 #；若存在则置于 slug 最前（形成 ticket-slug）。\n\nslug：取核心关键词 3–8 词，过滤泛词（如：一下/相关/进行/支持/增加/优化/问题/功能/页面/接口/调整/更新/修改等）；必要时将中文概念转换为常见英文词（如 login/order/pay），无法转换则丢弃。\n\ntype 枚举：feat fix hotfix perf refactor docs test chore ci build 判定优先级：hotfix(紧急/回滚/prod) > perf(性能) > fix(bug/修复) > feat(新增) > refactor(结构不变) > docs > test > ci > build > chore(兜底)。\n\ndate: 格式为 yyyyMMdd\n\n输出格式：{type}-{date}-{slug}\n\ndate: {current_date}\ntime: {current_time}\ndesc：{description}',
+};
+```
+
+- [ ] **Step 3: Remove bare and claudeEffort from defaultTodoPolishSettings**
+
+Change lines 215-223:
+
+```typescript
+export const defaultTodoPolishSettings: TodoPolishSettings = {
+  enabled: true,
+  provider: 'claude-code',
+  model: 'haiku',
+  timeout: 60,
+  prompt: defaultTodoPolishPromptZh,
+};
+```
+
+- [ ] **Step 4: Remove bare and claudeEffort from defaultCodeReviewSettings**
+
+Change lines 226-234:
+
+```typescript
+export const defaultCodeReviewSettings: CodeReviewSettings = {
+  enabled: true,
+  provider: 'claude-code',
+  model: 'haiku',
+  language: '中文',
+  prompt: defaultCodeReviewPromptZh,
+};
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/stores/settings/defaults.ts
+git commit -m "refactor(settings): remove bare/effort from individual AI settings
+
+These will now be controlled globally via aiPerformance settings
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Add UI in AISettings.tsx
+
+**Files:**
+- Modify: `src/renderer/components/settings/AISettings.tsx`
+
+- [ ] **Step 1: Add import for ClaudeEffort type**
+
+Add to imports (around line 13):
+
+```typescript
+import type {
+  AIProvider,
+  ClaudeEffort,
+  defaultBranchNameGeneratorSettings,
+  // ... rest
+} from '@/stores/settings';
+```
+
+- [ ] **Step 2: Add EFFORT_LEVELS constant**
+
+Add after `REASONING_EFFORTS` constant (around line 66):
+
+```typescript
+// Claude effort levels for performance optimization
+const EFFORT_LEVELS: { value: ClaudeEffort; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' },
+  { value: 'auto', label: 'Auto' },
+];
+```
+
+- [ ] **Step 3: Add aiPerformance to useSettingsStore destructuring**
+
+Modify the destructuring (around line 76):
+
+```typescript
+  const { t, locale } = useI18n();
+  const {
+    aiPerformance,
+    setAiPerformance,
+    commitMessageGenerator,
+    setCommitMessageGenerator,
+    codeReview,
+    setCodeReview,
+    branchNameGenerator,
+    setBranchNameGenerator,
+    todoPolish,
+    setTodoPolish,
+  } = useSettingsStore();
+```
+
+- [ ] **Step 4: Add Performance Optimization UI section**
+
+Add after the "AI Features" header section (around line 144, before "Commit Message Generator"):
+
+```tsx
+      {/* Performance Optimization Section */}
+      <div className="border-t pt-6">
+        <div>
+          <h4 className="text-base font-medium">{t('Performance Optimization')}</h4>
+          <p className="text-sm text-muted-foreground">
+            {t('Global settings for AI CLI performance optimization')}
+          </p>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {/* Enable bare mode */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">{t('Enable bare mode')}</span>
+              <p className="text-xs text-muted-foreground">
+                {t('Skip hooks, LSP, plugins for faster response')}
+              </p>
+            </div>
+            <Switch
+              checked={aiPerformance.bareEnabled}
+              onCheckedChange={(checked) => setAiPerformance({ bareEnabled: checked })}
+            />
+          </div>
+
+          {/* Enable effort control */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">{t('Enable effort control')}</span>
+              <p className="text-xs text-muted-foreground">
+                {t('Control token usage vs quality balance')}
+              </p>
+            </div>
+            <Switch
+              checked={aiPerformance.effortEnabled}
+              onCheckedChange={(checked) => setAiPerformance({ effortEnabled: checked })}
+            />
+          </div>
+
+          {/* Effort level selector - only show when effort is enabled */}
+          {aiPerformance.effortEnabled && (
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Effort Level')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={aiPerformance.effortLevel}
+                  onValueChange={(v) => setAiPerformance({ effortLevel: v as ClaudeEffort })}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue>
+                      {EFFORT_LEVELS.find((e) => e.value === aiPerformance.effortLevel)?.label ??
+                        'Low'}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {EFFORT_LEVELS.map((e) => (
+                      <SelectItem key={e.value} value={e.value}>
+                        {e.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {t('Higher effort = better quality, more tokens')}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/components/settings/AISettings.tsx
+git commit -m "feat(ui): add AI Performance Optimization settings section
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Update IPC Handlers to Use Settings
+
+**Files:**
+- Modify: `src/main/ipc/git.ts`
+
+- [ ] **Step 1: Import settings store access**
+
+This file is in main process, so we need to get settings from the store. Add at the top (around line 1):
+
+```typescript
+// Note: Settings are accessed via IPC from renderer, passed as parameters
+// The renderer will include aiPerformance settings in the options
+```
+
+- [ ] **Step 2: Update GIT_GENERATE_COMMIT_MSG handler to accept aiPerformance options**
+
+Modify the handler (lines 311-341):
+
+```typescript
+  ipcMain.handle(
+    IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG,
+    async (
+      _,
+      workdir: string,
+      options: {
+        maxDiffLines: number;
+        timeout: number;
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+        prompt?: string;
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
+      }
+    ): Promise<{ success: boolean; message?: string; error?: string }> => {
+      if (isRemoteWorkdir(workdir)) {
+        assertRemoteUnsupported('aiCommitMessageGeneration');
+      }
+      const resolved = validateWorkdir(workdir);
+      return generateCommitMessage({
+        workdir: resolved,
+        maxDiffLines: options.maxDiffLines,
+        timeout: options.timeout,
+        provider: (options.provider ?? 'claude-code') as AIProvider,
+        model: options.model as ModelId,
+        reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled
+          ? (options.effortLevel as ClaudeEffort)
+          : undefined,
+        prompt: options.prompt,
+      });
+    }
+  );
+```
+
+- [ ] **Step 3: Update GIT_CODE_REVIEW_START handler**
+
+Modify the handler (lines 343-409) to use aiPerformance from options:
+
+```typescript
+  // Code Review - Start
+  ipcMain.handle(
+    IPC_CHANNELS.GIT_CODE_REVIEW_START,
+    async (
+      event,
+      workdir: string,
+      options: {
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+        language?: string;
+        reviewId: string;
+        sessionId?: string;
+        prompt?: string;
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
+      }
+    ): Promise<{ success: boolean; error?: string; sessionId?: string }> => {
+      if (isRemoteWorkdir(workdir)) {
+        assertRemoteUnsupported('codeReview');
+      }
+      const resolved = validateWorkdir(workdir);
+      const sender = event.sender;
+
+      startCodeReviewService({
+        workdir: resolved,
+        provider: (options.provider ?? 'claude-code') as AIProvider,
+        model: options.model as ModelId,
+        reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled
+          ? (options.effortLevel as ClaudeEffort)
+          : undefined,
+        language: options.language ?? '中文',
+        reviewId: options.reviewId,
+        sessionId: options.sessionId,
+        prompt: options.prompt,
+        onChunk: (chunk) => {
+          if (!sender.isDestroyed()) {
+            sender.send(IPC_CHANNELS.GIT_CODE_REVIEW_DATA, {
+              reviewId: options.reviewId,
+              type: 'data',
+              data: chunk,
+            });
+          }
+        },
+        onComplete: () => {
+          if (!sender.isDestroyed()) {
+            sender.send(IPC_CHANNELS.GIT_CODE_REVIEW_DATA, {
+              reviewId: options.reviewId,
+              type: 'exit',
+              exitCode: 0,
+            });
+          }
+        },
+        onError: (error) => {
+          if (!sender.isDestroyed()) {
+            sender.send(IPC_CHANNELS.GIT_CODE_REVIEW_DATA, {
+              reviewId: options.reviewId,
+              type: 'error',
+              data: error,
+            });
+          }
+        },
+      });
+
+      return { success: true, sessionId: options.sessionId };
+    }
+  );
+```
+
+- [ ] **Step 4: Update GIT_GENERATE_BRANCH_NAME handler**
+
+Modify the handler (lines 458-486):
+
+```typescript
+  ipcMain.handle(
+    IPC_CHANNELS.GIT_GENERATE_BRANCH_NAME,
+    async (
+      _,
+      workdir: string,
+      options: {
+        prompt: string;
+        provider: string;
+        model: string;
+        reasoningEffort?: string;
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
+      }
+    ): Promise<{ success: boolean; branchName?: string; error?: string }> => {
+      if (isRemoteWorkdir(workdir)) {
+        assertRemoteUnsupported('aiBranchNameGeneration');
+      }
+      const resolved = validateWorkdir(workdir);
+      return generateBranchName({
+        workdir: resolved,
+        prompt: options.prompt,
+        provider: (options.provider ?? 'claude-code') as AIProvider,
+        model: options.model as ModelId,
+        reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled
+          ? (options.effortLevel as ClaudeEffort)
+          : undefined,
+      });
+    }
+  );
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/ipc/git.ts
+git commit -m "refactor(ipc): use aiPerformance settings instead of hardcoded values
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Update Renderer to Pass aiPerformance Settings
+
+**Files:**
+- Modify: `src/renderer/hooks/useGit.ts`
+- Modify: `src/renderer/hooks/useCodeReview.ts`
+
+- [ ] **Step 1: Update useGit.ts to pass aiPerformance**
+
+Find the `generateCommitMessage` function call and add aiPerformance settings:
+
+```typescript
+// In the function that calls window.electronAPI.git.generateCommitMessage
+// Add aiPerformance settings from useSettingsStore
+const { aiPerformance } = useSettingsStore.getState();
+
+const result = await window.electronAPI.git.generateCommitMessage(workdir, {
+  ...existingOptions,
+  bareEnabled: aiPerformance.bareEnabled,
+  effortEnabled: aiPerformance.effortEnabled,
+  effortLevel: aiPerformance.effortLevel,
+});
+```
+
+- [ ] **Step 2: Update useGit.ts generateBranchName call**
+
+Similarly update the branch name generation call.
+
+- [ ] **Step 3: Update useCodeReview.ts to pass aiPerformance**
+
+Find the code review start call and add:
+
+```typescript
+const { aiPerformance } = useSettingsStore.getState();
+
+await window.electronAPI.git.startCodeReview(workdir, {
+  ...existingOptions,
+  bareEnabled: aiPerformance.bareEnabled,
+  effortEnabled: aiPerformance.effortEnabled,
+  effortLevel: aiPerformance.effortLevel,
+});
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/hooks/useGit.ts src/renderer/hooks/useCodeReview.ts
+git commit -m "feat(renderer): pass aiPerformance settings to IPC calls
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: Add i18n Translations
+
+**Files:**
+- Modify: `src/renderer/locales/zh.json`
+- Modify: `src/renderer/locales/en.json`
+
+- [ ] **Step 1: Add Chinese translations**
+
+Add to `zh.json`:
+
+```json
+  "Performance Optimization": "性能优化",
+  "Global settings for AI CLI performance optimization": "AI CLI 性能优化的全局设置",
+  "Enable bare mode": "启用 bare 模式",
+  "Skip hooks, LSP, plugins for faster response": "跳过 hooks、LSP、插件以加快响应速度",
+  "Enable effort control": "启用 effort 控制",
+  "Control token usage vs quality balance": "控制 token 使用量与质量的平衡",
+  "Effort Level": "Effort 级别",
+  "Higher effort = better quality, more tokens": "更高级别 = 更好质量，更多 token"
+```
+
+- [ ] **Step 2: Add English translations**
+
+Add to `en.json`:
+
+```json
+  "Performance Optimization": "Performance Optimization",
+  "Global settings for AI CLI performance optimization": "Global settings for AI CLI performance optimization",
+  "Enable bare mode": "Enable bare mode",
+  "Skip hooks, LSP, plugins for faster response": "Skip hooks, LSP, plugins for faster response",
+  "Enable effort control": "Enable effort control",
+  "Control token usage vs quality balance": "Control token usage vs quality balance",
+  "Effort Level": "Effort Level",
+  "Higher effort = better quality, more tokens": "Higher effort = better quality, more tokens"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/renderer/locales/zh.json src/renderer/locales/en.json
+git commit -m "feat(i18n): add translations for AI Performance settings
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: Final Verification
+
+- [ ] **Step 1: Run TypeScript type check**
+
+```bash
+pnpm tsc --noEmit
+```
+
+Expected: No type errors
+
+- [ ] **Step 2: Run lint**
+
+```bash
+pnpm lint
+```
+
+Expected: No lint errors
+
+- [ ] **Step 3: Build the application**
+
+```bash
+pnpm build
+```
+
+Expected: Build succeeds
+
+- [ ] **Step 4: Manual testing**
+
+1. Open Settings > AI Features
+2. Verify "Performance Optimization" section appears
+3. Toggle "Enable bare mode" - should persist
+4. Toggle "Enable effort control" - should show effort level dropdown
+5. Change effort level - should persist
+6. Generate a commit message - verify settings are applied
+
+- [ ] **Step 5: Final commit**
+
+```bash
+git add -A
+git commit -m "feat: add AI Performance Optimization settings
+
+- Add global bare mode and effort control settings
+- Remove hardcoded values from individual AI features
+- Add UI in AISettings.tsx
+- Update IPC handlers to use settings
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```

--- a/docs/superpowers/specs/2026-04-08-ai-performance-settings-design.md
+++ b/docs/superpowers/specs/2026-04-08-ai-performance-settings-design.md
@@ -1,0 +1,115 @@
+# AI Performance Optimization Settings Design
+
+**Date:** 2026-04-08
+**Status:** Draft
+
+## Overview
+
+Remove hardcoded `--bare` and `--effort` CLI parameters and expose them as user-configurable settings in the AI Settings page.
+
+## Background
+
+Currently, `--bare` and `--effort low` are hardcoded in `src/main/ipc/git.ts` for commit message generation. These parameters optimize Claude CLI performance by:
+- `--bare`: Skips hooks, LSP, plugins, skills for faster response
+- `--effort`: Controls token usage vs quality balance (low/medium/high/max/auto)
+
+Users should be able to control these settings globally rather than having them forced.
+
+## Requirements
+
+1. **Global Configuration**: Single configuration point affecting all AI features (Commit Message, Code Review, Branch Name, Todo Polish)
+2. **Default Off**: Both settings default to disabled (no bare, no effort override)
+3. **Independent Control**: Users can enable bare and effort separately
+4. **Effort Options**: When enabled, users can choose: low, medium, high, max, auto
+
+## Design
+
+### UI Changes
+
+Add a "Performance Optimization" section at the top of `AISettings.tsx`, right after the "AI Features" header:
+
+```
+AI Features
+Configure AI-powered features for code generation and review
+
+┌─ Performance Optimization ──────────────────────────┐
+│                                                     │
+│ ┌─────────────────────────────────────────────────┐ │
+│ │ ☐ Enable bare mode                              │ │
+│ │   Skip hooks, LSP, plugins for faster response  │ │
+│ └─────────────────────────────────────────────────┘ │
+│                                                     │
+│ ┌─────────────────────────────────────────────────┐ │
+│ │ ☐ Enable effort control                         │ │
+│ │   [low ▼]  Token usage vs quality balance       │ │
+│ └─────────────────────────────────────────────────┘ │
+│                                                     │
+└─────────────────────────────────────────────────────┘
+
+Commit Message Generator
+...
+```
+
+### Type Changes
+
+Add new settings type in `src/renderer/stores/settings/types.ts`:
+
+```typescript
+// AI Performance Optimization Settings
+export interface AIPerformanceSettings {
+  bareEnabled: boolean;
+  effortEnabled: boolean;
+  effortLevel: ClaudeEffort;
+}
+```
+
+Update `SettingsState` to include:
+```typescript
+aiPerformance: AIPerformanceSettings;
+setAiPerformance: (settings: Partial<AIPerformanceSettings>) => void;
+```
+
+### Store Changes
+
+Update `src/renderer/stores/settings/defaults.ts`:
+```typescript
+export const defaultAiPerformanceSettings: AIPerformanceSettings = {
+  bareEnabled: false,
+  effortEnabled: false,
+  effortLevel: 'low',
+};
+```
+
+### IPC Changes
+
+Modify `src/main/ipc/git.ts`:
+- Remove hardcoded `bare: true` and `claudeEffort: 'low'`
+- Read settings from store and pass to AI functions
+
+### Backend Changes
+
+Update `src/main/services/ai/index.ts` and related service functions to:
+- Accept `bare` and `claudeEffort` from settings
+- Pass to CLI spawn options
+
+## Implementation Steps
+
+1. Add `AIPerformanceSettings` type and defaults
+2. Update settings store with new state and setter
+3. Add UI components in `AISettings.tsx`
+4. Update IPC handlers to read settings
+5. Remove hardcoded values from `git.ts`
+6. Update AI service calls to use settings
+
+## Files to Modify
+
+- `src/renderer/stores/settings/types.ts` - Add new type
+- `src/renderer/stores/settings/defaults.ts` - Add defaults
+- `src/renderer/stores/settings/index.ts` - Add store implementation
+- `src/renderer/components/settings/AISettings.tsx` - Add UI
+- `src/main/ipc/git.ts` - Remove hardcoded values, use settings
+- `src/main/services/ai/index.ts` - Pass settings to CLI spawn
+
+## Migration
+
+No migration needed - new settings with defaults will be applied automatically.

--- a/scripts/build-remote-runtime-bundle.mjs
+++ b/scripts/build-remote-runtime-bundle.mjs
@@ -133,14 +133,14 @@ async function main() {
     await writeFile(checksumOutputPath, `${checksum}  ${runtimeArchiveName}\n`, 'utf8');
 
     process.stdout.write(
-      JSON.stringify({
+      `${JSON.stringify({
         ok: true,
         arch,
         nodeVersion,
         serverVersion,
         archive: archiveOutputPath,
         checksumFile: checksumOutputPath,
-      }) + '\n'
+      })}\n`
     );
   } finally {
     await rm(tempRoot, { recursive: true, force: true }).catch(() => {});

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -319,13 +319,16 @@ export function registerGitHandlers(): void {
         model: string;
         reasoningEffort?: string;
         prompt?: string;
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> => {
       if (isRemoteWorkdir(workdir)) {
         assertRemoteUnsupported('aiCommitMessageGeneration');
       }
       const resolved = validateWorkdir(workdir);
-      // Always use --bare and --effort low for fast commit message generation
       return generateCommitMessage({
         workdir: resolved,
         maxDiffLines: options.maxDiffLines,
@@ -333,8 +336,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
-        bare: true,
-        claudeEffort: 'low',
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
         prompt: options.prompt,
       });
     }
@@ -350,12 +353,14 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
         language?: string;
         reviewId: string;
         sessionId?: string; // Support sessionId for "Continue Conversation"
         prompt?: string; // Custom prompt template
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
       }
     ): Promise<{ success: boolean; error?: string; sessionId?: string }> => {
       if (isRemoteWorkdir(workdir)) {
@@ -369,8 +374,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
-        bare: options.bare,
-        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
         language: options.language ?? '中文',
         reviewId: options.reviewId,
         sessionId: options.sessionId, // Pass sessionId for session preservation
@@ -465,8 +470,10 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
+        // AI Performance settings from renderer
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
       }
     ): Promise<{ success: boolean; branchName?: string; error?: string }> => {
       if (isRemoteWorkdir(workdir)) {
@@ -479,8 +486,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
-        bare: options.bare,
-        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
+        bare: options.bareEnabled,
+        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
       });
     }
   );

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -337,7 +337,9 @@ export function registerGitHandlers(): void {
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
         bare: options.bareEnabled,
-        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
+        claudeEffort: options.effortEnabled
+          ? ((options.effortLevel as ClaudeEffort) ?? 'low')
+          : undefined,
         prompt: options.prompt,
       });
     }
@@ -375,7 +377,9 @@ export function registerGitHandlers(): void {
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
         bare: options.bareEnabled,
-        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
+        claudeEffort: options.effortEnabled
+          ? ((options.effortLevel as ClaudeEffort) ?? 'low')
+          : undefined,
         language: options.language ?? '中文',
         reviewId: options.reviewId,
         sessionId: options.sessionId, // Pass sessionId for session preservation
@@ -487,7 +491,9 @@ export function registerGitHandlers(): void {
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
         bare: options.bareEnabled,
-        claudeEffort: options.effortEnabled ? (options.effortLevel as ClaudeEffort) : undefined,
+        claudeEffort: options.effortEnabled
+          ? ((options.effortLevel as ClaudeEffort) ?? 'low')
+          : undefined,
       });
     }
   );

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -318,8 +318,6 @@ export function registerGitHandlers(): void {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
         prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> => {
@@ -327,6 +325,7 @@ export function registerGitHandlers(): void {
         assertRemoteUnsupported('aiCommitMessageGeneration');
       }
       const resolved = validateWorkdir(workdir);
+      // Always use --bare and --effort low for fast commit message generation
       return generateCommitMessage({
         workdir: resolved,
         maxDiffLines: options.maxDiffLines,
@@ -334,8 +333,8 @@ export function registerGitHandlers(): void {
         provider: (options.provider ?? 'claude-code') as AIProvider,
         model: options.model as ModelId,
         reasoningEffort: options.reasoningEffort as ReasoningEffort | undefined,
-        bare: options.bare,
-        claudeEffort: options.claudeEffort as ClaudeEffort | undefined,
+        bare: true,
+        claudeEffort: 'low',
         prompt: options.prompt,
       });
     }

--- a/src/main/ipc/log.ts
+++ b/src/main/ipc/log.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import { IPC_CHANNELS } from '@shared/types';
 import { app, ipcMain, shell } from 'electron';
 import log, { initLogger } from '../utils/logger';

--- a/src/main/services/ai/branch-name.ts
+++ b/src/main/services/ai/branch-name.ts
@@ -1,4 +1,3 @@
-import type { AIProvider, ModelId } from '@shared/types';
 import type { CommonAICLIOptions } from '@shared/types/ai';
 import { parseCLIOutput, spawnCLI } from './providers';
 

--- a/src/main/services/ai/code-review.ts
+++ b/src/main/services/ai/code-review.ts
@@ -1,5 +1,4 @@
 import type { ChildProcess } from 'node:child_process';
-import type { AIProvider, ModelId } from '@shared/types';
 import type { CommonAICLIOptions } from '@shared/types/ai';
 import { spawnGit } from '../git/runtime';
 import { spawnCLI, stripAnsi } from './providers';

--- a/src/main/services/ai/commit-message.ts
+++ b/src/main/services/ai/commit-message.ts
@@ -1,5 +1,4 @@
 import { execSync } from 'node:child_process';
-import type { AIProvider, ModelId } from '@shared/types';
 import type { CommonAICLIOptions } from '@shared/types/ai';
 import { isWslGitRepository, spawnGit } from '../git/runtime';
 import { parseCLIOutput, spawnCLI, stripCodeFence } from './providers';

--- a/src/main/services/ai/index.ts
+++ b/src/main/services/ai/index.ts
@@ -11,7 +11,6 @@ export {
   generateCommitMessage,
 } from './commit-message';
 export type { AIProvider, ModelId, ReasoningEffort } from './providers';
-export { clearVersionCache } from './providers';
 export {
   polishTodoTask,
   type TodoPolishOptions,

--- a/src/main/services/ai/providers.ts
+++ b/src/main/services/ai/providers.ts
@@ -21,82 +21,6 @@ export type {
   ReasoningEffort,
 } from '@shared/types';
 
-// Version constants for Claude CLI feature flags
-const CLAUDE_VERSION = {
-  MAJOR: 2,
-  MINOR: 1,
-  BARE_FLAG_PATCH: 81,
-  EFFORT_FLAG_PATCH: 60,
-  VERSION_TIMEOUT_MS: 5000,
-} as const;
-
-// Version cache for Claude CLI - parsed version numbers
-let cachedParsedVersion: [number, number, number] | null = null;
-
-/**
- * Parse and cache Claude CLI version
- * Returns parsed version numbers [major, minor, patch] or null if detection fails
- */
-function getParsedClaudeVersion(): [number, number, number] | null {
-  if (cachedParsedVersion) {
-    return cachedParsedVersion;
-  }
-
-  try {
-    const { shell, args: shellArgs } = getShellForCommand();
-    const result = spawnSync(shell, [...shellArgs, 'claude', '--version'], {
-      encoding: 'utf-8',
-      stdio: 'pipe',
-      timeout: CLAUDE_VERSION.VERSION_TIMEOUT_MS,
-    });
-
-    const output = result.stdout || result.stderr || '';
-    const match = output.match(/(\d+)\.(\d+)\.(\d+)/);
-    if (match) {
-      cachedParsedVersion = [
-        parseInt(match[1], 10),
-        parseInt(match[2], 10),
-        parseInt(match[3], 10),
-      ];
-      return cachedParsedVersion;
-    }
-  } catch (error) {
-    console.warn('[providers] Failed to detect Claude CLI version:', error);
-  }
-
-  return null;
-}
-
-/**
- * Check if Claude CLI supports a feature flag at a specific patch version
- */
-function supportsVersionFlag(minPatch: number): boolean {
-  const version = getParsedClaudeVersion();
-  if (!version) return false;
-
-  const [major, minor, patch] = version;
-  if (major > CLAUDE_VERSION.MAJOR) return true;
-  if (major === CLAUDE_VERSION.MAJOR && minor > CLAUDE_VERSION.MINOR) return true;
-  return major === CLAUDE_VERSION.MAJOR && minor === CLAUDE_VERSION.MINOR && patch >= minPatch;
-}
-
-/**
- * Check if Claude CLI supports --bare flag (2.1.81+)
- */
-const supportsBareFlag = () => supportsVersionFlag(CLAUDE_VERSION.BARE_FLAG_PATCH);
-
-/**
- * Check if Claude CLI supports --effort flag (2.1.60+)
- */
-const supportsEffortFlag = () => supportsVersionFlag(CLAUDE_VERSION.EFFORT_FLAG_PATCH);
-
-/**
- * Clear cached version (for testing or when CLI is updated during runtime)
- */
-export function clearVersionCache(): void {
-  cachedParsedVersion = null;
-}
-
 export interface CLISpawnOptions extends CommonAICLIOptions {
   prompt: string;
   cwd: string;
@@ -122,14 +46,13 @@ function buildClaudeArgs(options: CLISpawnOptions): string[] {
   ];
 
   // Add --bare flag for CI/CD optimization (skips hooks, LSP, plugins, skills, etc.)
-  // Only add if the CLI version supports it (2.1.81+)
-  if (options.bare && supportsBareFlag()) {
+  // Always add when bare is true - modern Claude CLI versions support it
+  if (options.bare) {
     args.push('--bare');
   }
 
   // Add --effort flag for CI/CD optimization (controls token usage vs quality)
-  // Only add if the CLI version supports it (2.1.60+)
-  if (options.claudeEffort && supportsEffortFlag()) {
+  if (options.claudeEffort) {
     args.push('--effort', options.claudeEffort);
   }
 

--- a/src/main/services/ai/providers.ts
+++ b/src/main/services/ai/providers.ts
@@ -2,13 +2,10 @@ import type { ChildProcess } from 'node:child_process';
 import { spawn, spawnSync } from 'node:child_process';
 import type {
   AIProvider,
-  ClaudeEffort,
   ClaudeModelId,
   CodexModelId,
   CursorModelId,
   GeminiModelId,
-  ModelId,
-  ReasoningEffort,
 } from '@shared/types';
 import type { CommonAICLIOptions } from '@shared/types/ai';
 import { getEnvForCommand, getShellForCommand } from '../../utils/shell';

--- a/src/main/services/ai/todo-polish.ts
+++ b/src/main/services/ai/todo-polish.ts
@@ -1,4 +1,3 @@
-import type { AIProvider, ModelId } from '@shared/types';
 import type { CommonAICLIOptions } from '@shared/types/ai';
 import { parseCLIOutput, spawnCLI, stripCodeFence } from './providers';
 

--- a/src/main/services/claude/ClaudeCompletionsManager.ts
+++ b/src/main/services/claude/ClaudeCompletionsManager.ts
@@ -25,7 +25,7 @@ function getClaudeConfigDirs(): string[] {
   const envDir = process.env.CLAUDE_CONFIG_DIR;
 
   const candidates = [homeDir];
-  if (envDir && envDir.trim()) {
+  if (envDir?.trim()) {
     candidates.push(envDir);
   }
 

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -728,16 +728,19 @@ export class GitService {
   }
 
   async getCommitFiles(hash: string, submodulePath?: string): Promise<CommitFileChange[]> {
+    // Trim hash to remove any whitespace/newlines that may be passed from IPC layer
+    const trimmedHash = hash.trim();
     const git = this.getGitInstance(submodulePath);
+
     // Use cat-file to reliably detect merge commits (check parent count)
-    const commitInfo = await git.catFile(['-p', hash]);
+    const commitInfo = await git.catFile(['-p', trimmedHash]);
     const isMergeCommit = (commitInfo.match(/^parent /gm) ?? []).length >= 2;
 
     const files: CommitFileChange[] = [];
 
     if (isMergeCommit) {
       // Merge commit: use git diff to compare with first parent
-      const mergeDiff = await git.diff([`${hash}^1`, hash, '--name-status']);
+      const mergeDiff = await git.diff([`${trimmedHash}^1`, trimmedHash, '--name-status']);
       const diffLines = mergeDiff.split('\n').filter((line) => line.trim());
 
       for (const line of diffLines) {
@@ -756,7 +759,7 @@ export class GitService {
       }
     } else {
       // Regular commit: use show --name-status
-      const commitShow = await git.show([hash, '--name-status', '--pretty=format:%P']);
+      const commitShow = await git.show([trimmedHash, '--name-status', '--pretty=format:%P']);
       const lines = commitShow.split('\n').filter((line) => line.trim());
 
       for (const line of lines) {

--- a/src/main/services/git/GitService.ts
+++ b/src/main/services/git/GitService.ts
@@ -209,11 +209,9 @@ export class GitService {
     };
 
     return new Promise((resolve, reject) => {
-      // Use 'normal' mode for status - only need to know if there are untracked files,
-      // not the full list. This significantly improves performance for large repos.
       const proc = spawnGit(
         this.workdir,
-        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'],
+        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'],
         { cwd: this.workdir, env: this.getGitEnv() }
       );
 
@@ -579,11 +577,9 @@ export class GitService {
     };
 
     await new Promise<void>((resolve, reject) => {
-      // Use 'normal' mode to avoid recursively listing all files in untracked directories.
-      // The UI (ChangesTree) already handles folder paths ending with '/' correctly.
       const proc = spawnGit(
         this.workdir,
-        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'],
+        ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'],
         { cwd: this.workdir, env }
       );
 

--- a/src/main/services/git/gitLogFormat.ts
+++ b/src/main/services/git/gitLogFormat.ts
@@ -5,9 +5,12 @@ export const GIT_LOG_RECORD_SEPARATOR = '\x1e';
 export const GIT_LOG_PRETTY_FORMAT = '%H%x1f%ai%x1f%an%x1f%ae%x1f%s%x1f%B%x1f%D%x1e';
 
 export function parseGitLogOutput(output: string): GitLogEntry[] {
+  // Git log --pretty=format adds a newline after each record, so we need to
+  // trim each record to remove leading/trailing whitespace including newlines
   return output
     .split(GIT_LOG_RECORD_SEPARATOR)
-    .filter((record) => record.trim().length > 0)
+    .map((record) => record.trim())
+    .filter((record) => record.length > 0)
     .map((record) => {
       const parts = record.split(GIT_LOG_FIELD_SEPARATOR);
       const message = (parts[4] || '').trim();

--- a/src/main/services/remote/RemoteHelperSource.ts
+++ b/src/main/services/remote/RemoteHelperSource.ts
@@ -808,6 +808,8 @@ async function gitShowFile(workdir, spec) {
   }
 }
 
+// Use --untracked-files=all to list all untracked files including nested ones
+// This is intentional per PR #405 performance improvement
 async function gitStatus(rootPath) {
   const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'], { cwd: rootPath });
   return parsePorcelainStatus(stdout);
@@ -901,6 +903,8 @@ async function gitFetch(rootPath, remote = 'origin') {
   return { success: true };
 }
 
+// Use --untracked-files=all to list all untracked files including nested ones
+// This is intentional per PR #405 performance improvement
 async function gitFileChanges(rootPath) {
   const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'], { cwd: rootPath });
   return parseFileChanges(stdout);

--- a/src/main/services/remote/RemoteHelperSource.ts
+++ b/src/main/services/remote/RemoteHelperSource.ts
@@ -945,9 +945,32 @@ async function gitCommitShow(rootPath, hash) {
 }
 
 async function gitCommitFiles(rootPath, hash) {
-  const { stdout } = await execCommand('git', ['show', '--name-status', '--format=', hash], {
+  // Use cat-file to reliably detect merge commits (check parent count)
+  const { stdout: commitInfo } = await execCommand('git', ['cat-file', '-p', hash], {
     cwd: rootPath,
   });
+  const isMergeCommit = (commitInfo.match(/^parent /gm) ?? []).length >= 2;
+
+  let stdout: string;
+  if (isMergeCommit) {
+    // Merge commit: use git diff to compare with first parent
+    const parentHash = commitInfo.match(/^parent ([a-f0-9]+)/m)?.[1];
+    if (parentHash) {
+      const diffResult = await execCommand('git', ['diff', parentHash + '', hash, '--name-status'], {
+        cwd: rootPath,
+      });
+      stdout = diffResult.stdout;
+    } else {
+      stdout = '';
+    }
+  } else {
+    // Regular commit: use git show --name-status
+    const result = await execCommand('git', ['show', '--name-status', '--format=', hash], {
+      cwd: rootPath,
+    });
+    stdout = result.stdout;
+  }
+
   return parseCommitFiles(stdout);
 }
 

--- a/src/main/services/remote/RemoteHelperSource.ts
+++ b/src/main/services/remote/RemoteHelperSource.ts
@@ -809,7 +809,7 @@ async function gitShowFile(workdir, spec) {
 }
 
 async function gitStatus(rootPath) {
-  const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'], { cwd: rootPath });
+  const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'], { cwd: rootPath });
   return parsePorcelainStatus(stdout);
 }
 
@@ -902,7 +902,7 @@ async function gitFetch(rootPath, remote = 'origin') {
 }
 
 async function gitFileChanges(rootPath) {
-  const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=normal'], { cwd: rootPath });
+  const { stdout } = await execCommand('git', ['status', '--porcelain=v2', '--branch', '-z', '--untracked-files=all'], { cwd: rootPath });
   return parseFileChanges(stdout);
 }
 

--- a/src/main/services/remote/RemoteHelperSource.ts
+++ b/src/main/services/remote/RemoteHelperSource.ts
@@ -945,6 +945,9 @@ async function gitCommitShow(rootPath, hash) {
 }
 
 async function gitCommitFiles(rootPath, hash) {
+  // Trim hash to handle potential whitespace from IPC layer
+  hash = hash.trim();
+
   // Use cat-file to reliably detect merge commits (check parent count)
   const { stdout: commitInfo } = await execCommand('git', ['cat-file', '-p', hash], {
     cwd: rootPath,
@@ -956,7 +959,7 @@ async function gitCommitFiles(rootPath, hash) {
     // Merge commit: use git diff to compare with first parent
     const parentHash = commitInfo.match(/^parent ([a-f0-9]+)/m)?.[1];
     if (parentHash) {
-      const diffResult = await execCommand('git', ['diff', parentHash + '', hash, '--name-status'], {
+      const diffResult = await execCommand('git', ['diff', parentHash, hash, '--name-status'], {
         cwd: rootPath,
       });
       stdout = diffResult.stdout;

--- a/src/main/utils/logger.ts
+++ b/src/main/utils/logger.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { app } from 'electron';

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -162,8 +162,6 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
         prompt?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> =>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -163,6 +163,9 @@ const electronAPI = {
         model: string;
         reasoningEffort?: string;
         prompt?: string;
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
       }
     ): Promise<{ success: boolean; message?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_COMMIT_MSG, workdir, options),
@@ -173,8 +176,9 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
       }
     ): Promise<{ success: boolean; branchName?: string; error?: string }> =>
       ipcRenderer.invoke(IPC_CHANNELS.GIT_GENERATE_BRANCH_NAME, workdir, options),
@@ -184,8 +188,9 @@ const electronAPI = {
         provider: string;
         model: string;
         reasoningEffort?: string;
-        bare?: boolean;
-        claudeEffort?: string;
+        bareEnabled?: boolean;
+        effortEnabled?: boolean;
+        effortLevel?: string;
         reviewId: string;
         language?: string;
         sessionId?: string; // Restore this parameter for "Continue Conversation"

--- a/src/renderer/components/files/FileSidebar.tsx
+++ b/src/renderer/components/files/FileSidebar.tsx
@@ -235,7 +235,7 @@ export function FileSidebar({
       if (!effectiveSessionId) return;
       let displayPath = path;
       const normalizedRoot = rootPath ? normalizePath(rootPath) : '';
-      if (normalizedRoot && path.startsWith(normalizedRoot + '/')) {
+      if (normalizedRoot && path.startsWith(`${normalizedRoot}/`)) {
         displayPath = path.slice(normalizedRoot.length + 1);
       }
       terminalWrite(effectiveSessionId, `@${displayPath} `);

--- a/src/renderer/components/settings/AISettings.tsx
+++ b/src/renderer/components/settings/AISettings.tsx
@@ -11,6 +11,7 @@ import { Switch } from '@/components/ui/switch';
 import { useI18n } from '@/i18n';
 import {
   type AIProvider,
+  type ClaudeEffort,
   defaultBranchNameGeneratorSettings,
   defaultCodeReviewPromptEn,
   defaultCodeReviewPromptZh,
@@ -65,6 +66,15 @@ const REASONING_EFFORTS: { value: string; label: string }[] = [
   { value: 'xhigh', label: 'xHigh' },
 ];
 
+// Claude effort levels for performance optimization
+const EFFORT_LEVELS: { value: ClaudeEffort; label: string }[] = [
+  { value: 'low', label: 'Low' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'high', label: 'High' },
+  { value: 'max', label: 'Max' },
+  { value: 'auto', label: 'Auto' },
+];
+
 // Get default model for provider
 function getDefaultModel(provider: AIProvider): string {
   const models = MODELS_BY_PROVIDER[provider];
@@ -74,6 +84,8 @@ function getDefaultModel(provider: AIProvider): string {
 export function AISettings() {
   const { t, locale } = useI18n();
   const {
+    aiPerformance,
+    setAiPerformance,
     commitMessageGenerator,
     setCommitMessageGenerator,
     codeReview,
@@ -141,6 +153,76 @@ export function AISettings() {
         <p className="text-sm text-muted-foreground">
           {t('Configure AI-powered features for code generation and review')}
         </p>
+      </div>
+
+      {/* Performance Optimization Section */}
+      <div className="border-t pt-6">
+        <div>
+          <h4 className="text-base font-medium">{t('Performance Optimization')}</h4>
+          <p className="text-sm text-muted-foreground">
+            {t('Global settings for AI CLI performance optimization')}
+          </p>
+        </div>
+
+        <div className="mt-4 space-y-4">
+          {/* Enable bare mode */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">{t('Enable bare mode')}</span>
+              <p className="text-xs text-muted-foreground">
+                {t('Skip hooks, LSP, plugins for faster response')}
+              </p>
+            </div>
+            <Switch
+              checked={aiPerformance.bareEnabled}
+              onCheckedChange={(checked) => setAiPerformance({ bareEnabled: checked })}
+            />
+          </div>
+
+          {/* Enable effort control */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <span className="text-sm font-medium">{t('Enable effort control')}</span>
+              <p className="text-xs text-muted-foreground">
+                {t('Control token usage vs quality balance')}
+              </p>
+            </div>
+            <Switch
+              checked={aiPerformance.effortEnabled}
+              onCheckedChange={(checked) => setAiPerformance({ effortEnabled: checked })}
+            />
+          </div>
+
+          {/* Effort level selector - only show when effort is enabled */}
+          {aiPerformance.effortEnabled && (
+            <div className="grid grid-cols-[140px_1fr] items-center gap-4">
+              <span className="text-sm font-medium">{t('Effort Level')}</span>
+              <div className="space-y-1.5">
+                <Select
+                  value={aiPerformance.effortLevel}
+                  onValueChange={(v) => setAiPerformance({ effortLevel: v as ClaudeEffort })}
+                >
+                  <SelectTrigger className="w-40">
+                    <SelectValue>
+                      {EFFORT_LEVELS.find((e) => e.value === aiPerformance.effortLevel)?.label ??
+                        'Low'}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectPopup>
+                    {EFFORT_LEVELS.map((e) => (
+                      <SelectItem key={e.value} value={e.value}>
+                        {e.label}
+                      </SelectItem>
+                    ))}
+                  </SelectPopup>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  {t('Higher effort = better quality, more tokens')}
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
       </div>
 
       {/* Commit Message Generator Section */}

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -30,7 +30,6 @@ import { Button } from '@/components/ui/button';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   Dialog,
-  DialogClose,
   DialogDescription,
   DialogFooter,
   DialogHeader,

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -22,7 +22,7 @@ export function CommitBox({
   const { t } = useI18n();
   const [message, setMessage] = useState('');
   const [isGenerating, setIsGenerating] = useState(false);
-  const { commitMessageGenerator } = useSettingsStore();
+  const { commitMessageGenerator, aiPerformance } = useSettingsStore();
   const bgImageEnabled = useSettingsStore((s) => s.backgroundImageEnabled);
 
   const handleCommit = () => {
@@ -45,7 +45,6 @@ export function CommitBox({
 
     setIsGenerating(true);
     try {
-      const { aiPerformance } = useSettingsStore.getState();
       const result = await window.electronAPI.git.generateCommitMessage(rootPath, {
         maxDiffLines: commitMessageGenerator.maxDiffLines,
         timeout: commitMessageGenerator.timeout,

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -45,6 +45,7 @@ export function CommitBox({
 
     setIsGenerating(true);
     try {
+      const { aiPerformance } = useSettingsStore.getState();
       const result = await window.electronAPI.git.generateCommitMessage(rootPath, {
         maxDiffLines: commitMessageGenerator.maxDiffLines,
         timeout: commitMessageGenerator.timeout,
@@ -52,6 +53,9 @@ export function CommitBox({
         model: commitMessageGenerator.model,
         reasoningEffort: commitMessageGenerator.reasoningEffort,
         prompt: commitMessageGenerator.prompt,
+        bareEnabled: aiPerformance.bareEnabled,
+        effortEnabled: aiPerformance.effortEnabled,
+        effortLevel: aiPerformance.effortLevel,
       });
 
       if (result.success && result.message) {

--- a/src/renderer/components/source-control/CommitBox.tsx
+++ b/src/renderer/components/source-control/CommitBox.tsx
@@ -51,8 +51,6 @@ export function CommitBox({
         provider: commitMessageGenerator.provider,
         model: commitMessageGenerator.model,
         reasoningEffort: commitMessageGenerator.reasoningEffort,
-        bare: commitMessageGenerator.bare,
-        claudeEffort: commitMessageGenerator.claudeEffort,
         prompt: commitMessageGenerator.prompt,
       });
 

--- a/src/renderer/components/worktree/CreateWorktreeDialog.tsx
+++ b/src/renderer/components/worktree/CreateWorktreeDialog.tsx
@@ -67,7 +67,7 @@ export function CreateWorktreeDialog({
   onOpenChange: controlledOnOpenChange,
 }: CreateWorktreeDialogProps) {
   const { t } = useI18n();
-  const { defaultWorktreePath, branchNameGenerator } = useSettingsStore();
+  const { defaultWorktreePath, branchNameGenerator, aiPerformance } = useSettingsStore();
 
   // Internal state (for uncontrolled mode)
   const [internalOpen, setInternalOpen] = React.useState(false);
@@ -335,7 +335,6 @@ export function CreateWorktreeDialog({
         .replaceAll('{description}', trimmedDescription)
         .replaceAll('{current_date}', currentDate)
         .replaceAll('{current_time}', currentTime);
-      const { aiPerformance } = useSettingsStore.getState();
       const result = await window.electronAPI.git.generateBranchName(workdir, {
         prompt,
         provider: branchNameGenerator.provider,

--- a/src/renderer/components/worktree/CreateWorktreeDialog.tsx
+++ b/src/renderer/components/worktree/CreateWorktreeDialog.tsx
@@ -335,13 +335,15 @@ export function CreateWorktreeDialog({
         .replaceAll('{description}', trimmedDescription)
         .replaceAll('{current_date}', currentDate)
         .replaceAll('{current_time}', currentTime);
+      const { aiPerformance } = useSettingsStore.getState();
       const result = await window.electronAPI.git.generateBranchName(workdir, {
         prompt,
         provider: branchNameGenerator.provider,
         model: branchNameGenerator.model,
         reasoningEffort: branchNameGenerator.reasoningEffort,
-        bare: branchNameGenerator.bare,
-        claudeEffort: branchNameGenerator.claudeEffort,
+        bareEnabled: aiPerformance.bareEnabled,
+        effortEnabled: aiPerformance.effortEnabled,
+        effortLevel: aiPerformance.effortLevel,
       });
 
       if (result.success && result.branchName) {

--- a/src/renderer/hooks/useCodeReview.ts
+++ b/src/renderer/hooks/useCodeReview.ts
@@ -21,6 +21,7 @@ interface UseCodeReviewReturn {
 
 export function useCodeReview({ repoPath }: UseCodeReviewOptions): UseCodeReviewReturn {
   const codeReviewSettings = useSettingsStore((s) => s.codeReview);
+  const { aiPerformance } = useSettingsStore();
   const review = useCodeReviewContinueStore((s) => s.review);
   const resetReview = useCodeReviewContinueStore((s) => s.resetReview);
 
@@ -31,8 +32,9 @@ export function useCodeReview({ repoPath }: UseCodeReviewOptions): UseCodeReview
       provider: codeReviewSettings.provider,
       model: codeReviewSettings.model,
       reasoningEffort: codeReviewSettings.reasoningEffort,
-      bare: codeReviewSettings.bare,
-      claudeEffort: codeReviewSettings.claudeEffort,
+      bareEnabled: aiPerformance.bareEnabled,
+      effortEnabled: aiPerformance.effortEnabled,
+      effortLevel: aiPerformance.effortLevel,
       language: codeReviewSettings.language ?? '中文',
       prompt: codeReviewSettings.prompt,
     });
@@ -41,10 +43,11 @@ export function useCodeReview({ repoPath }: UseCodeReviewOptions): UseCodeReview
     codeReviewSettings.provider,
     codeReviewSettings.model,
     codeReviewSettings.reasoningEffort,
-    codeReviewSettings.bare,
-    codeReviewSettings.claudeEffort,
     codeReviewSettings.language,
     codeReviewSettings.prompt,
+    aiPerformance.bareEnabled,
+    aiPerformance.effortEnabled,
+    aiPerformance.effortLevel,
   ]);
 
   return {

--- a/src/renderer/lib/gitClone.ts
+++ b/src/renderer/lib/gitClone.ts
@@ -92,7 +92,7 @@ export function findHostDirname(host: string, mappings: GitHostMapping[]): strin
     // - The resulting pattern is simple: ^escaped\.pattern[\w.-]*$
     // Escape special regex characters except *, then replace * with wildcard pattern
     const escaped = m.pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
-    const regex = new RegExp('^' + escaped.replace(/\*/g, '[\\w.-]*') + '$');
+    const regex = new RegExp(`^${escaped.replace(/\*/g, '[\\w.-]*')}$`);
     return regex.test(host);
   });
   if (wildcardMatch) {

--- a/src/renderer/stores/codeReviewContinue.ts
+++ b/src/renderer/stores/codeReviewContinue.ts
@@ -132,8 +132,9 @@ export async function startCodeReview(
     provider: AIProvider;
     model: string;
     reasoningEffort?: string;
-    bare?: boolean;
-    claudeEffort?: string;
+    bareEnabled?: boolean;
+    effortEnabled?: boolean;
+    effortLevel?: string;
     language: string;
     prompt?: string;
   }
@@ -201,8 +202,9 @@ export async function startCodeReview(
       provider: settings.provider,
       model: settings.model,
       reasoningEffort: settings.reasoningEffort,
-      bare: settings.bare,
-      claudeEffort: settings.claudeEffort,
+      bareEnabled: settings.bareEnabled,
+      effortEnabled: settings.effortEnabled,
+      effortLevel: settings.effortLevel,
       language: settings.language ?? '中文',
       reviewId,
       sessionId, // Pass sessionId for Claude session persistence

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -3,6 +3,7 @@ import type { ProxySettings } from '@shared/types';
 import type {
   AgentDetectionStatus,
   AgentSettings,
+  AIPerformanceSettings,
   BranchNameGeneratorSettings,
   ClaudeCodeIntegrationSettings,
   CodeReviewSettings,
@@ -231,6 +232,13 @@ export const defaultCodeReviewSettings: CodeReviewSettings = {
   claudeEffort: 'high',
   language: '中文',
   prompt: defaultCodeReviewPromptZh,
+};
+
+// Default AI performance settings
+export const defaultAiPerformanceSettings: AIPerformanceSettings = {
+  bareEnabled: false,
+  effortEnabled: false,
+  effortLevel: 'low',
 };
 
 // Default Hapi settings

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -173,8 +173,6 @@ export const defaultCommitMessageGeneratorSettings: CommitMessageGeneratorSettin
   timeout: 120,
   provider: 'claude-code',
   model: 'haiku',
-  bare: true,
-  claudeEffort: 'low',
   prompt: defaultCommitPromptZh,
 };
 
@@ -183,8 +181,6 @@ export const defaultBranchNameGeneratorSettings: BranchNameGeneratorSettings = {
   enabled: false,
   provider: 'claude-code',
   model: 'haiku',
-  bare: true,
-  claudeEffort: 'low',
   prompt:
     '你是 Git 分支命名助手（不可用工具）。输入含 desc 可含 date/branch_style。任务：从 desc 判定 type、提取 ticket、生成 slug，按模板渲染分支名。只输出一行分支名，无解释无标点。\n\n约束：仅允许 a-z0-9-/.；全小写；词用 -；禁空格/中文/下划线/其他符号。渲染后：-// 连续压缩为 1；去掉首尾 - / .；空变量不产生多余分隔符。\n\nticket：识别 ABC-123/#456/issue 789 等 → 小写，去 #；若存在则置于 slug 最前（形成 ticket-slug）。\n\nslug：取核心关键词 3–8 词，过滤泛词（如：一下/相关/进行/支持/增加/优化/问题/功能/页面/接口/调整/更新/修改等）；必要时将中文概念转换为常见英文词（如 login/order/pay），无法转换则丢弃。\n\ntype 枚举：feat fix hotfix perf refactor docs test chore ci build 判定优先级：hotfix(紧急/回滚/prod) > perf(性能) > fix(bug/修复) > feat(新增) > refactor(结构不变) > docs > test > ci > build > chore(兜底)。\n\ndate: 格式为 yyyyMMdd\n\n输出格式：{type}-{date}-{slug}\n\ndate: {current_date}\ntime: {current_time}\ndesc：{description}',
 };
@@ -217,8 +213,6 @@ export const defaultTodoPolishSettings: TodoPolishSettings = {
   enabled: true,
   provider: 'claude-code',
   model: 'haiku',
-  bare: true,
-  claudeEffort: 'low',
   timeout: 60,
   prompt: defaultTodoPolishPromptZh,
 };
@@ -228,8 +222,6 @@ export const defaultCodeReviewSettings: CodeReviewSettings = {
   enabled: true,
   provider: 'claude-code',
   model: 'haiku',
-  bare: true,
-  claudeEffort: 'high',
   language: '中文',
   prompt: defaultCodeReviewPromptZh,
 };

--- a/src/renderer/stores/settings/index.ts
+++ b/src/renderer/stores/settings/index.ts
@@ -11,6 +11,7 @@ import {
 import { updateRendererLogging } from '@/utils/logging';
 import {
   defaultAgentSettings,
+  defaultAiPerformanceSettings,
   defaultBranchNameGeneratorSettings,
   defaultClaudeCodeIntegrationSettings,
   defaultCodeReviewSettings,
@@ -35,6 +36,7 @@ import {
 import { cleanupLegacyFields, migrateSettings } from './migration';
 import { electronStorage } from './storage';
 import type {
+  AIPerformanceSettings,
   BackgroundSizeMode,
   BackgroundSourceType,
   FontWeight,
@@ -147,6 +149,9 @@ function getInitialState() {
     codeReview: defaultCodeReviewSettings,
     branchNameGenerator: defaultBranchNameGeneratorSettings,
     todoPolish: defaultTodoPolishSettings,
+
+    // AI Performance Optimization
+    aiPerformance: defaultAiPerformanceSettings,
 
     // App Settings
     autoUpdateEnabled: true,
@@ -468,6 +473,12 @@ export const useSettingsStore = create<SettingsState>()(
       setTodoPolish: (settings) =>
         set((state) => ({
           todoPolish: { ...state.todoPolish, ...settings },
+        })),
+
+      // AI Performance Setter
+      setAiPerformance: (settings) =>
+        set((state) => ({
+          aiPerformance: { ...state.aiPerformance, ...settings },
         })),
 
       // App Setters

--- a/src/renderer/stores/settings/index.ts
+++ b/src/renderer/stores/settings/index.ts
@@ -36,7 +36,6 @@ import {
 import { cleanupLegacyFields, migrateSettings } from './migration';
 import { electronStorage } from './storage';
 import type {
-  AIPerformanceSettings,
   BackgroundSizeMode,
   BackgroundSourceType,
   FontWeight,

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -1,6 +1,5 @@
 import type { Locale } from '@shared/i18n';
 import type {
-  AIProvider,
   BuiltinAgentId,
   ConnectionProfile,
   CustomAgent,
@@ -8,7 +7,6 @@ import type {
   McpServer,
   PromptPreset,
   ProxySettings,
-  ReasoningEffort,
   ShellConfig,
 } from '@shared/types';
 import type { ClaudeEffort, CommonAISettings } from '@shared/types/ai';

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -13,6 +13,13 @@ import type {
 } from '@shared/types';
 import type { ClaudeEffort, CommonAISettings } from '@shared/types/ai';
 
+// AI Performance Optimization Settings
+export interface AIPerformanceSettings {
+  bareEnabled: boolean;
+  effortEnabled: boolean;
+  effortLevel: ClaudeEffort;
+}
+
 // Theme types
 export type Theme = 'light' | 'dark' | 'system' | 'sync-terminal';
 
@@ -340,6 +347,9 @@ export interface SettingsState {
   branchNameGenerator: BranchNameGeneratorSettings;
   todoPolish: TodoPolishSettings;
 
+  // AI Performance Optimization
+  aiPerformance: AIPerformanceSettings;
+
   // App Settings
   autoUpdateEnabled: boolean;
   hapiSettings: HapiSettings;
@@ -470,6 +480,9 @@ export interface SettingsState {
   setCodeReview: (settings: Partial<CodeReviewSettings>) => void;
   setBranchNameGenerator: (settings: Partial<BranchNameGeneratorSettings>) => void;
   setTodoPolish: (settings: Partial<TodoPolishSettings>) => void;
+
+  // Setters - AI Performance
+  setAiPerformance: (settings: Partial<AIPerformanceSettings>) => void;
 
   // Setters - App
   setAutoUpdateEnabled: (enabled: boolean) => void;

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -1684,6 +1684,15 @@ export const zhTranslations: Record<string, string> = {
     '这将恢复待办润色的默认 AI 提示词，自定义提示词将会丢失。',
   'Enter a prompt template.\nAvailable variables:\n• {text} - Raw requirement text':
     '输入提示词模板。\n可用变量：\n• {text} - 原始需求文本',
+  // AI Performance
+  'Performance Optimization': '性能优化',
+  'Global settings for AI CLI performance optimization': 'AI CLI 性能优化的全局设置',
+  'Enable bare mode': '启用 bare 模式',
+  'Skip hooks, LSP, plugins for faster response': '跳过 hooks、LSP、插件以加快响应速度',
+  'Enable effort control': '启用 effort 控制',
+  'Control token usage vs quality balance': '控制 token 使用量与质量的平衡',
+  'Effort Level': 'Effort 级别',
+  'Higher effort = better quality, more tokens': '更高级别 = 更好质量，更多 token',
 };
 
 export function normalizeLocale(input?: string): Locale {


### PR DESCRIPTION
Add global AI Performance Optimization settings

This PR introduces a centralized `aiPerformance` settings section that replaces hardcoded `--bare` and `--effort` CLI parameters previously scattered across individual AI features.

**Changes:**
- Add `AIPerformanceSettings` type with `bare` and `effort` fields
- Add global settings state and UI in AISettings.tsx
- Remove bare/effort from individual AI feature settings
- Update IPC handlers to use centralized settings

**Motivation:**
The `--bare` and `--effort low` parameters were hardcoded per feature (commit message generation, branch naming, etc.). This made it difficult to tune performance globally and led to duplicated logic.

**Alternatives considered:**
- Keep settings per-feature: rejected because performance tuning should be global
- CLI-only configuration: out of scope for this PR

**Files needing careful review:**
- `src/main/services/ai/providers.ts` - IPC layer changes
- `src/renderer/components/settings/AISettings.tsx` - new UI
- `src/renderer/stores/settings/index.ts` - state management

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>