### PR TITLE
fix(sidebar): 修复开启分组时隐藏仓库功能无效的问题

### DIFF
--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -1538,7 +1538,12 @@ export function TreeSidebar({
       {repoSettingsTarget && (
         <RepositorySettingsDialog
           open={repoSettingsOpen}
-          onOpenChange={setRepoSettingsOpen}
+          onOpenChange={(open) => {
+            setRepoSettingsOpen(open);
+            if (open === false) {
+              refreshRepoSettings();
+            }
+          }}
           repoPath={repoSettingsTarget.path}
           repoName={repoSettingsTarget.name}
         />


### PR DESCRIPTION
当开启分组时，RepositorySettingsDialog 关闭后没有刷新缓存状态，
导致隐藏的仓库仍然显示在侧边栏。

**问题原因：** TreeSidebar 的 repoSettingsMap 在对话框关闭时没有更新，虽然设置已保存到 localStorage，但缓存状态未刷新。

**修复方法：** 在对话框关闭时调用 refreshRepoSettings() 刷新缓存，与 RepositoryManagerDialog 的行为保持一致。

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>