### PR TITLE
fix(terminal): 修复 OSC 8 链接打开失败

### DIFF
--- a/src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts
+++ b/src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts
@@ -12,4 +12,11 @@ describe('useXterm terminal display options', () => {
   it('passes Windows ConPTY compatibility setting to terminal creation', () => {
     expect(source).toContain('windowsConptyCompatibilityFixEnabled');
   });
+
+  it('routes OSC 8 hyperlinks through Electron instead of the xterm default warning', () => {
+    expect(source).toMatch(
+      /new Terminal\(\{[\s\S]*?linkHandler:\s*\{\s*activate:\s*openTerminalExternalLink/
+    );
+    expect(source).toContain('window.electronAPI.shell.openExternal(uri)');
+  });
 });

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -32,6 +32,10 @@ function hasVisibleContent(data: string): boolean {
   return stripped.trim().length > 0;
 }
 
+function openTerminalExternalLink(_event: MouseEvent, uri: string): void {
+  void window.electronAPI.shell.openExternal(uri);
+}
+
 export interface UseXtermOptions {
   cwd?: string;
   command?: {
@@ -311,13 +315,14 @@ export function useXterm({
       allowProposedApi: true,
       allowTransparency: settings.backgroundImageEnabled,
       rescaleOverlappingGlyphs: true,
+      linkHandler: {
+        activate: openTerminalExternalLink,
+      },
     });
 
     const fitAddon = new FitAddon();
     const searchAddon = new SearchAddon();
-    const webLinksAddon = new WebLinksAddon((_event, uri) => {
-      window.electronAPI.shell.openExternal(uri);
-    });
+    const webLinksAddon = new WebLinksAddon(openTerminalExternalLink);
     const unicode11Addon = new Unicode11Addon();
 
     terminal.loadAddon(fitAddon);


### PR DESCRIPTION
## 摘要

修复 Codex 终端中部分链接弹出安全警告后仍无法正常打开的问题。

Codex 输出的 OSC 8 超链接此前由 xterm.js 默认处理：点击时显示安全确认，并通过 `window.open()` 打开。该路径在 Electron 中不能可靠交给系统浏览器；普通文本 URL 则通过 Electron `shell.openExternal` 打开，因此两类链接的行为不一致。

## 变更

- 为 xterm.js 的 OSC 8 链接配置 Electron 外部链接处理器。
- 让 OSC 8 链接与普通文本 URL 共用 `shell.openExternal`。
- 保留 xterm.js 默认的协议限制，没有放开任意非 HTTP/HTTPS 协议。
- 增加回归测试，防止 OSC 8 链接重新落入 xterm.js 默认警告路径。

## 验证

- `pnpm test -- src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts`：3/3 通过
- `pnpm typecheck`：通过
- `pnpm build`：通过
- 提交钩子 Biome 检查：通过
- 全量 `pnpm test`：已执行的 208 个测试全部通过；`PtyManagerWindowsHelper.test.ts` 因本地 Electron 二进制缺失而无法加载，两次重新下载均被网络 `ECONNRESET` 中断
- 未执行真实 Electron 点击验证；本地 Electron 二进制受上述下载问题阻挡
