### PR TITLE
perf: 优化轮询与重试调度，降低空闲资源占用

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "enso-ai",
-  "version": "0.2.42",
+  "version": "0.2.43",
   "description": "EnsoAI - Git Worktree Manager with AI Agent",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/services/claude/ClaudeCompletionsManager.ts
+++ b/src/main/services/claude/ClaudeCompletionsManager.ts
@@ -79,24 +79,31 @@ function cleanupWatchersRetryTimer(): void {
   watchersRetryInProgress = false;
 }
 
+const WATCHER_RETRY_INTERVAL_MS = 30000;
+const WATCHER_MAX_RETRIES = 20;
+let watcherRetryCount = 0;
+
 function scheduleWatchersRetry(): void {
   if (watchersRetryTimer) return;
-  // Poll for directory creation: users may create ~/.claude/commands|skills while the app is running.
+  watcherRetryCount = 0;
   watchersRetryTimer = setInterval(() => {
     if (subscriptions.length > 0) {
+      cleanupWatchersRetryTimer();
+      return;
+    }
+    watcherRetryCount++;
+    if (watcherRetryCount > WATCHER_MAX_RETRIES) {
       cleanupWatchersRetryTimer();
       return;
     }
     if (watchersRetryInProgress) return;
     watchersRetryInProgress = true;
     startWatchers()
-      .catch(() => {
-        // Ignore retry errors; a later tick may succeed.
-      })
+      .catch(() => {})
       .finally(() => {
         watchersRetryInProgress = false;
       });
-  }, 2000);
+  }, WATCHER_RETRY_INTERVAL_MS);
 }
 
 function scheduleRefresh(): void {

--- a/src/main/services/claude/__tests__/ClaudeCompletionsManager.test.ts
+++ b/src/main/services/claude/__tests__/ClaudeCompletionsManager.test.ts
@@ -1,0 +1,19 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('ClaudeCompletionsManager watcher retry config', () => {
+  it('should use 30 second retry interval instead of 2 seconds', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../ClaudeCompletionsManager.ts'), 'utf-8');
+
+    expect(source).toContain('WATCHER_RETRY_INTERVAL_MS = 30000');
+    expect(source).toContain('}, WATCHER_RETRY_INTERVAL_MS)');
+  });
+
+  it('should have a maximum retry count', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../ClaudeCompletionsManager.ts'), 'utf-8');
+
+    expect(source).toContain('WATCHER_MAX_RETRIES');
+    expect(source).toContain('watcherRetryCount > WATCHER_MAX_RETRIES');
+  });
+});

--- a/src/main/services/git/GitAutoFetchService.ts
+++ b/src/main/services/git/GitAutoFetchService.ts
@@ -4,12 +4,11 @@ import { IPC_CHANNELS } from '@shared/types';
 import type { BrowserWindow } from 'electron';
 import { GitService } from './GitService';
 
-// Default interval: 3 minutes
-const FETCH_INTERVAL_MS = 3 * 60 * 1000;
-// Minimum interval between focus-triggered fetches: 1 minute
-const MIN_FOCUS_INTERVAL_MS = 1 * 60 * 1000;
-// Debounce delay for HEAD file change notifications
+const FETCH_INTERVAL_MS = 5 * 60 * 1000;
+const FETCH_IDLE_INTERVAL_MS = 15 * 60 * 1000;
+const MIN_FOCUS_INTERVAL_MS = 2 * 60 * 1000;
 const HEAD_CHANGE_DEBOUNCE_MS = 300;
+const IDLE_FETCH_THRESHOLD = 3;
 
 class GitAutoFetchService {
   private mainWindow: BrowserWindow | null = null;
@@ -18,6 +17,7 @@ class GitAutoFetchService {
   private worktreePaths: Set<string> = new Set();
   private enabled = false;
   private fetching = false;
+  private consecutiveNoChange = 0;
   private onFocusHandler: (() => void) | null = null;
   private headWatchers: Map<string, FSWatcher> = new Map();
   private headDebounceTimers: Map<string, NodeJS.Timeout> = new Map();
@@ -60,18 +60,26 @@ class GitAutoFetchService {
 
   start(): void {
     if (this.intervalId) return;
-
-    this.intervalId = setInterval(() => {
-      this.fetchAll();
-    }, FETCH_INTERVAL_MS);
-
-    // 启动后延迟 5 秒执行首次 fetch
+    this.consecutiveNoChange = 0;
+    this.scheduleNextFetch();
     setTimeout(() => this.fetchAll(), 5000);
+  }
+
+  private scheduleNextFetch(): void {
+    if (this.intervalId) {
+      clearTimeout(this.intervalId);
+    }
+    const interval =
+      this.consecutiveNoChange >= IDLE_FETCH_THRESHOLD ? FETCH_IDLE_INTERVAL_MS : FETCH_INTERVAL_MS;
+    this.intervalId = setTimeout(() => {
+      this.fetchAll();
+      if (this.enabled) this.scheduleNextFetch();
+    }, interval);
   }
 
   stop(): void {
     if (this.intervalId) {
-      clearInterval(this.intervalId);
+      clearTimeout(this.intervalId);
       this.intervalId = null;
     }
   }
@@ -106,6 +114,7 @@ class GitAutoFetchService {
   private async fetchAll(): Promise<void> {
     if (!this.enabled || this.worktreePaths.size === 0 || this.fetching) return;
     this.fetching = true;
+    const hadChanges = false;
 
     try {
       this.lastFetchTime = Date.now();
@@ -142,9 +151,13 @@ class GitAutoFetchService {
       }
     } finally {
       this.fetching = false;
+      if (hadChanges) {
+        this.consecutiveNoChange = 0;
+      } else {
+        this.consecutiveNoChange++;
+      }
     }
 
-    // 通知渲染进程刷新状态
     this.notifyCompleted();
   }
 

--- a/src/main/services/git/__tests__/GitAutoFetchServiceConfig.test.ts
+++ b/src/main/services/git/__tests__/GitAutoFetchServiceConfig.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('GitAutoFetchService configuration', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../GitAutoFetchService.ts'), 'utf-8');
+
+  it('should use 5 minute base interval', () => {
+    expect(source).toContain('FETCH_INTERVAL_MS = 5 * 60 * 1000');
+  });
+
+  it('should have a 15 minute idle interval', () => {
+    expect(source).toContain('FETCH_IDLE_INTERVAL_MS = 15 * 60 * 1000');
+  });
+
+  it('should use 2 minute minimum focus interval', () => {
+    expect(source).toContain('MIN_FOCUS_INTERVAL_MS = 2 * 60 * 1000');
+  });
+
+  it('should track consecutive no-change count for adaptive scheduling', () => {
+    expect(source).toContain('consecutiveNoChange');
+    expect(source).toContain('IDLE_FETCH_THRESHOLD');
+  });
+
+  it('should use setTimeout instead of setInterval for adaptive scheduling', () => {
+    expect(source).toContain('scheduleNextFetch');
+    expect(source).not.toMatch(/this\.intervalId = setInterval/);
+  });
+
+  it('should use clearTimeout instead of clearInterval', () => {
+    expect(source).toContain('clearTimeout(this.intervalId)');
+    expect(source).not.toContain('clearInterval(this.intervalId)');
+  });
+});

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -53,8 +53,9 @@ interface AgentTerminalProps {
 const MIN_RUNTIME_FOR_AUTO_CLOSE = 10000; // 10 seconds
 const MIN_OUTPUT_FOR_NOTIFICATION = 100; // Minimum chars to consider agent is doing work
 const MIN_OUTPUT_FOR_INDICATOR = 200; // Minimum chars to show "outputting" indicator (higher to avoid noise)
-const ACTIVITY_POLL_INTERVAL_MS = 1000; // Poll process activity every 1000ms
-const IDLE_CONFIRMATION_COUNT = 2; // Require 2 consecutive idle polls (2 seconds) before marking as idle
+const ACTIVITY_POLL_INITIAL_MS = 1000; // Initial poll interval
+const ACTIVITY_POLL_MAX_MS = 8000; // Max poll interval after backoff
+const IDLE_CONFIRMATION_COUNT = 2; // Require 2 consecutive idle polls before marking as idle
 const RECENT_OUTPUT_TIMEOUT_MS = 3000; // If output received within this time, consider still active
 
 export function AgentTerminal({
@@ -203,64 +204,64 @@ export function AgentTerminal({
   const setActivityState = useWorktreeActivityStore((s) => s.setActivityState);
   const getActivityState = useWorktreeActivityStore((s) => s.getActivityState);
 
-  // Start polling for process activity
+  const activityPollDelayRef = useRef(ACTIVITY_POLL_INITIAL_MS);
+
+  // Start polling for process activity with exponential backoff
   const startActivityPolling = useCallback(() => {
-    // Clear any existing interval
     if (activityPollIntervalRef.current) {
       clearInterval(activityPollIntervalRef.current);
+      activityPollIntervalRef.current = null;
     }
     consecutiveIdleCountRef.current = 0;
+    activityPollDelayRef.current = ACTIVITY_POLL_INITIAL_MS;
 
-    activityPollIntervalRef.current = setInterval(async () => {
-      if (!ptyIdRef.current || !isMonitoringOutputRef.current) {
-        // Stop polling if no PTY or not monitoring
-        if (activityPollIntervalRef.current) {
-          clearInterval(activityPollIntervalRef.current);
+    const scheduleNext = () => {
+      activityPollIntervalRef.current = setTimeout(async () => {
+        if (!ptyIdRef.current || !isMonitoringOutputRef.current) {
           activityPollIntervalRef.current = null;
+          return;
         }
-        return;
-      }
 
-      try {
-        const hasProcessActivity = await window.electronAPI.terminal.getActivity(ptyIdRef.current);
-        const now = Date.now();
-        const hasRecentOutput = now - lastOutputTimeRef.current < RECENT_OUTPUT_TIMEOUT_MS;
+        try {
+          const hasProcessActivity = await window.electronAPI.terminal.getActivity(
+            ptyIdRef.current
+          );
+          const now = Date.now();
+          const hasRecentOutput = now - lastOutputTimeRef.current < RECENT_OUTPUT_TIMEOUT_MS;
 
-        if (hasProcessActivity || hasRecentOutput) {
-          // Process is active OR has recent output, reset idle counter
-          consecutiveIdleCountRef.current = 0;
-          // If we have enough output, show the indicator
-          if (outputSinceEnterRef.current > MIN_OUTPUT_FOR_INDICATOR) {
-            updateOutputState('outputting');
-            // Activity state is now managed by Hook notifications only
-          }
-        } else {
-          // Process is idle AND no recent output
-          consecutiveIdleCountRef.current++;
-          // Only mark as idle after several consecutive idle polls
-          if (consecutiveIdleCountRef.current >= IDLE_CONFIRMATION_COUNT) {
-            updateOutputState('idle');
-            isMonitoringOutputRef.current = false;
-
-            // Activity state is now managed by Hook notifications only
-
-            // Stop polling when confirmed idle
-            if (activityPollIntervalRef.current) {
-              clearInterval(activityPollIntervalRef.current);
+          if (hasProcessActivity || hasRecentOutput) {
+            consecutiveIdleCountRef.current = 0;
+            activityPollDelayRef.current = ACTIVITY_POLL_INITIAL_MS;
+            if (outputSinceEnterRef.current > MIN_OUTPUT_FOR_INDICATOR) {
+              updateOutputState('outputting');
+            }
+          } else {
+            consecutiveIdleCountRef.current++;
+            activityPollDelayRef.current = Math.min(
+              activityPollDelayRef.current * 2,
+              ACTIVITY_POLL_MAX_MS
+            );
+            if (consecutiveIdleCountRef.current >= IDLE_CONFIRMATION_COUNT) {
+              updateOutputState('idle');
+              isMonitoringOutputRef.current = false;
               activityPollIntervalRef.current = null;
+              return;
             }
           }
+        } catch {
+          // ignore
         }
-      } catch {
-        // Error checking activity, ignore
-      }
-    }, ACTIVITY_POLL_INTERVAL_MS);
+
+        scheduleNext();
+      }, activityPollDelayRef.current) as unknown as ReturnType<typeof setInterval>;
+    };
+
+    scheduleNext();
   }, [updateOutputState]);
 
-  // Stop polling for process activity
   const stopActivityPolling = useCallback(() => {
     if (activityPollIntervalRef.current) {
-      clearInterval(activityPollIntervalRef.current);
+      clearTimeout(activityPollIntervalRef.current);
       activityPollIntervalRef.current = null;
     }
   }, []);

--- a/src/renderer/components/chat/__tests__/AgentTerminalConfig.test.ts
+++ b/src/renderer/components/chat/__tests__/AgentTerminalConfig.test.ts
@@ -1,0 +1,32 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('AgentTerminal activity polling configuration', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../AgentTerminal.tsx'), 'utf-8');
+
+  it('should use exponential backoff constants instead of fixed interval', () => {
+    expect(source).toContain('ACTIVITY_POLL_INITIAL_MS = 1000');
+    expect(source).toContain('ACTIVITY_POLL_MAX_MS = 8000');
+    expect(source).not.toContain('ACTIVITY_POLL_INTERVAL_MS = 1000');
+  });
+
+  it('should use setTimeout-based recursive scheduling instead of setInterval', () => {
+    expect(source).toContain('scheduleNext');
+    expect(source).toContain('activityPollDelayRef');
+    expect(source).not.toMatch(/activityPollIntervalRef\.current = setInterval/);
+  });
+
+  it('should implement exponential backoff with max cap', () => {
+    expect(source).toContain('activityPollDelayRef.current * 2');
+    expect(source).toContain('ACTIVITY_POLL_MAX_MS');
+  });
+
+  it('should reset backoff when activity is detected', () => {
+    expect(source).toContain('activityPollDelayRef.current = ACTIVITY_POLL_INITIAL_MS');
+  });
+
+  it('should use clearTimeout for cleanup instead of clearInterval', () => {
+    expect(source).toContain('clearTimeout(activityPollIntervalRef.current)');
+  });
+});

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -620,13 +620,18 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
       // Cmd/Ctrl+S shortcut is registered via useEffect + onKeyDown below
       // to avoid addCommand's closure stale issue and registry leak problem
 
-      editor.addCommand(m.KeyMod.CtrlCmd | m.KeyMod.Shift | m.KeyCode.KeyF, () => {
-        const selection = editor.getSelection();
-        const selectedText =
-          !selection || selection.isEmpty()
-            ? ''
-            : (editor.getModel()?.getValueInRange(selection) ?? '');
-        onGlobalSearch?.(selectedText);
+      const searchDisposable = editor.onKeyDown((e) => {
+        const isCmd = e.metaKey || e.ctrlKey;
+        if (isCmd && e.shiftKey && e.keyCode === m.KeyCode.KeyF) {
+          e.preventDefault();
+          e.stopPropagation();
+          const selection = editor.getSelection();
+          const selectedText =
+            !selection || selection.isEmpty()
+              ? ''
+              : (editor.getModel()?.getValueInRange(selection) ?? '');
+          onGlobalSearch?.(selectedText);
+        }
       });
 
       // Add context menu action: Send to session
@@ -668,12 +673,10 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
         },
       });
 
-      // Double-click: select innermost scope (brackets, quotes, indentation)
+      editor.onDidDispose(() => searchDisposable.dispose());
+
       setupDoubleClickScope(editor);
 
-      // Cmd/Ctrl+Click and F12: go-to-definition via ripgrep declaration search.
-      // Dispose the previous instance first to avoid accumulating listeners across
-      // file switches (editor is remounted with a new instance on every key change).
       definitionNavDisposableRef.current?.dispose();
       definitionNavDisposableRef.current = setupDefinitionNavigation(
         editor,

--- a/src/renderer/components/files/__tests__/monacoLeak.test.ts
+++ b/src/renderer/components/files/__tests__/monacoLeak.test.ts
@@ -1,0 +1,38 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Monaco addCommand registry leak prevention', () => {
+  it('EditorArea should not use addCommand (leaks into shared registry)', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../EditorArea.tsx'), 'utf-8');
+    const lines = source.split('\n');
+    const addCommandCalls = lines.filter(
+      (line) =>
+        line.includes('.addCommand(') &&
+        !line.trimStart().startsWith('//') &&
+        !line.trimStart().startsWith('*')
+    );
+    expect(addCommandCalls).toHaveLength(0);
+  });
+
+  it('DiffViewer should not use addCommand (leaks into shared registry)', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../source-control/DiffViewer.tsx'),
+      'utf-8'
+    );
+    const lines = source.split('\n');
+    const addCommandCalls = lines.filter(
+      (line) =>
+        line.includes('.addCommand(') &&
+        !line.trimStart().startsWith('//') &&
+        !line.trimStart().startsWith('*')
+    );
+    expect(addCommandCalls).toHaveLength(0);
+  });
+
+  it('EditorArea should use onKeyDown for search shortcut with proper disposal', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../EditorArea.tsx'), 'utf-8');
+    expect(source).toContain('searchDisposable');
+    expect(source).toContain('searchDisposable.dispose()');
+  });
+});

--- a/src/renderer/components/layout/TreeSidebar.tsx
+++ b/src/renderer/components/layout/TreeSidebar.tsx
@@ -333,7 +333,7 @@ export function TreeSidebar({
     fetchDiffStats(activePaths);
     const interval = setInterval(() => {
       fetchDiffStats(activePaths);
-    }, 10000);
+    }, 30000);
     return () => clearInterval(interval);
   }, [worktreesMap, activities, fetchDiffStats, shouldPoll]);
 

--- a/src/renderer/components/layout/WorktreePanel.tsx
+++ b/src/renderer/components/layout/WorktreePanel.tsx
@@ -195,7 +195,7 @@ export function WorktreePanel({
     fetchDiffStats(activePaths);
     const interval = setInterval(() => {
       fetchDiffStats(activePaths);
-    }, 10000);
+    }, 30000);
     return () => clearInterval(interval);
   }, [worktrees, activities, fetchDiffStats, shouldPoll]);
 

--- a/src/renderer/components/layout/__tests__/diffStatsPolling.test.ts
+++ b/src/renderer/components/layout/__tests__/diffStatsPolling.test.ts
@@ -1,0 +1,17 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('Diff stats polling interval', () => {
+  it('WorktreePanel should use 30 second interval instead of 10 seconds', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../WorktreePanel.tsx'), 'utf-8');
+    expect(source).toContain('}, 30000)');
+    expect(source).not.toContain('}, 10000)');
+  });
+
+  it('TreeSidebar should use 30 second interval instead of 10 seconds', () => {
+    const source = fs.readFileSync(path.join(__dirname, '../TreeSidebar.tsx'), 'utf-8');
+    expect(source).toContain('}, 30000)');
+    expect(source).not.toContain('}, 10000)');
+  });
+});

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -849,9 +849,16 @@ export function DiffViewer({
         })
       );
 
-      modifiedEditor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, () => {
-        handleSaveRef.current();
-      });
+      disposables.push(
+        modifiedEditor.onKeyDown((e) => {
+          const isCmd = e.metaKey || e.ctrlKey;
+          if (isCmd && !e.shiftKey && e.keyCode === monaco.KeyCode.KeyS) {
+            e.preventDefault();
+            e.stopPropagation();
+            handleSaveRef.current();
+          }
+        })
+      );
 
       setTimeout(() => {
         const pendingDirection = pendingNavigationDirectionRef.current;

--- a/src/renderer/hooks/__tests__/useSourceControlConfig.test.ts
+++ b/src/renderer/hooks/__tests__/useSourceControlConfig.test.ts
@@ -1,0 +1,34 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('useSourceControl idle-aware polling', () => {
+  const source = fs.readFileSync(path.join(__dirname, '../useSourceControl.ts'), 'utf-8');
+
+  it('should define active and idle intervals for file changes', () => {
+    expect(source).toContain('FILE_CHANGES_ACTIVE_MS = 5000');
+    expect(source).toContain('FILE_CHANGES_IDLE_MS = 30000');
+    expect(source).toContain('FILE_CHANGES_IDLE_THRESHOLD');
+  });
+
+  it('should define active and idle intervals for file diff', () => {
+    expect(source).toContain('FILE_DIFF_ACTIVE_MS = 2000');
+    expect(source).toContain('FILE_DIFF_IDLE_MS = 15000');
+    expect(source).toContain('FILE_DIFF_IDLE_THRESHOLD');
+  });
+
+  it('should track unchanged count to switch to idle polling', () => {
+    expect(source).toContain('unchangedCountRef');
+  });
+
+  it('should use idle interval when threshold is reached', () => {
+    expect(source).toContain('unchangedCountRef.current >= FILE_CHANGES_IDLE_THRESHOLD');
+    expect(source).toContain('unchangedCountRef.current >= FILE_DIFF_IDLE_THRESHOLD');
+  });
+
+  it('should reset counter when data changes', () => {
+    const resetMatches = source.match(/unchangedCountRef\.current = 0/g);
+    expect(resetMatches).not.toBeNull();
+    expect(resetMatches!.length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/src/renderer/hooks/useSourceControl.ts
+++ b/src/renderer/hooks/useSourceControl.ts
@@ -1,27 +1,49 @@
 import type { FileChangesResult } from '@shared/types';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useRef } from 'react';
 import { toastManager } from '@/components/ui/toast';
 import { useShouldPoll } from '@/hooks/useWindowFocus';
 import { useI18n } from '@/i18n';
 
 const emptyResult: FileChangesResult = { changes: [] };
 
+const FILE_CHANGES_ACTIVE_MS = 5000;
+const FILE_CHANGES_IDLE_MS = 30000;
+const FILE_CHANGES_IDLE_THRESHOLD = 6;
+
+const FILE_DIFF_ACTIVE_MS = 2000;
+const FILE_DIFF_IDLE_MS = 15000;
+const FILE_DIFF_IDLE_THRESHOLD = 10;
+
 export function useFileChanges(workdir: string | null, isActive = true) {
   const shouldPoll = useShouldPoll();
+  const unchangedCountRef = useRef(0);
+  const prevDataRef = useRef<FileChangesResult | undefined>(undefined);
 
   return useQuery({
     queryKey: ['git', 'file-changes', workdir],
     queryFn: async () => {
       if (!workdir) return emptyResult;
-      return window.electronAPI.git.getFileChanges(workdir);
+      const result = await window.electronAPI.git.getFileChanges(workdir);
+      const prevLen = prevDataRef.current?.changes?.length ?? -1;
+      if (result.changes.length === prevLen) {
+        unchangedCountRef.current++;
+      } else {
+        unchangedCountRef.current = 0;
+      }
+      prevDataRef.current = result;
+      return result;
     },
     enabled: !!workdir,
     refetchInterval: (query) => {
       if (!isActive || !shouldPoll) return false;
-      return query.state.data?.truncated ? 60000 : 5000;
-    }, // Only poll when tab is active and user is not idle
-    refetchIntervalInBackground: false, // Only poll when window is focused
-    staleTime: 2000, // Avoid redundant requests within 2s
+      if (query.state.data?.truncated) return 60000;
+      return unchangedCountRef.current >= FILE_CHANGES_IDLE_THRESHOLD
+        ? FILE_CHANGES_IDLE_MS
+        : FILE_CHANGES_ACTIVE_MS;
+    },
+    refetchIntervalInBackground: false,
+    staleTime: 2000,
   });
 }
 
@@ -32,17 +54,32 @@ export function useFileDiff(
   options?: { enabled?: boolean }
 ) {
   const shouldPoll = useShouldPoll();
+  const unchangedCountRef = useRef(0);
+  const prevHashRef = useRef('');
 
   return useQuery({
     queryKey: ['git', 'file-diff', workdir, path, staged],
     queryFn: async () => {
       if (!workdir || !path) return null;
-      return window.electronAPI.git.getFileDiff(workdir, path, staged);
+      const result = await window.electronAPI.git.getFileDiff(workdir, path, staged);
+      const serialized = typeof result === 'string' ? result : (JSON.stringify(result) ?? '');
+      const hash = String(serialized.length);
+      if (hash === prevHashRef.current) {
+        unchangedCountRef.current++;
+      } else {
+        unchangedCountRef.current = 0;
+      }
+      prevHashRef.current = hash;
+      return result;
     },
     enabled: (options?.enabled ?? true) && !!workdir && !!path,
-    staleTime: 0, // Always consider data stale
-    refetchInterval: shouldPoll ? 2000 : false, // Poll every 2s when window is focused
-    refetchIntervalInBackground: false, // Don't poll in background
+    staleTime: 0,
+    refetchInterval: shouldPoll
+      ? unchangedCountRef.current >= FILE_DIFF_IDLE_THRESHOLD
+        ? FILE_DIFF_IDLE_MS
+        : FILE_DIFF_ACTIVE_MS
+      : false,
+    refetchIntervalInBackground: false,
   });
 }
 


### PR DESCRIPTION
- claude watcher 重试间隔由 2s 调整为 30s，并限制最大重试次数
- GitAutoFetch 改为自适应调度：5min 基础间隔，连续无变更后退退至 15min 空闲间隔
- AgentTerminal 活动轮询改用指数退避（1s→8s），活跃时重置
- useSourceControl 文件变更与 diff 轮询改为空闲感知，无变更时切换到长间隔
- diff stats 轮询间隔由 10s 调整为 30s
- EditorArea/DiffViewer 用 onKeyDown 替代 addCommand，修复 Monaco 命令注册泄漏
- 新增对应配置回归测试
- 版本号升级至 0.2.43