### PR TITLE
feat(terminal): 添加复制 tmux 恢复命令功能

### DIFF
--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -877,6 +877,15 @@ export function AgentTerminal({
         { id: 'copy', label: t('Copy'), disabled: !terminal?.hasSelection() },
         { id: 'paste', label: t('Paste') },
         { id: 'selectAll', label: t('Select all') },
+        ...(tmuxSessionNameRef.current
+          ? [
+              { id: 'separator-2', label: '', type: 'separator' as const },
+              {
+                id: 'copyTmuxRestore',
+                label: t('Copy tmux restore command'),
+              },
+            ]
+          : []),
       ];
 
       const selectedId = await window.electronAPI.contextMenu.show(menuItems);
@@ -909,6 +918,12 @@ export function AgentTerminal({
           break;
         case 'selectAll':
           terminal?.selectAll();
+          break;
+        case 'copyTmuxRestore':
+          if (tmuxSessionNameRef.current) {
+            const restoreCmd = `tmux -L enso attach-session -t ${tmuxSessionNameRef.current}`;
+            navigator.clipboard.writeText(restoreCmd);
+          }
           break;
       }
     },

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -152,6 +152,7 @@ export const zhTranslations: Record<string, string> = {
   'Copy Commit ID': '复制 Commit ID',
   'Copy Path': '复制路径',
   'Copy Relative Path': '复制相对路径',
+  'Copy tmux restore command': '复制 tmux 恢复命令',
   'Revert commit': 'Revert 提交',
   'Reset to commit': 'Reset 到此提交',
   'Select reset mode for commit': '选择 Reset 模式',


### PR DESCRIPTION
## Summary
- 当终端存在 tmux session 时，在右键菜单中新增"复制 tmux 恢复命令"选项
- 方便用户快速复制 `tmux -L enso attach-session -t <session>` 命令

## Test plan
- [ ] 在终端无 tmux session 时，右键菜单不显示"复制 tmux 恢复命令"
- [ ] 在终端有 tmux session 时，右键菜单显示"复制 tmux 恢复命令"
- [ ] 点击后命令已复制到剪贴板

🤖 Generated with [Claude Code](https://claude.com/claude-code)