### PR TITLE
fix: 修复 Codex 会话识别、Git 提交图虚节点、Windows PTY 后端与文件树 Auto Reveal

### DIFF
--- a/src/main/ipc/terminal.ts
+++ b/src/main/ipc/terminal.ts
@@ -43,7 +43,7 @@ export function registerTerminalHandlers(): void {
       ensureTerminalCleanup(event.sender);
       const ownerId = event.sender.id;
 
-      const id = await ptyManager.create(
+      const result = await ptyManager.create(
         options,
         (ptyId, data) => {
           if (!event.sender.isDestroyed()) {
@@ -62,7 +62,7 @@ export function registerTerminalHandlers(): void {
         ownerId
       );
 
-      return id;
+      return result;
     }
   );
 

--- a/src/main/services/codex/CodexHistoryService.ts
+++ b/src/main/services/codex/CodexHistoryService.ts
@@ -479,6 +479,7 @@ export async function findLatestCodexSession({
   excludeSessionIds = [],
   originator,
   matchMode = 'strict',
+  refreshOnMiss = false,
   runtime,
   wslDistro,
   sessionsRoot,
@@ -497,7 +498,7 @@ export async function findLatestCodexSession({
       ? findLatestCodexSessionFromMetadata(
           await wslScanCache.list(location.sessionsRoot, {
             newerThanMs: startedAfter,
-            ...(requireUnique ? { forceRefresh: true } : {}),
+            ...(requireUnique || refreshOnMiss ? { forceRefresh: true } : {}),
           }),
           location.cwd,
           startedAfter,
@@ -530,7 +531,7 @@ export async function findLatestCodexSession({
     if (latest) return addWslDistro(latest, location);
 
     const initialScanCompleted = await indexStore.getState('initial_scan_completed');
-    if (initialScanCompleted !== 'true') {
+    if (initialScanCompleted !== 'true' || refreshOnMiss) {
       await indexer.runRecentScan({
         maxFiles: RECENT_SCAN_MAX_FILES,
         cwd: location.cwd,
@@ -546,23 +547,23 @@ export async function findLatestCodexSession({
       });
       if (latest) return addWslDistro(latest, location);
     }
+    return null;
   } catch (error) {
     console.warn('[CodexHistoryService] 索引查询失败，使用文件扫描：', error);
     indexFailed = true;
+    return addWslDistro(
+      await findLatestCodexSessionByScan(
+        location.sessionsRoot,
+        location.cwd,
+        startedAfter,
+        excludeSessionIds,
+        queryOriginator,
+        sessionSource,
+        requireUnique
+      ),
+      location
+    );
   }
-
-  return addWslDistro(
-    await findLatestCodexSessionByScan(
-      location.sessionsRoot,
-      location.cwd,
-      startedAfter,
-      excludeSessionIds,
-      queryOriginator,
-      sessionSource,
-      requireUnique
-    ),
-    location
-  );
 }
 
 export async function getCodexHistory({

--- a/src/main/services/codex/__tests__/CodexHistoryService.test.ts
+++ b/src/main/services/codex/__tests__/CodexHistoryService.test.ts
@@ -3,6 +3,7 @@ import { mkdir, utimes, writeFile } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CodexHistoryIndexStore } from '../CodexHistoryIndexStore';
 import {
   cleanupCodexHistoryIndex,
   findLatestCodexSession,
@@ -229,6 +230,40 @@ describe('CodexHistoryService', () => {
     );
   });
 
+  it('refreshes a completed native index only when the final lookup requests it', async () => {
+    const root = path.join(os.tmpdir(), `enso-codex-final-refresh-${Date.now()}`);
+    const dbPath = path.join(root, 'index.db');
+    const cwd = 'D:/work/current';
+    const originator = 'ensoai-final-refresh';
+    const sessionId = '61996abf-bc87-7e80-9909-3a86a414f7e8';
+    await mkdir(root, { recursive: true });
+    await initializeCodexHistoryIndex({ dbPath, sessionsRoot: root });
+
+    const stateStore = new CodexHistoryIndexStore(dbPath);
+    await stateStore.initialize();
+    await stateStore.setState('initial_scan_completed', 'true');
+    await stateStore.close();
+
+    const filePath = await createSessionFile(
+      root,
+      `rollout-2026-07-17T10-00-00-${sessionId}.jsonl`,
+      JSON.stringify({ type: 'session_meta', payload: { cwd, originator, source: 'cli' } })
+    );
+
+    await expect(
+      findLatestCodexSession({ sessionsRoot: root, cwd, originator, startedAfter: 0 })
+    ).resolves.toBeNull();
+    await expect(
+      findLatestCodexSession({
+        sessionsRoot: root,
+        cwd,
+        originator,
+        startedAfter: 0,
+        refreshOnMiss: true,
+      })
+    ).resolves.toEqual({ sessionId, filePath });
+  });
+
   it('loads history by session id', async () => {
     const root = path.join(os.tmpdir(), `enso-codex-history-${Date.now()}`);
     await mkdir(root, { recursive: true });
@@ -317,6 +352,35 @@ describe('CodexHistoryService', () => {
         cwd,
         startedAfter: 0,
         matchMode: 'legacy-unique',
+      })
+    ).resolves.toEqual({ sessionId, filePath, wslDistro: 'Ubuntu' });
+  });
+
+  it('forces a fresh WSL scan for the final strict lookup', async () => {
+    const root = path.join(os.tmpdir(), `enso-codex-wsl-strict-refresh-${Date.now()}`);
+    const cwd = '/home/user/repo';
+    const originator = 'ensoai-wsl-final';
+    const sessionId = '71996abf-bc87-7e80-9909-3a86a414f7e8';
+    await mkdir(root, { recursive: true });
+    wslResolver.resolve.mockResolvedValue({ sessionsRoot: root, cwd, wslDistro: 'Ubuntu' });
+
+    await expect(
+      findLatestCodexSession({ runtime: 'wsl', cwd, originator, startedAfter: 0 })
+    ).resolves.toBeNull();
+
+    const filePath = await createSessionFile(
+      root,
+      `rollout-2026-07-17T10-00-00-${sessionId}.jsonl`,
+      JSON.stringify({ type: 'session_meta', payload: { cwd, originator, source: 'cli' } })
+    );
+
+    await expect(
+      findLatestCodexSession({
+        runtime: 'wsl',
+        cwd,
+        originator,
+        startedAfter: 0,
+        refreshOnMiss: true,
       })
     ).resolves.toEqual({ sessionId, filePath, wslDistro: 'Ubuntu' });
   });

--- a/src/main/services/terminal/PtyManager.ts
+++ b/src/main/services/terminal/PtyManager.ts
@@ -1,8 +1,8 @@
 import { execSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { homedir, release } from 'node:os';
 import { delimiter, join } from 'node:path';
-import type { TerminalCreateOptions } from '@shared/types';
+import type { TerminalCreateOptions, TerminalCreateResult } from '@shared/types';
 import type { IPty } from 'node-pty';
 import pidtree from 'pidtree';
 import pidusage from 'pidusage';
@@ -11,6 +11,7 @@ import { getProxyEnvVars } from '../proxy/ProxyConfig';
 import { detectShell, shellDetector } from './ShellDetector';
 import {
   createWindowsPtyWithFallback,
+  resolveWindowsPtyBackend,
   startWindowsPtyHelper,
   type WindowsPtyHelperAttempt,
   type WindowsPtyHelperCallbacks,
@@ -252,6 +253,7 @@ interface PendingLocalSession {
 
 export interface PtyManagerDependencies {
   platform?: NodeJS.Platform;
+  osRelease?: string;
   loadNodePty?: () => Promise<typeof import('node-pty')>;
   startWindowsPtyHelper?: (
     request: WindowsPtyHelperRequest,
@@ -393,6 +395,7 @@ export class PtyManager {
   private pendingLocalSessions = new Map<string, PendingLocalSession>();
   private counter = 0;
   private readonly platform: NodeJS.Platform;
+  private readonly osRelease: string;
   private readonly loadNodePty: () => Promise<typeof import('node-pty')>;
   private readonly startWindowsPtyHelper: (
     request: WindowsPtyHelperRequest,
@@ -413,6 +416,7 @@ export class PtyManager {
 
   constructor(dependencies: PtyManagerDependencies = {}) {
     this.platform = dependencies.platform ?? process.platform;
+    this.osRelease = dependencies.osRelease ?? release();
     this.loadNodePty = dependencies.loadNodePty ?? (() => import('node-pty'));
     this.startWindowsPtyHelper = dependencies.startWindowsPtyHelper ?? startWindowsPtyHelper;
   }
@@ -422,7 +426,7 @@ export class PtyManager {
     onData: TerminalDataHandler,
     onExit?: TerminalExitHandler,
     ownerId: number | null = null
-  ): Promise<string> {
+  ): Promise<TerminalCreateResult> {
     const id = `pty-${++this.counter}`;
     const home = process.env.HOME || process.env.USERPROFILE || homedir();
     const cwd = options.cwd || home;
@@ -588,7 +592,7 @@ export class PtyManager {
       });
       session.exitDisposable = exitDisposable;
 
-      return id;
+      return { id };
     } finally {
       this.pendingLocalSessions.delete(id);
     }
@@ -605,7 +609,7 @@ export class PtyManager {
     onData: TerminalDataHandler,
     onExit: TerminalExitHandler | undefined,
     ownerId: number | null
-  ): Promise<string> {
+  ): Promise<TerminalCreateResult> {
     let currentAttempt: WindowsPtyHelperAttempt | null = null;
     const pending: PendingWindowsSession = {
       ownerId,
@@ -649,7 +653,9 @@ export class PtyManager {
     };
 
     try {
-      const helperSession = await createWindowsPtyWithFallback({
+      const windowsPtyBackend = resolveWindowsPtyBackend(this.osRelease);
+      const { session: helperSession, conptySource } = await createWindowsPtyWithFallback({
+        backend: windowsPtyBackend,
         request,
         useBundledConpty,
         createAttempt: async (attemptRequest) => {
@@ -688,7 +694,11 @@ export class PtyManager {
         this.activityCache.delete(id);
         onExit?.(id, pendingExit.exitCode, pendingExit.signal);
       }
-      return id;
+      return {
+        id,
+        windowsPtyBackend,
+        ...(conptySource ? { windowsConptySource: conptySource } : {}),
+      };
     } catch (error) {
       this.pendingWindowsSessions.delete(id);
       throw error;

--- a/src/main/services/terminal/WindowsPtyHelper.ts
+++ b/src/main/services/terminal/WindowsPtyHelper.ts
@@ -1,6 +1,7 @@
 import type { ChildProcess } from 'node:child_process';
 import { fork } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import type { WindowsConptySource, WindowsPtyBackend } from '@shared/types';
 import {
   formatPtyHelperError,
   isPtyHelperEvent,
@@ -10,6 +11,7 @@ import {
 
 export const WINDOWS_PTY_CREATE_TIMEOUT_MS = 10_000;
 export const WINDOWS_PTY_DESTROY_TIMEOUT_MS = 3_000;
+const NODE_PTY_MIN_CONPTY_BUILD = 18309;
 
 export interface WindowsPtyHelperRequest {
   shell: string;
@@ -46,8 +48,23 @@ export interface WindowsPtyHelperDependencies {
 
 export interface WindowsPtyHelperFallbackInput {
   request: WindowsPtyHelperRequest;
+  backend: WindowsPtyBackend;
   useBundledConpty: boolean;
   createAttempt(request: WindowsPtyHelperRequest): Promise<WindowsPtyHelperSession>;
+}
+
+export interface WindowsPtyHelperCreationResult {
+  session: WindowsPtyHelperSession;
+  backend: WindowsPtyBackend;
+  conptySource?: WindowsConptySource;
+}
+
+export function resolveWindowsPtyBackend(osRelease: string): WindowsPtyBackend {
+  const buildNumber = Number.parseInt(osRelease.split('.')[2] ?? '', 10);
+  // 与 node-pty 的默认选择保持一致；无法确认支持 ConPTY 时使用 WinPTY。
+  return Number.isFinite(buildNumber) && buildNumber >= NODE_PTY_MIN_CONPTY_BUILD
+    ? 'conpty'
+    : 'winpty';
 }
 
 export function resolvePtyHelperPath(): string {
@@ -282,20 +299,46 @@ export function startWindowsPtyHelper(
 
 export async function createWindowsPtyWithFallback(
   input: WindowsPtyHelperFallbackInput
-): Promise<WindowsPtyHelperSession> {
-  try {
-    return await input.createAttempt({
+): Promise<WindowsPtyHelperCreationResult> {
+  if (input.backend === 'winpty') {
+    const session = await input.createAttempt({
       ...input.request,
-      options: { ...input.request.options, useConptyDll: input.useBundledConpty },
+      options: {
+        ...input.request.options,
+        useConpty: false,
+        useConptyDll: false,
+      },
     });
+    return { session, backend: 'winpty' };
+  }
+
+  try {
+    const session = await input.createAttempt({
+      ...input.request,
+      options: {
+        ...input.request.options,
+        useConpty: true,
+        useConptyDll: input.useBundledConpty,
+      },
+    });
+    return {
+      session,
+      backend: 'conpty',
+      conptySource: input.useBundledConpty ? 'bundled' : 'system',
+    };
   } catch (bundledError) {
     if (!input.useBundledConpty) throw bundledError;
 
     try {
-      return await input.createAttempt({
+      const session = await input.createAttempt({
         ...input.request,
-        options: { ...input.request.options, useConptyDll: false },
+        options: {
+          ...input.request.options,
+          useConpty: true,
+          useConptyDll: false,
+        },
       });
+      return { session, backend: 'conpty', conptySource: 'system' };
     } catch (systemError) {
       throw new Error(
         `PTY creation failed with bundled and system ConPTY: ${formatPtyHelperError(bundledError)}; ${formatPtyHelperError(systemError)}`

--- a/src/main/services/terminal/__tests__/PtyManagerWindowsHelper.test.ts
+++ b/src/main/services/terminal/__tests__/PtyManagerWindowsHelper.test.ts
@@ -56,10 +56,12 @@ function createOptions() {
 }
 
 function createManager(
-  startWindowsPtyHelper: NonNullable<PtyManagerDependencies['startWindowsPtyHelper']>
+  startWindowsPtyHelper: NonNullable<PtyManagerDependencies['startWindowsPtyHelper']>,
+  osRelease = '10.0.19045'
 ): PtyManager {
   return new PtyManager({
     platform: 'win32',
+    osRelease,
     startWindowsPtyHelper,
   });
 }
@@ -84,13 +86,15 @@ describe('PtyManager Windows helper integration', () => {
     await Promise.resolve();
     ready.resolve(session);
 
-    const id = await pending;
-    manager.write(id, 'echo ready\r');
+    const result = await pending;
+    manager.write(result.id, 'echo ready\r');
+    expect(result.windowsPtyBackend).toBe('conpty');
+    expect(result.windowsConptySource).toBe('system');
     expect(session.write).toHaveBeenCalledWith('echo ready\r');
     expect(session.activate).not.toHaveBeenCalled();
 
-    manager.activate(id);
-    manager.activate(id);
+    manager.activate(result.id);
+    manager.activate(result.id);
     expect(session.activate).toHaveBeenCalledTimes(1);
   });
 
@@ -134,12 +138,9 @@ describe('PtyManager Windows helper integration', () => {
         cancel: vi.fn().mockResolvedValue(undefined),
       };
     });
-    const manager = new PtyManager({
-      platform: 'win32',
-      startWindowsPtyHelper: start,
-    });
+    const manager = createManager(start);
 
-    await manager.create(
+    const result = await manager.create(
       { ...createOptions(), windowsConptyCompatibilityFixEnabled: true },
       vi.fn(),
       vi.fn(),
@@ -147,5 +148,52 @@ describe('PtyManager Windows helper integration', () => {
     );
 
     expect(useConptyValues).toEqual([true, false]);
+    expect(result.windowsPtyBackend).toBe('conpty');
+    expect(result.windowsConptySource).toBe('system');
+  });
+
+  it('reports bundled ConPTY when the bundled helper succeeds', async () => {
+    const session = createFakeSession(9030, 9031);
+    const manager = createManager(
+      (): WindowsPtyHelperAttempt => ({
+        helperPid: session.helperPid,
+        ready: Promise.resolve(session),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      })
+    );
+
+    const result = await manager.create(
+      { ...createOptions(), windowsConptyCompatibilityFixEnabled: true },
+      vi.fn(),
+      vi.fn(),
+      12
+    );
+
+    expect(result.windowsPtyBackend).toBe('conpty');
+    expect(result.windowsConptySource).toBe('bundled');
+  });
+
+  it('reports WinPTY on Windows builds below 18309', async () => {
+    const session = createFakeSession(9040, 9041);
+    const requests: WindowsPtyHelperRequest[] = [];
+    const manager = createManager((request): WindowsPtyHelperAttempt => {
+      requests.push(request);
+      return {
+        helperPid: session.helperPid,
+        ready: Promise.resolve(session),
+        cancel: vi.fn().mockResolvedValue(undefined),
+      };
+    }, '10.0.17763');
+
+    const result = await manager.create(
+      { ...createOptions(), windowsConptyCompatibilityFixEnabled: true },
+      vi.fn(),
+      vi.fn(),
+      13
+    );
+
+    expect(result).toEqual({ id: expect.any(String), windowsPtyBackend: 'winpty' });
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.options).toMatchObject({ useConpty: false, useConptyDll: false });
   });
 });

--- a/src/main/services/terminal/__tests__/WindowsPtyHelper.test.ts
+++ b/src/main/services/terminal/__tests__/WindowsPtyHelper.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PtyHelperEvent, PtyHelperSpawnOptions } from '../ptyHelperProtocol';
 import {
   createWindowsPtyWithFallback,
+  resolveWindowsPtyBackend,
   startWindowsPtyHelper,
   type WindowsPtyHelperCallbacks,
   type WindowsPtyHelperRequest,
@@ -78,6 +79,16 @@ function createFakeSession(
 describe('WindowsPtyHelper', () => {
   beforeEach(() => {
     vi.useRealTimers();
+  });
+
+  it.each([
+    ['10.0.17763', 'winpty'],
+    ['10.0.18308', 'winpty'],
+    ['10.0.18309', 'conpty'],
+    ['10.0.19045', 'conpty'],
+    ['bad-release', 'winpty'],
+  ] as const)('resolves Windows release %s to %s', (osRelease, expected) => {
+    expect(resolveWindowsPtyBackend(osRelease)).toBe(expected);
   });
 
   it('resolves ready with helperPid and ptyPid after created', async () => {
@@ -191,6 +202,7 @@ describe('WindowsPtyHelper', () => {
     const session = createFakeSession();
     const result = await createWindowsPtyWithFallback({
       request: createRequest(),
+      backend: 'conpty',
       useBundledConpty: true,
       createAttempt: async (request) => {
         useConptyValues.push(request.options.useConptyDll === true);
@@ -199,7 +211,52 @@ describe('WindowsPtyHelper', () => {
       },
     });
 
-    expect(result).toBe(session);
+    expect(result).toEqual({ session, backend: 'conpty', conptySource: 'system' });
     expect(useConptyValues).toEqual([true, false]);
+  });
+
+  it('reports bundled ConPTY when the first attempt succeeds', async () => {
+    const session = createFakeSession();
+    const result = await createWindowsPtyWithFallback({
+      request: createRequest(),
+      backend: 'conpty',
+      useBundledConpty: true,
+      createAttempt: async () => session,
+    });
+
+    expect(result).toEqual({ session, backend: 'conpty', conptySource: 'bundled' });
+  });
+
+  it('reports system ConPTY when bundled ConPTY is not requested', async () => {
+    const session = createFakeSession();
+    const result = await createWindowsPtyWithFallback({
+      request: createRequest(),
+      backend: 'conpty',
+      useBundledConpty: false,
+      createAttempt: async () => session,
+    });
+
+    expect(result).toEqual({ session, backend: 'conpty', conptySource: 'system' });
+  });
+
+  it('creates WinPTY once without a ConPTY DLL source', async () => {
+    const session = createFakeSession();
+    const requests: WindowsPtyHelperRequest[] = [];
+    const result = await createWindowsPtyWithFallback({
+      request: createRequest(),
+      backend: 'winpty',
+      useBundledConpty: true,
+      createAttempt: async (request) => {
+        requests.push(request);
+        return session;
+      },
+    });
+
+    expect(requests).toHaveLength(1);
+    expect(requests[0]?.options).toMatchObject({
+      useConpty: false,
+      useConptyDll: false,
+    });
+    expect(result).toEqual({ session, backend: 'winpty' });
   });
 });

--- a/src/main/services/terminal/ptyHelperProtocol.ts
+++ b/src/main/services/terminal/ptyHelperProtocol.ts
@@ -4,6 +4,7 @@ export interface PtyHelperSpawnOptions {
   rows: number;
   cwd: string;
   env: Record<string, string>;
+  useConpty?: boolean;
   useConptyDll?: boolean;
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -49,6 +49,7 @@ import type {
   TempWorkspaceCreateResult,
   TempWorkspaceRemoveResult,
   TerminalCreateOptions,
+  TerminalCreateResult,
   TerminalResizeOptions,
   ValidateLocalPathResult,
   ValidateUrlResult,
@@ -410,7 +411,7 @@ const electronAPI = {
 
   // Terminal
   terminal: {
-    create: (options?: TerminalCreateOptions): Promise<string> =>
+    create: (options?: TerminalCreateOptions): Promise<TerminalCreateResult> =>
       ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_CREATE, options),
     activate: (id: string): Promise<void> => ipcRenderer.invoke(IPC_CHANNELS.TERMINAL_ACTIVATE, id),
     write: (id: string, data: string): Promise<void> =>

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -81,7 +81,9 @@ const RECENT_OUTPUT_TIMEOUT_MS = 3000; // If output received within this time, c
 const CODEX_SESSION_DETECT_RETRY_MS = 1000;
 const CODEX_SESSION_DETECT_TIMEOUT_MS = 15000;
 const CODEX_SESSION_DETECT_STARTED_AFTER_PADDING_MS = 5000;
-const CODEX_SESSION_UPGRADE_MESSAGE = '未能唯一识别 Codex 会话，请升级 Codex 后重试。';
+const CODEX_SESSION_NOT_FOUND_MESSAGE = '暂未找到 Codex 会话记录，可在下一次发送内容时重试。';
+const CODEX_SESSION_ALREADY_CLAIMED_MESSAGE = '该 Codex 会话已关联到其他标签页。';
+const CODEX_SESSION_READ_FAILED_MESSAGE = '读取 Codex 会话记录失败，请稍后重试。';
 
 export function AgentTerminal({
   id,
@@ -163,11 +165,12 @@ export function AgentTerminal({
   const currentTitleRef = useRef<string>(''); // Terminal title from OSC escape sequence.
   const tmuxSessionNameRef = useRef<string | null>(null); // Tmux session name for cleanup.
   const codexStartTimeRef = useRef<number | null>(null);
+  const codexInitialPromptDetectionStartedRef = useRef(false);
   const codexSessionDetectIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const codexSessionDetectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const codexSessionDetectInFlightRef = useRef(false);
-  const codexLegacyFallbackPendingRef = useRef(false);
-  const codexLegacyFallbackStartedRef = useRef(false);
+  const codexFinalDetectionPendingRef = useRef(false);
+  const codexFinalDetectionStartedRef = useRef(false);
   const codexStatusOutputRef = useRef<(data: string) => void>(() => {});
   const cliSessionIdRef = useRef<string | undefined>(cliSessionId);
   const notifiedCodexRuntimeRef = useRef<CodexRuntime | null>(null);
@@ -226,7 +229,7 @@ export function AgentTerminal({
       clearTimeout(codexSessionDetectTimeoutRef.current);
       codexSessionDetectTimeoutRef.current = null;
     }
-    codexLegacyFallbackPendingRef.current = false;
+    codexFinalDetectionPendingRef.current = false;
   }, []);
 
   const startCodexSessionDetection = useCallback(() => {
@@ -247,10 +250,10 @@ export function AgentTerminal({
       excludeSessionIds,
       runtime: codexRuntime,
     };
-    codexLegacyFallbackPendingRef.current = false;
-    codexLegacyFallbackStartedRef.current = false;
+    codexFinalDetectionPendingRef.current = false;
+    codexFinalDetectionStartedRef.current = false;
 
-    let runLegacyFallback: () => void;
+    let runFinalDetection: () => void;
 
     const detectOnce = () => {
       if (
@@ -287,15 +290,15 @@ export function AgentTerminal({
         .catch(() => {})
         .finally(() => {
           codexSessionDetectInFlightRef.current = false;
-          if (codexLegacyFallbackPendingRef.current) runLegacyFallback();
+          if (codexFinalDetectionPendingRef.current) runFinalDetection();
         });
     };
 
-    runLegacyFallback = () => {
+    runFinalDetection = () => {
       if (
-        codexLegacyFallbackStartedRef.current ||
+        codexFinalDetectionStartedRef.current ||
         codexSessionDetectInFlightRef.current ||
-        !codexLegacyFallbackPendingRef.current
+        !codexFinalDetectionPendingRef.current
       ) {
         return;
       }
@@ -304,37 +307,48 @@ export function AgentTerminal({
         return;
       }
 
-      codexLegacyFallbackStartedRef.current = true;
-      codexLegacyFallbackPendingRef.current = false;
+      codexFinalDetectionStartedRef.current = true;
+      codexFinalDetectionPendingRef.current = false;
       codexSessionDetectInFlightRef.current = true;
-      // 超时后只查询一次，旧版 Codex 仅在唯一主 CLI 会话时才允许关联。
-      window.electronAPI.codexHistory
-        .findLatest({ ...strictQuery, matchMode: 'legacy-unique' })
-        .then((result) => {
+      // 结束前刷新近期文件并严格匹配；仍为空时才查询旧版 Codex 的唯一主会话。
+      void (async () => {
+        try {
+          const strictResult = await window.electronAPI.codexHistory.findLatest({
+            ...strictQuery,
+            originator: codexSessionOriginator,
+            refreshOnMiss: true,
+          });
+          const result =
+            strictResult ??
+            (await window.electronAPI.codexHistory.findLatest({
+              ...strictQuery,
+              matchMode: 'legacy-unique',
+              refreshOnMiss: true,
+            }));
+
           if (!result?.sessionId || cliSessionIdRef.current) {
             if (!result?.sessionId && !cliSessionIdRef.current) {
-              codexStatusOutputRef.current(`\r\n${CODEX_SESSION_UPGRADE_MESSAGE}\r\n`);
+              codexStatusOutputRef.current(`\r\n${CODEX_SESSION_NOT_FOUND_MESSAGE}\r\n`);
             }
             return;
           }
           const claimed =
             onCliSessionIdDetected?.(result.sessionId, codexRuntime, result.wslDistro) ?? true;
           if (!claimed) {
-            codexStatusOutputRef.current(`\r\n${CODEX_SESSION_UPGRADE_MESSAGE}\r\n`);
+            codexStatusOutputRef.current(`\r\n${CODEX_SESSION_ALREADY_CLAIMED_MESSAGE}\r\n`);
             return;
           }
 
           cliSessionIdRef.current = result.sessionId;
-        })
-        .catch(() => {
+        } catch {
           if (!cliSessionIdRef.current) {
-            codexStatusOutputRef.current(`\r\n${CODEX_SESSION_UPGRADE_MESSAGE}\r\n`);
+            codexStatusOutputRef.current(`\r\n${CODEX_SESSION_READ_FAILED_MESSAGE}\r\n`);
           }
-        })
-        .finally(() => {
+        } finally {
           codexSessionDetectInFlightRef.current = false;
           stopCodexSessionDetection();
-        });
+        }
+      })();
     };
 
     detectOnce();
@@ -345,8 +359,8 @@ export function AgentTerminal({
         clearInterval(codexSessionDetectIntervalRef.current);
         codexSessionDetectIntervalRef.current = null;
       }
-      codexLegacyFallbackPendingRef.current = true;
-      runLegacyFallback();
+      codexFinalDetectionPendingRef.current = true;
+      runFinalDetection();
     }, CODEX_SESSION_DETECT_TIMEOUT_MS);
   }, [
     agentCommand,
@@ -717,15 +731,6 @@ export function AgentTerminal({
       // Track output volume since last Enter
       dataSinceEnterRef.current += data.length;
 
-      if (
-        agentCommand === 'codex' &&
-        !cliSessionId &&
-        codexStartTimeRef.current !== null &&
-        dataSinceEnterRef.current > 100
-      ) {
-        startCodexSessionDetection();
-      }
-
       // === Output state tracking for UI indicator ===
       // Only track when we're monitoring (after user pressed Enter)
       if (isMonitoringOutputRef.current) {
@@ -784,9 +789,7 @@ export function AgentTerminal({
       initialized,
       onInitialized,
       agentCommand,
-      cliSessionId,
       cwd,
-      startCodexSessionDetection,
       agentNotificationEnabled,
       agentNotificationDelay,
       claudeCodeIntegration.stopHookEnabled,
@@ -846,6 +849,9 @@ export function AgentTerminal({
             const line = getCurrentLine();
             if (line) onActivatedWithFirstLine(line);
           }
+        }
+        if (agentCommand === 'codex' && !cliSessionIdRef.current) {
+          startCodexSessionDetection();
         }
         // Reset output counter.
         dataSinceEnterRef.current = 0;
@@ -933,6 +939,7 @@ export function AgentTerminal({
       setActivityState,
       agentId,
       agentCommand,
+      startCodexSessionDetection,
       claudeCodeIntegration.enhancedInputEnabled,
       enhancedInputOpen,
       setEnhancedInputOpen,
@@ -955,11 +962,18 @@ export function AgentTerminal({
   }, [environment, hapiGlobalInstalled, isActive, resolvedShell, hasPendingCommand]);
 
   useEffect(() => {
-    if (agentCommand !== 'codex' || !effectiveIsActive || codexStartTimeRef.current !== null) {
+    if (agentCommand !== 'codex' || !effectiveIsActive) return;
+    if (codexStartTimeRef.current === null) codexStartTimeRef.current = Date.now();
+    if (
+      !initialPrompt ||
+      cliSessionIdRef.current ||
+      codexInitialPromptDetectionStartedRef.current
+    ) {
       return;
     }
-    codexStartTimeRef.current = Date.now();
-  }, [agentCommand, effectiveIsActive]);
+    codexInitialPromptDetectionStartedRef.current = true;
+    startCodexSessionDetection();
+  }, [agentCommand, effectiveIsActive, initialPrompt, startCodexSessionDetection]);
 
   const {
     containerRef,
@@ -1029,12 +1043,24 @@ export function AgentTerminal({
 
   // Register write and focus functions to global store for external access
   const { register, unregister } = useTerminalWriteStore();
+  const writeFromExternal = useCallback(
+    (data: string) => {
+      if (!write) return;
+
+      write(data);
+      // 外部组件写入回车代表真正提交，此时才开始识别新 Codex 会话。
+      if (data.includes('\r')) {
+        startCodexSessionDetection();
+      }
+    },
+    [write, startCodexSessionDetection]
+  );
   useEffect(() => {
     if (!terminalSessionId || !write) return;
 
-    register(terminalSessionId, write, () => terminal?.focus());
+    register(terminalSessionId, writeFromExternal, () => terminal?.focus());
     return () => unregister(terminalSessionId);
-  }, [terminalSessionId, write, terminal, register, unregister]);
+  }, [terminalSessionId, write, writeFromExternal, terminal, register, unregister]);
 
   // Handle Cmd+F / Ctrl+F
   const handleKeyDown = useCallback(
@@ -1188,11 +1214,15 @@ export function AgentTerminal({
       }
 
       const delay = imagePaths.length > 0 ? 800 : hasInternalNewlines ? 300 : 30;
-      setTimeout(() => write('\r'), delay);
+      setTimeout(() => {
+        write('\r');
+        // 增强输入绕过键盘回调，需在真正发送回车时启动识别。
+        startCodexSessionDetection();
+      }, delay);
 
       terminal?.focus();
     },
-    [write, terminalSessionId, terminal]
+    [write, terminalSessionId, terminal, startCodexSessionDetection]
   );
 
   useEffect(() => {

--- a/src/renderer/components/files/FileSidebar.tsx
+++ b/src/renderer/components/files/FileSidebar.tsx
@@ -17,6 +17,7 @@ import { useFileTree } from '@/hooks/useFileTree';
 import { useFileChanges } from '@/hooks/useSourceControl';
 import { useI18n } from '@/i18n';
 import { isFocusLocked, pauseFocusLock, restoreFocus } from '@/lib/focusLock';
+import { useSettingsStore } from '@/stores/settings';
 import { useTerminalWriteStore } from '@/stores/terminalWrite';
 import { getEditorSelectionText } from './EditorArea';
 import {
@@ -97,11 +98,16 @@ export function FileSidebar({
   const newItemPausedSessionIdRef = useRef<string | null>(null);
 
   // Auto-sync file tree selection with active tab
+  const fileTreeAutoReveal = useSettingsStore((s) => s.fileTreeAutoReveal);
+
   useEffect(() => {
     if (!activeTab?.path || !rootPath) return;
     setSelectedFilePath(activeTab.path);
-    revealFile(activeTab.path);
-  }, [activeTab?.path, rootPath, revealFile]);
+    // Expand parent directories to reveal the file (only if enabled)
+    if (fileTreeAutoReveal) {
+      revealFile(activeTab.path);
+    }
+  }, [activeTab?.path, rootPath, revealFile, fileTreeAutoReveal]);
 
   const handleRecordOperations = useCallback((addFn: (operations: any[]) => void) => {
     addOperationsRef.current = addFn;

--- a/src/renderer/components/source-control/CommitGraph.tsx
+++ b/src/renderer/components/source-control/CommitGraph.tsx
@@ -59,7 +59,9 @@ export function CommitGraph({
   const graphWidth = Math.max(22, getLaneX(Math.max(0, maxColumns - 1), columnWidth) + 6);
   const centerY = rowHeight / 2;
   const nodeX = getLaneX(row.column, columnWidth);
-  const isHollow = row.kind === 'HEAD' || row.kind === 'incoming' || row.kind === 'outgoing';
+  const isVirtualChange = row.kind === 'incoming' || row.kind === 'outgoing';
+  // HEAD 使用实线圆环，传入和传出提示节点使用虚线圆环，避免含义混淆。
+  const isHollow = row.kind === 'HEAD' || isVirtualChange;
 
   return (
     <svg
@@ -162,9 +164,10 @@ export function CommitGraph({
         cx={nodeX}
         cy={centerY}
         fill={isHollow ? undefined : getGraphColor(row.circleColor)}
-        r="4"
+        r={isVirtualChange ? 5 : 4}
         stroke={getGraphColor(row.circleColor)}
-        strokeWidth={isHollow ? 2 : 0}
+        strokeDasharray={isVirtualChange ? '3 2' : undefined}
+        strokeWidth={isVirtualChange ? 1.5 : isHollow ? 2 : 0}
       />
     </svg>
   );

--- a/src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts
+++ b/src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts
@@ -12,4 +12,17 @@ describe('useXterm terminal display options', () => {
   it('passes Windows ConPTY compatibility setting to terminal creation', () => {
     expect(source).toContain('windowsConptyCompatibilityFixEnabled');
   });
+
+  it('passes native Windows PTY compatibility options to xterm', () => {
+    expect(source).toContain('buildWindowsPtyCompatibilityOptions({');
+    expect(source).toContain('osRelease: window.electronAPI.env.osRelease');
+    expect(source).toContain('backend: windowsPtyBackend');
+    expect(source).toContain('conptySource: windowsConptySource');
+    expect(source).toContain('terminal.options.windowsPty = windowsPtyOptions.windowsPty');
+
+    const optionsIndex = source.indexOf('terminal.options.windowsPty =');
+    const activateIndex = source.indexOf('window.electronAPI.terminal.activate(ptyId)');
+    expect(optionsIndex).toBeGreaterThan(-1);
+    expect(optionsIndex).toBeLessThan(activateIndex);
+  });
 });

--- a/src/renderer/hooks/useTerminal.ts
+++ b/src/renderer/hooks/useTerminal.ts
@@ -22,7 +22,7 @@ export function useTerminal() {
         ...options,
         shellConfig: options?.shell ? undefined : shellConfig,
       };
-      const id = await window.electronAPI.terminal.create(createOptions);
+      const { id } = await window.electronAPI.terminal.create(createOptions);
       addSession({
         id,
         title: 'Terminal',

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -8,6 +8,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { defaultDarkTheme, getXtermTheme } from '@/lib/ghosttyTheme';
 import { matchesKeybinding } from '@/lib/keybinding';
 import { stripTerminalColorQueryResponses } from '@/lib/terminalInputFilter';
+import { buildWindowsPtyCompatibilityOptions } from '@/lib/windowsPtyCompatibility';
 import { useNavigationStore } from '@/stores/navigation';
 import { useSettingsStore } from '@/stores/settings';
 import '@xterm/xterm/css/xterm.css';
@@ -596,7 +597,11 @@ export function useXterm({
 
     try {
       const createRequestId = ++createRequestIdRef.current;
-      const ptyId = await window.electronAPI.terminal.create({
+      const {
+        id: ptyId,
+        windowsPtyBackend,
+        windowsConptySource,
+      } = await window.electronAPI.terminal.create({
         cwd: cwd || window.electronAPI.env.HOME,
         // If command is provided (e.g., for agent), use shell/args directly
         // Otherwise, use shellConfig from settings
@@ -611,6 +616,16 @@ export function useXterm({
       if (isUnmountedRef.current || createRequestId !== createRequestIdRef.current) {
         await window.electronAPI.terminal.destroy(ptyId).catch(() => {});
         return;
+      }
+
+      const windowsPtyOptions = buildWindowsPtyCompatibilityOptions({
+        platform: window.electronAPI.env.platform,
+        osRelease: window.electronAPI.env.osRelease,
+        backend: windowsPtyBackend,
+        conptySource: windowsConptySource,
+      });
+      if (windowsPtyOptions.windowsPty) {
+        terminal.options.windowsPty = windowsPtyOptions.windowsPty;
       }
 
       ptyIdRef.current = ptyId;

--- a/src/renderer/lib/windowsPtyCompatibility.ts
+++ b/src/renderer/lib/windowsPtyCompatibility.ts
@@ -1,0 +1,37 @@
+import type { WindowsConptySource, WindowsPtyBackend } from '@shared/types';
+import type { ITerminalOptions } from '@xterm/xterm';
+
+const UNKNOWN_WINDOWS_BUILD_NUMBER = 1;
+const MODERN_CONPTY_MIN_BUILD_NUMBER = 21376;
+
+export interface WindowsPtyCompatibilityContext {
+  platform: string;
+  osRelease?: string;
+  backend?: WindowsPtyBackend;
+  conptySource?: WindowsConptySource;
+}
+
+type WindowsPtyCompatibilityOptions = Partial<Pick<ITerminalOptions, 'windowsPty'>>;
+
+function parseWindowsBuildNumber(osRelease: string | undefined): number | undefined {
+  const buildNumber = Number.parseInt(osRelease?.split('.')[2] ?? '', 10);
+  return Number.isFinite(buildNumber) && buildNumber > 0 ? buildNumber : undefined;
+}
+
+export function buildWindowsPtyCompatibilityOptions(
+  context: WindowsPtyCompatibilityContext
+): WindowsPtyCompatibilityOptions {
+  if (context.platform !== 'win32' || !context.backend) return {};
+  if (context.backend === 'winpty') {
+    return { windowsPty: { backend: 'winpty' } };
+  }
+
+  // 随包版是新版 ConPTY；系统版使用宿主 build 选择 xterm 的兼容规则。
+  const buildNumber =
+    context.conptySource === 'bundled'
+      ? MODERN_CONPTY_MIN_BUILD_NUMBER
+      : (parseWindowsBuildNumber(context.osRelease) ?? UNKNOWN_WINDOWS_BUILD_NUMBER);
+  return {
+    windowsPty: { backend: 'conpty', buildNumber },
+  };
+}

--- a/src/shared/types/codexHistory.ts
+++ b/src/shared/types/codexHistory.ts
@@ -23,6 +23,7 @@ export interface CodexLatestSessionQuery {
   excludeSessionIds?: string[];
   originator?: string;
   matchMode?: 'strict' | 'legacy-unique';
+  refreshOnMiss?: boolean;
   runtime?: CodexRuntime;
   wslDistro?: string;
 }

--- a/src/shared/types/terminal.ts
+++ b/src/shared/types/terminal.ts
@@ -4,6 +4,15 @@ export interface TerminalSession {
   cwd: string;
 }
 
+export type WindowsPtyBackend = 'conpty' | 'winpty';
+export type WindowsConptySource = 'bundled' | 'system';
+
+export interface TerminalCreateResult {
+  id: string;
+  windowsPtyBackend?: WindowsPtyBackend;
+  windowsConptySource?: WindowsConptySource;
+}
+
 export interface TerminalCreateOptions {
   cwd?: string;
   shell?: string;


### PR DESCRIPTION
## 主要改动

### Codex

- 修复新会话识别时机与最终查询刷新（避免会话切换时展示陈旧查询结果）

### Git 提交历史

- 区分提交图中的虚拟变更节点：HEAD 使用实线圆环，incoming/outgoing 提示节点改用虚线圆环并放大，避免含义混淆

### 终端

- 识别并传递 Windows PTY 实际后端（ConPTY / WinPty），渲染层据此正确选择显示策略
- 新增 `windowsPtyCompatibility` 兼容层

### 文件树

- 分栏模式（Split sidebar）下文件树忽略 Auto Reveal 设置导致收起后自动展开：`FileSidebar` 补上与 `FilePanel` 一致的 `fileTreeAutoReveal` 开关检查

## 改动文件

src/main/ipc/terminal.ts
src/main/services/codex/CodexHistoryService.ts
src/main/services/terminal/PtyManager.ts
src/main/services/terminal/WindowsPtyHelper.ts
src/main/services/terminal/ptyHelperProtocol.ts
src/preload/index.ts
src/renderer/components/chat/AgentTerminal.tsx
src/renderer/components/files/FileSidebar.tsx
src/renderer/components/source-control/CommitGraph.tsx
src/renderer/hooks/useTerminal.ts
src/renderer/hooks/useXterm.ts
src/renderer/lib/windowsPtyCompatibility.ts
src/shared/types/codexHistory.ts
src/shared/types/terminal.ts

## 验证结果

- [x] `pnpm typecheck` 通过
- [x] `pnpm test`：28 个测试文件、223 项测试全部通过
- [x] 已在 Windows 本地手动验证文件树收起行为与终端显示