### PR TITLE
feat(todo): 将 Agent Tasks 与待办功能开关绑定

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -184,6 +184,34 @@ export default function App() {
     });
   }, []);
 
+  // Bind Agent Tasks panel to Todo feature: hide panel when Todo is disabled
+  const todoEnabled = useSettingsStore((s) => s.todoEnabled);
+  useEffect(() => {
+    if (todoEnabled) return;
+
+    if (isAgentTasksPanelOpen) {
+      void window.electronAPI.agentTaskPanel.toggle();
+    }
+
+    // Leave Todo tab when the feature is turned off
+    if (activeTab === 'todo') {
+      setActiveTab('chat');
+      if (activeWorktree?.path) {
+        setWorktreeTabMap((prev) => ({
+          ...prev,
+          [activeWorktree.path]: 'chat',
+        }));
+      }
+    }
+  }, [
+    todoEnabled,
+    isAgentTasksPanelOpen,
+    activeTab,
+    activeWorktree?.path,
+    setActiveTab,
+    setWorktreeTabMap,
+  ]);
+
   // Respond to snapshot requests from agent task panel window
   useEffect(() => {
     return window.electronAPI.agentTaskPanel.onGetSnapshot(() => {

--- a/src/renderer/components/layout/MainContent.tsx
+++ b/src/renderer/components/layout/MainContent.tsx
@@ -411,25 +411,27 @@ export function MainContent({
           >
             <Settings className="h-4 w-4" />
           </button>
-          {/* Agent Tasks button */}
-          <button
-            type="button"
-            className={cn(
-              'relative flex h-8 w-8 items-center justify-center rounded-md transition-colors',
-              isAgentTasksPanelOpen
-                ? 'bg-accent text-accent-foreground'
-                : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
-            )}
-            onClick={onOpenAgentTasks}
-            title={t('Agent Tasks')}
-          >
-            <ListTodo className="h-4 w-4" />
-            {activeTaskCount > 0 && (
-              <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
-                {activeTaskCount}
-              </span>
-            )}
-          </button>
+          {/* Agent Tasks button - bound to Todo feature flag */}
+          {todoEnabled && onOpenAgentTasks && (
+            <button
+              type="button"
+              className={cn(
+                'relative flex h-8 w-8 items-center justify-center rounded-md transition-colors',
+                isAgentTasksPanelOpen
+                  ? 'bg-accent text-accent-foreground'
+                  : 'text-muted-foreground hover:bg-accent/50 hover:text-foreground'
+              )}
+              onClick={onOpenAgentTasks}
+              title={t('Agent Tasks')}
+            >
+              <ListTodo className="h-4 w-4" />
+              {activeTaskCount > 0 && (
+                <span className="absolute -right-1 -top-1 flex h-4 min-w-4 items-center justify-center rounded-full bg-primary px-1 text-[10px] font-medium text-primary-foreground">
+                  {activeTaskCount}
+                </span>
+              )}
+            </button>
+          )}
           {activeSessionId && (
             <Button
               variant="outline"

--- a/src/renderer/components/settings/GeneralSettings.tsx
+++ b/src/renderer/components/settings/GeneralSettings.tsx
@@ -596,7 +596,9 @@ export function GeneralSettings() {
       <div className="grid grid-cols-[100px_1fr] items-center gap-4">
         <span className="text-sm font-medium">{t('Todo')}</span>
         <div className="flex items-center justify-between">
-          <p className="text-sm text-muted-foreground">{t('Enable Todo kanban board tab')}</p>
+          <p className="text-sm text-muted-foreground">
+            {t('Enable Todo kanban board tab and Agent Tasks panel')}
+          </p>
           <Switch checked={todoEnabled} onCheckedChange={setTodoEnabled} />
         </div>
       </div>

--- a/src/shared/i18n.ts
+++ b/src/shared/i18n.ts
@@ -792,6 +792,7 @@ export const zhTranslations: Record<string, string> = {
   'Enable Quick Terminal': '启用快捷终端',
   'Show floating terminal button for quick access': '显示浮动终端按钮以便快速访问',
   'Enable Todo kanban board tab': '启用待办看板标签页',
+  'Enable Todo kanban board tab and Agent Tasks panel': '启用待办看板标签页与 Agent 任务面板',
   'Hide Groups': '隐藏分组',
   'Hide group management panel and show all repositories': '隐藏分组管理面板，显示所有仓库',
   'Quick Open': '快捷打开',


### PR DESCRIPTION
## Summary
- 用 `todoEnabled` 同时控制 Todo 看板 tab 和 Agent Tasks 入口
- 关闭 Todo 时自动关闭已打开的 Agent Tasks 独立窗，并离开 Todo tab
- 更新设置文案，明确 Todo 开关覆盖看板与 Agent 任务面板

## Why
心电图负责项目导航；待办 + Agent 任务应作为同一套工作流能力一起出现/消失。避免 Todo 关闭后右侧 Agent Tasks 仍独立存在。

## Test plan
- [ ] 开启 Todo：导航栏出现 Todo tab，右侧出现 Agent Tasks 按钮
- [ ] 打开 Agent Tasks 独立窗后关闭 Todo：按钮消失，独立窗关闭
- [ ] 停留在 Todo tab 时关闭 Todo：自动切到 chat
- [ ] 心电图入口不受影响
- [ ] 中英文设置文案显示正常