### PR TITLE
fix(terminal): 锁定用户滚动位置防止 AI 输出时内容跳动

### DIFF
--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -614,7 +614,27 @@ export function useXterm({
             setTimeout(() => {
               if (writeBufferRef.current.length > 0) {
                 const bufferedData = writeBufferRef.current;
+
+                // If user has scrolled up to view history, lock their viewport position.
+                // TUI control sequences (CSI 2J, CSI 3J, alternate buffer switch)
+                // can reset or scroll the viewport regardless of isUserScrolling.
+                // We preserve the user's scroll offset from the bottom.
+                const buffer = terminal.buffer.active;
+                const offsetFromBottom = buffer.baseY - buffer.viewportY;
+                const shouldLockViewport = offsetFromBottom > 0;
+                const savedOffsetFromBottom = shouldLockViewport ? offsetFromBottom : 0;
+
                 terminal.write(bufferedData);
+
+                // Restore viewport if it was moved by the write
+                if (shouldLockViewport) {
+                  const targetViewportY = terminal.buffer.active.baseY - savedOffsetFromBottom;
+                  const currentViewportY = terminal.buffer.active.viewportY;
+                  if (targetViewportY !== currentViewportY) {
+                    terminal.scrollLines(targetViewportY - currentViewportY);
+                  }
+                }
+
                 // Call onData after write to avoid React re-render storm
                 onDataRef.current?.(bufferedData);
                 writeBufferRef.current = '';


### PR DESCRIPTION
## Summary

- 修复 AI 回答过程中，用户手动向上滚动查看历史内容时出现的**文字跳动/重叠**问题
- 在 `terminal.write()` 前后锁定用户距离底部的滚动偏移量，写入完成后用 `scrollLines()` 恢复 viewport 位置
- 解决 TUI 控制序列（`\x1b[2J`、`\x1b[3J` 等清屏操作）无视 `isUserScrolling` 状态导致的渲染错乱

## Root Cause

Claude Code 等 agent CLI 使用 TUI 框架，会周期性地发送清屏/刷新序列来重绘界面。xterm 的 `isUserScrolling` 保护仅阻止普通换行时的自动滚动，但 `eraseInDisplay`（清屏）等控制序列会直接修改 viewport 内容，导致用户正在阅读的内容位置跳变。

## Changes

- `src/renderer/hooks/useXterm.ts` — 在 PTY 数据写入时检测用户是否已向上滚动，如果是则记录 `offsetFromBottom` 并在写入后恢复

## Test plan

- [x] TypeScript 编译通过
- [ ] 手动测试：AI 输出过程中向上滚动，验证正在阅读的文字不跳动
- [ ] 手动测试：底部跟随输出，确认行为无变化
- [ ] 手动测试：TUI 清屏场景下滚动位置稳定