### PR TITLE
fix(sidebar): 修复 Windows 下隐藏仓库设置因存储 key 格式不一致而失效的问题

### DIFF
--- a/src/renderer/components/layout/RepositorySidebar.tsx
+++ b/src/renderer/components/layout/RepositorySidebar.tsx
@@ -58,6 +58,7 @@ import { useWorktreeActivityStore } from '@/stores/worktreeActivity';
 import { RunningProjectsPopover } from './RunningProjectsPopover';
 
 interface Repository {
+  id: string;
   name: string;
   path: string;
   groupId?: string;
@@ -82,7 +83,7 @@ interface RepositorySidebarProps {
   onCreateGroup: (name: string, emoji: string, color: string) => RepositoryGroup;
   onUpdateGroup: (groupId: string, name: string, emoji: string, color: string) => void;
   onDeleteGroup: (groupId: string) => void;
-  onMoveToGroup?: (repoPath: string, groupId: string | null) => void;
+  onMoveToGroup?: (repoId: string, groupId: string | null) => void;
   onSwitchTab?: (tab: TabId) => void;
   onSwitchWorktreeByPath?: (path: string) => Promise<void> | void;
   /** Whether a file is being dragged over the sidebar (from App.tsx global handler) */
@@ -705,7 +706,7 @@ export function RepositorySidebar({
                 currentGroupId={menuRepo?.groupId}
                 onMove={(groupId) => {
                   if (menuRepo) {
-                    onMoveToGroup(menuRepo.path, groupId);
+                    onMoveToGroup(menuRepo.id, groupId);
                   }
                 }}
                 onClose={() => setMenuOpen(false)}

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -42,6 +42,7 @@ import {
   getStoredGroupCollapsedState,
   getStoredRepositorySettings,
   normalizePath,
+  normalizeWorkspacePathKey,
   type RepositorySettings,
   saveGroupCollapsedState,
   saveRepositorySettings,
@@ -626,7 +627,8 @@ export function TreeSidebar({
 
     // Filter hidden repositories using cached settings
     filtered = filtered.filter((repo) => {
-      const settings = repoSettingsMap[normalizePath(repo.path)] || DEFAULT_REPOSITORY_SETTINGS;
+      const settings =
+        repoSettingsMap[normalizeWorkspacePathKey(repo.path)] || DEFAULT_REPOSITORY_SETTINGS;
       return !settings.hidden;
     });
 
@@ -676,7 +678,8 @@ export function TreeSidebar({
 
     // Use the same hidden filter as filteredRepos
     const visibleRepos = repositories.filter((repo) => {
-      const settings = repoSettingsMap[normalizePath(repo.path)] || DEFAULT_REPOSITORY_SETTINGS;
+      const settings =
+        repoSettingsMap[normalizeWorkspacePathKey(repo.path)] || DEFAULT_REPOSITORY_SETTINGS;
       return !settings.hidden;
     });
 


### PR DESCRIPTION
## Summary

- `saveRepositorySettings` 使用 `normalizeWorkspacePathKey`（将 `\` 转为 `/`），但 `TreeSidebar` 过滤隐藏仓库时使用 `normalizePath`（保留 `\`），导致 Windows 上存储 key 和查找 key 格式不一致，隐藏仓库设置永远匹配不上
- 将 `TreeSidebar.tsx` 中两处 `normalizePath` 改为 `normalizeWorkspacePathKey`，统一 key 格式

## Root Cause

v0.2.39 的 remote workspace 重构 (#380) 将 `getRepositorySettings` / `saveRepositorySettings` 的 key 规范化从 `normalizePath` 改为 `normalizeWorkspacePathKey`，但 `TreeSidebar` 中的过滤逻辑未同步更新：

```
保存 key: normalizeWorkspacePathKey("D:\code\foo") → "d:/code/foo"
查找 key: normalizePath("D:\code\foo")             → "d:\code\foo"  ← 不匹配
```

## Test plan

- [ ] Windows 环境下，开启分组 → 右键隐藏仓库 → 验证仓库从侧边栏消失
- [ ] 通过 RepositorySettingsDialog 隐藏仓库 → 关闭对话框 → 验证仓库隐藏生效
- [ ] macOS / Linux 下隐藏仓库功能不受影响（这些平台 key 格式本身一致）