### PR TITLE
fix: 修复关闭应用后窗口大小无法恢复的问题

### DIFF
--- a/src/main/windows/MainWindow.ts
+++ b/src/main/windows/MainWindow.ts
@@ -97,12 +97,14 @@ export function forceReplaceClose(win: BrowserWindow): void {
 }
 
 export function createMainWindow(options: CreateMainWindowOptions = {}): BrowserWindow {
-  const replacementState = options.replaceWindow?.isDestroyed()
-    ? null
-    : {
-        ...options.replaceWindow?.getBounds(),
-        isMaximized: options.replaceWindow?.isMaximized(),
-      };
+  const replacementState =
+    options.replaceWindow && !options.replaceWindow.isDestroyed()
+      ? {
+          ...options.replaceWindow.getBounds(),
+          isMaximized: options.replaceWindow.isMaximized(),
+        }
+      : null;
+
   const state = replacementState ?? loadWindowState();
 
   const isMac = process.platform === 'darwin';
@@ -265,6 +267,7 @@ export function createMainWindow(options: CreateMainWindowOptions = {}): Browser
     if (win.isDestroyed()) {
       return;
     }
+    saveWindowState(win);
     forceClose = true;
     win.hide();
     win.close();
@@ -368,8 +371,10 @@ export function createMainWindow(options: CreateMainWindowOptions = {}): Browser
   });
 
   win.on('close', (e) => {
-    // Skip confirmation if force close, or quitting for update
-    if (forceClose || autoUpdaterService.isQuittingForUpdate()) {
+    if (forceClose) {
+      return;
+    }
+    if (autoUpdaterService.isQuittingForUpdate()) {
       saveWindowState(win);
       return;
     }


### PR DESCRIPTION
## 问题描述

点击关闭按钮或按 Cmd+Q 退出应用后，再次打开应用时窗口大小没有恢复为关闭前的大小，而是变成了偏小的固定尺寸。

## 根因分析

`createMainWindow` 中 `replacementState` 的判断条件使用了可选链 `?.`：

```typescript
const replacementState = options.replaceWindow?.isDestroyed()
  ? null
  : { ...options.replaceWindow?.getBounds(), ... };
```

当 `options.replaceWindow` 为 `null` 时，`null?.isDestroyed()` 返回 `undefined`（假值），走了 else 分支，创建了空对象 `{}`。随后 `state = {} ?? loadWindowState()` 中，空对象不是 `null/undefined`，`??` 不会触发 `loadWindowState()`，导致窗口使用空对象的默认值创建，大小不正确。

## 修复内容

1. **修复 `replacementState` 判断逻辑**：先判断 `replaceWindow` 存在且未销毁才使用其状态，否则为 `null`，让 `??` 正确走到 `loadWindowState()`

2. **调整 `saveWindowState` 时机**：在 `forceReplaceCloseCurrentWindow` 中移至 `win.hide()` 之前调用，确保 `getBounds()` 在窗口可见时获取正确的值，避免 `hide()` 后 bounds 异常