### PR TITLE
feat(agent): 添加 OMP 作为内置 Agent

### DIFF
--- a/src/main/services/agent/AgentRegistry.ts
+++ b/src/main/services/agent/AgentRegistry.ts
@@ -57,6 +57,20 @@ export const BUILTIN_AGENTS: AgentMetadata[] = [
       fileWrite: true,
     },
   },
+  {
+    id: 'omp',
+    name: 'OMP',
+    description: 'Oh My Pi Coding Agent CLI',
+    icon: 'omp',
+    binary: 'omp',
+    capabilities: {
+      chat: true,
+      codeEdit: true,
+      terminal: true,
+      fileRead: true,
+      fileWrite: true,
+    },
+  },
 ];
 
 export class AgentRegistry {

--- a/src/main/services/cli/CliDetector.ts
+++ b/src/main/services/cli/CliDetector.ts
@@ -79,6 +79,13 @@ const BUILTIN_AGENT_CONFIGS: BuiltinAgentConfig[] = [
     versionFlag: '--version',
     versionRegex: /(\d+\.\d+\.\d+)/,
   },
+  {
+    id: 'omp',
+    name: 'OMP',
+    command: 'omp',
+    versionFlag: '--version',
+    versionRegex: /(\d+\.\d+\.\d+)/,
+  },
 ];
 
 class CliDetector {

--- a/src/main/services/cli/__tests__/BuiltinAgents.test.ts
+++ b/src/main/services/cli/__tests__/BuiltinAgents.test.ts
@@ -1,0 +1,55 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Contract: OMP is a first-class builtin agent (like pi), not a custom agent.
+ * These source-level checks keep the multi-site registry in sync.
+ */
+describe('OMP builtin agent registration', () => {
+  const root = path.join(__dirname, '../../../..');
+
+  const read = (rel: string) => fs.readFileSync(path.join(root, rel), 'utf-8');
+
+  it('includes omp in BuiltinAgentId union', () => {
+    const source = read('shared/types/cli.ts');
+    expect(source).toMatch(/export type BuiltinAgentId =[\s\S]*\|\s*'omp'/);
+  });
+
+  it('detects omp CLI with --version', () => {
+    const source = read('main/services/cli/CliDetector.ts');
+    expect(source).toContain("id: 'omp'");
+    expect(source).toContain("command: 'omp'");
+    expect(source).toContain("versionFlag: '--version'");
+  });
+
+  it('lists omp in settings builtin agent IDs and defaults', () => {
+    const types = read('renderer/stores/settings/types.ts');
+    const defaults = read('renderer/stores/settings/defaults.ts');
+    expect(types).toMatch(/BUILTIN_AGENT_IDS[\s\S]*'omp'/);
+    expect(defaults).toMatch(/omp:\s*\{\s*enabled:\s*false,\s*isDefault:\s*false\s*\}/);
+  });
+
+  it('exposes omp in settings UI constants', () => {
+    const source = read('renderer/components/settings/constants.ts');
+    expect(source).toMatch(/omp:\s*\{\s*name:\s*'OMP'/);
+    expect(source).toMatch(/BUILTIN_AGENTS[\s\S]*'omp'/);
+  });
+
+  it('maps omp display name and command in agent UIs', () => {
+    for (const rel of [
+      'renderer/components/chat/AgentPanel.tsx',
+      'renderer/components/chat/SessionBar.tsx',
+      'renderer/components/todo/useEnabledAgents.ts',
+    ]) {
+      const source = read(rel);
+      expect(source, rel).toContain("omp: { name: 'OMP', command: 'omp' }");
+    }
+  });
+
+  it('registers omp metadata in AgentRegistry', () => {
+    const source = read('main/services/agent/AgentRegistry.ts');
+    expect(source).toContain("id: 'omp'");
+    expect(source).toContain("binary: 'omp'");
+  });
+});

--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -51,6 +51,7 @@ const AGENT_INFO: Record<string, { name: string; command: string }> = {
   cursor: { name: 'Cursor', command: 'cursor-agent' },
   opencode: { name: 'OpenCode', command: 'opencode' },
   pi: { name: 'Pi', command: 'pi' },
+  omp: { name: 'OMP', command: 'omp' },
 };
 
 /**

--- a/src/renderer/components/chat/SessionBar.tsx
+++ b/src/renderer/components/chat/SessionBar.tsx
@@ -88,6 +88,7 @@ const AGENT_INFO: Record<string, { name: string; command: string }> = {
   cursor: { name: 'Cursor', command: 'cursor-agent' },
   opencode: { name: 'OpenCode', command: 'opencode' },
   pi: { name: 'Pi', command: 'pi' },
+  omp: { name: 'OMP', command: 'omp' },
 };
 
 // Session tab with glow effect

--- a/src/renderer/components/settings/constants.ts
+++ b/src/renderer/components/settings/constants.ts
@@ -38,6 +38,7 @@ export const BUILTIN_AGENT_INFO: Record<BuiltinAgentId, { name: string; descript
   cursor: { name: 'Cursor', description: 'Cursor Agent CLI' },
   opencode: { name: 'OpenCode', description: 'OpenCode AI CLI' },
   pi: { name: 'Pi', description: 'Pi Coding Agent CLI' },
+  omp: { name: 'OMP', description: 'Oh My Pi Coding Agent CLI' },
 };
 
 export const BUILTIN_AGENTS: BuiltinAgentId[] = [
@@ -49,4 +50,5 @@ export const BUILTIN_AGENTS: BuiltinAgentId[] = [
   'cursor',
   'opencode',
   'pi',
+  'omp',
 ];

--- a/src/renderer/components/todo/useEnabledAgents.ts
+++ b/src/renderer/components/todo/useEnabledAgents.ts
@@ -11,6 +11,7 @@ const AGENT_INFO: Record<string, { name: string; command: string }> = {
   cursor: { name: 'Cursor', command: 'cursor-agent' },
   opencode: { name: 'OpenCode', command: 'opencode' },
   pi: { name: 'Pi', command: 'pi' },
+  omp: { name: 'OMP', command: 'omp' },
 };
 
 export interface ResolvedAgent {

--- a/src/renderer/stores/settings/defaults.ts
+++ b/src/renderer/stores/settings/defaults.ts
@@ -351,6 +351,7 @@ export const defaultAgentSettings: AgentSettings = {
   cursor: { enabled: false, isDefault: false },
   opencode: { enabled: false, isDefault: false },
   pi: { enabled: false, isDefault: false },
+  omp: { enabled: false, isDefault: false },
 };
 
 // No default detection status - all agents need to be detected

--- a/src/renderer/stores/settings/types.ts
+++ b/src/renderer/stores/settings/types.ts
@@ -571,4 +571,5 @@ export const BUILTIN_AGENT_IDS: BuiltinAgentId[] = [
   'cursor',
   'opencode',
   'pi',
+  'omp',
 ];

--- a/src/shared/types/cli.ts
+++ b/src/shared/types/cli.ts
@@ -6,7 +6,8 @@ export type BuiltinAgentId =
   | 'auggie'
   | 'cursor'
   | 'opencode'
-  | 'pi';
+  | 'pi'
+  | 'omp';
 
 export type AgentEnvironment = 'native' | 'hapi' | 'happy';
 


### PR DESCRIPTION
## Summary
- 将 Oh My Pi (`omp`) 接入内置 Agent 列表（类型、CLI 检测、设置默认值、UI 显示名/命令、AgentRegistry）
- 默认关闭且非 default，启用后可在 Session 菜单中选择并启动 `omp`
- 补充 builtin agent 注册契约测试，防止多处列表不同步

## Test plan
- [x] `vitest run src/main/services/cli/__tests__/BuiltinAgents.test.ts` 通过
- [ ] 设置 → Agent → 刷新检测，确认 OMP 能被检测并显示版本
- [ ] 启用 OMP 后，长按 `+` 可选择 OMP
- [ ] 新建 OMP Session，终端成功启动 `omp`