### PR TITLE
fix: 修复长时间使用导致的内存泄露与崩溃问题

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -5,7 +5,7 @@ import { electronApp, optimizer } from '@electron-toolkit/utils';
 import { type Locale, normalizeLocale } from '@shared/i18n';
 import { IPC_CHANNELS, type OpenContext, type ProxySettings } from '@shared/types';
 import { customProtocolUriToPath, type SupportedFileUrlPlatform } from '@shared/utils/fileUrl';
-import { app, BrowserWindow, ipcMain, Menu, net, protocol } from 'electron';
+import { app, BrowserWindow, crashReporter, ipcMain, Menu, net, protocol } from 'electron';
 
 // Register custom protocol privileges
 protocol.registerSchemesAsPrivileged([
@@ -37,7 +37,7 @@ import {
   cleanupAllResourcesSync,
   registerIpcHandlers,
 } from './ipc';
-import { registerAgentTaskPanelHandlers } from './ipc/agentTaskPanel';
+import { registerAgentTaskPanelHandlers, setAgentTaskPanelMainWindow } from './ipc/agentTaskPanel';
 import { initClaudeProviderWatcher } from './ipc/claudeProvider';
 import { cleanupTempFiles } from './ipc/files';
 import { readSettings } from './ipc/settings';
@@ -79,6 +79,36 @@ if (isDev) {
   const profile = sanitizeProfileName(process.env.ENSOAI_PROFILE || '') || 'dev';
   app.setPath('userData', join(app.getPath('appData'), `${app.getName()}-${profile}`));
 }
+
+// Crash observability: keep local minidumps for native crashes so "app crashed
+// after long usage" reports can be diagnosed. Must start before app is ready.
+crashReporter.start({ uploadToServer: false });
+
+// Log child process crashes (renderer OOM/crash was previously silent: the
+// window just went blank with no trace anywhere).
+const rendererReloadAt = new WeakMap<Electron.WebContents, number>();
+app.on('render-process-gone', (_event, webContents, details) => {
+  log.error(
+    `[crash] Renderer process gone: reason=${details.reason} exitCode=${details.exitCode} url=${webContents.getURL()}`
+  );
+  // Auto-recover from OOM/crash by reloading, at most once per 10s to avoid loops
+  if ((details.reason === 'oom' || details.reason === 'crashed') && !webContents.isDestroyed()) {
+    const now = Date.now();
+    const lastReload = rendererReloadAt.get(webContents) ?? 0;
+    if (now - lastReload > 10_000) {
+      rendererReloadAt.set(webContents, now);
+      webContents.reload();
+    }
+  }
+});
+
+app.on('child-process-gone', (_event, details) => {
+  // 'clean-exit' is normal termination; everything else is worth recording
+  if (details.reason === 'clean-exit') return;
+  log.error(
+    `[crash] Child process gone: type=${details.type} reason=${details.reason} exitCode=${details.exitCode} name=${details.name ?? ''}`
+  );
+});
 
 // Register URL scheme handler (must be done before app is ready)
 if (process.defaultApp) {
@@ -711,7 +741,9 @@ app.whenReady().then(async () => {
   gitAutoFetchService.init(mainWindow);
 
   const handleNewWindow = () => {
-    createMainWindow();
+    const win = createMainWindow();
+    // Rebind services that hold a main-window reference to the new window
+    setAgentTaskPanelMainWindow(win);
   };
 
   // Build and set application menu

--- a/src/main/ipc/agentTaskPanel.ts
+++ b/src/main/ipc/agentTaskPanel.ts
@@ -10,8 +10,29 @@ import {
   showAgentTaskPanelWindow,
 } from '../windows/AgentTaskPanelWindow';
 
+// Current main window, resolved dynamically so IPC handlers never pin a
+// destroyed BrowserWindow (and keep working after a new window is created).
+let currentMainWindow: BrowserWindow | null = null;
+
+export function setAgentTaskPanelMainWindow(window: BrowserWindow): void {
+  currentMainWindow = window;
+  setMainWindowRef(window);
+  window.once('closed', () => {
+    if (currentMainWindow === window) {
+      currentMainWindow = null;
+    }
+  });
+}
+
+function getMainWindow(): BrowserWindow | null {
+  if (currentMainWindow && !currentMainWindow.isDestroyed()) {
+    return currentMainWindow;
+  }
+  return null;
+}
+
 export function registerAgentTaskPanelHandlers(mainWindow: BrowserWindow): void {
-  setMainWindowRef(mainWindow);
+  setAgentTaskPanelMainWindow(mainWindow);
   // Toggle panel visibility
   ipcMain.handle(IPC_CHANNELS.AGENT_TASK_PANEL_TOGGLE, () => {
     if (isAgentTaskPanelVisible()) {
@@ -21,9 +42,7 @@ export function registerAgentTaskPanelHandlers(mainWindow: BrowserWindow): void 
     }
     const visible = isAgentTaskPanelVisible();
     // Notify main window of visibility change
-    if (!mainWindow.isDestroyed()) {
-      mainWindow.webContents.send(IPC_CHANNELS.AGENT_TASK_PANEL_VISIBILITY_CHANGED, visible);
-    }
+    getMainWindow()?.webContents.send(IPC_CHANNELS.AGENT_TASK_PANEL_VISIBILITY_CHANGED, visible);
     return visible;
   });
 
@@ -31,22 +50,24 @@ export function registerAgentTaskPanelHandlers(mainWindow: BrowserWindow): void 
   ipcMain.on(
     IPC_CHANNELS.AGENT_TASK_NAVIGATE_TO_SESSION,
     (_event, params: { sessionId: string; repoPath: string; cwd: string }) => {
-      if (!mainWindow.isDestroyed()) {
+      const window = getMainWindow();
+      if (window) {
         // Restore main window if minimized
-        if (mainWindow.isMinimized()) {
-          mainWindow.restore();
+        if (window.isMinimized()) {
+          window.restore();
         }
-        mainWindow.focus();
-        mainWindow.webContents.send(IPC_CHANNELS.AGENT_TASK_NAVIGATE_TO_SESSION, params);
+        window.focus();
+        window.webContents.send(IPC_CHANNELS.AGENT_TASK_NAVIGATE_TO_SESSION, params);
       }
     }
   );
 
   // Get snapshot from main window and forward to task panel
   ipcMain.handle(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT, () => {
-    if (mainWindow.isDestroyed()) return null;
+    const window = getMainWindow();
+    if (!window) return null;
     // Request snapshot from main window renderer
-    mainWindow.webContents.send(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT);
+    window.webContents.send(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT);
     return true;
   });
 

--- a/src/main/ipc/claudeProvider.ts
+++ b/src/main/ipc/claudeProvider.ts
@@ -31,6 +31,14 @@ let watcherWindow: BrowserWindow | null = null;
  */
 export function initClaudeProviderWatcher(window: BrowserWindow, enabled: boolean): void {
   watcherWindow = window;
+  // Release the reference (and stop the watcher) when the window closes so the
+  // destroyed window can be garbage collected
+  window.once('closed', () => {
+    if (watcherWindow === window) {
+      watcherWindow = null;
+      unwatchClaudeSettings();
+    }
+  });
   if (enabled) {
     watchClaudeSettings(window);
   }

--- a/src/main/ipc/git.ts
+++ b/src/main/ipc/git.ts
@@ -54,12 +54,27 @@ function validateWorkdir(workdir: string): string {
   return resolved;
 }
 
+// LRU cap: long sessions across many repos/worktrees would otherwise grow the
+// map forever. Evicted instances are recreated on demand (stateless per call).
+const MAX_GIT_SERVICES = 32;
+
 function getGitService(workdir: string): GitService {
   const resolved = validateWorkdir(workdir);
-  if (!gitServices.has(resolved)) {
-    gitServices.set(resolved, new GitService(resolved));
+  const existing = gitServices.get(resolved);
+  if (existing) {
+    // Refresh LRU position
+    gitServices.delete(resolved);
+    gitServices.set(resolved, existing);
+    return existing;
   }
-  return gitServices.get(resolved)!;
+  const service = new GitService(resolved);
+  gitServices.set(resolved, service);
+  while (gitServices.size > MAX_GIT_SERVICES) {
+    const oldest = gitServices.keys().next().value;
+    if (oldest === undefined) break;
+    gitServices.delete(oldest);
+  }
+  return service;
 }
 
 export function registerGitHandlers(): void {

--- a/src/main/ipc/worktree.ts
+++ b/src/main/ipc/worktree.ts
@@ -15,11 +15,25 @@ import { ptyManager } from './terminal';
 
 const worktreeServices = new Map<string, WorktreeService>();
 
+// LRU cap: instances are cheap to recreate; keep the map from growing forever
+const MAX_WORKTREE_SERVICES = 16;
+
 function getWorktreeService(workdir: string): WorktreeService {
-  if (!worktreeServices.has(workdir)) {
-    worktreeServices.set(workdir, new WorktreeService(workdir));
+  const existing = worktreeServices.get(workdir);
+  if (existing) {
+    // Refresh LRU position
+    worktreeServices.delete(workdir);
+    worktreeServices.set(workdir, existing);
+    return existing;
   }
-  return worktreeServices.get(workdir)!;
+  const service = new WorktreeService(workdir);
+  worktreeServices.set(workdir, service);
+  while (worktreeServices.size > MAX_WORKTREE_SERVICES) {
+    const oldest = worktreeServices.keys().next().value;
+    if (oldest === undefined) break;
+    worktreeServices.delete(oldest);
+  }
+  return service;
 }
 
 export function clearWorktreeService(workdir: string): void {

--- a/src/main/services/ai/code-review.ts
+++ b/src/main/services/ai/code-review.ts
@@ -351,11 +351,20 @@ export async function startCodeReview(options: CodeReviewOptions): Promise<void>
 
   const claudeParser = new ClaudeStreamParser();
   const geminiParser = new GeminiStreamParser();
+  // Full output is only needed for Codex end-of-run parsing; cap it so a very
+  // long review can't accumulate a huge string in the main process.
+  const MAX_FULL_OUTPUT_CHARS = 4 * 1024 * 1024;
   let fullOutput = '';
 
   proc.stdout?.on('data', (data) => {
     const dataStr = data.toString();
-    fullOutput += dataStr;
+    if (provider === 'codex-cli') {
+      fullOutput += dataStr;
+      if (fullOutput.length > MAX_FULL_OUTPUT_CHARS) {
+        // Keep the tail: the final result message is what gets parsed
+        fullOutput = fullOutput.slice(-Math.floor(MAX_FULL_OUTPUT_CHARS / 2));
+      }
+    }
 
     const cleaned = stripAnsi(dataStr);
 

--- a/src/main/services/claude/ClaudeIdeBridge.ts
+++ b/src/main/services/claude/ClaudeIdeBridge.ts
@@ -220,12 +220,25 @@ export async function startClaudeIdeBridge(
   const { workspaceFolders: initialFolders = [], ideName = 'EnsoAI' } = options;
   const authToken = crypto.randomUUID();
   const STATUS_UPDATE_MIN_INTERVAL_MS = 500;
+  // Throttle bookkeeping is keyed by Claude session id; prune stale entries so
+  // the map doesn't grow for the whole app lifetime.
+  const STATUS_SENT_AT_MAX_ENTRIES = 256;
+  const STATUS_SENT_AT_TTL_MS = 60 * 60 * 1000;
 
   // Mutable state for workspace folders
   let currentWorkspaceFolders = [...initialFolders];
   const pendingStatusUpdates = new Map<string, AgentStatusUpdatePayload>();
   const lastStatusUpdateSentAt = new Map<string, number>();
   let statusUpdateFlushTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function pruneStatusSentAt(now: number): void {
+    if (lastStatusUpdateSentAt.size <= STATUS_SENT_AT_MAX_ENTRIES) return;
+    for (const [sessionId, sentAt] of lastStatusUpdateSentAt) {
+      if (now - sentAt > STATUS_SENT_AT_TTL_MS) {
+        lastStatusUpdateSentAt.delete(sessionId);
+      }
+    }
+  }
 
   function sendStatusUpdateToWindows(update: AgentStatusUpdatePayload): void {
     for (const window of BrowserWindow.getAllWindows()) {
@@ -256,6 +269,7 @@ export async function startClaudeIdeBridge(
 
   function queueStatusUpdate(update: AgentStatusUpdatePayload): void {
     const now = Date.now();
+    pruneStatusSentAt(now);
     const lastSentAt = lastStatusUpdateSentAt.get(update.sessionId) ?? 0;
     const elapsed = now - lastSentAt;
 
@@ -269,14 +283,38 @@ export async function startClaudeIdeBridge(
     scheduleStatusUpdateFlush(Math.max(0, STATUS_UPDATE_MIN_INTERVAL_MS - elapsed));
   }
 
+  // Cap request bodies (aligned with WebInspector); a runaway or malicious POST
+  // must not be able to grow main-process memory without bound.
+  const MAX_HOOK_BODY_BYTES = 1024 * 1024;
+
+  function collectBodyWithLimit(
+    req: http.IncomingMessage,
+    res: http.ServerResponse,
+    onEnd: (body: string) => void
+  ): void {
+    let body = '';
+    let rejected = false;
+    req.on('data', (chunk) => {
+      if (rejected) return;
+      body += chunk.toString();
+      if (body.length > MAX_HOOK_BODY_BYTES) {
+        rejected = true;
+        body = '';
+        res.writeHead(413, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Payload too large' }));
+        req.destroy();
+      }
+    });
+    req.on('end', () => {
+      if (rejected) return;
+      onEnd(body);
+    });
+  }
+
   const httpServer = http.createServer((req, res) => {
     // Handle POST /agent-hook for Claude hook notifications (Stop, PermissionRequest, etc.)
     if (req.method === 'POST' && req.url === '/agent-hook') {
-      let body = '';
-      req.on('data', (chunk) => {
-        body += chunk.toString();
-      });
-      req.on('end', async () => {
+      collectBodyWithLimit(req, res, async (body) => {
         try {
           const data = JSON.parse(body);
           const sessionId = data.session_id;
@@ -450,11 +488,7 @@ export async function startClaudeIdeBridge(
 
     // Handle POST /status-line for Claude status line updates
     if (req.method === 'POST' && req.url === '/status-line') {
-      let body = '';
-      req.on('data', (chunk) => {
-        body += chunk.toString();
-      });
-      req.on('end', () => {
+      collectBodyWithLimit(req, res, (body) => {
         try {
           const data = JSON.parse(body);
 
@@ -693,6 +727,17 @@ export async function startClaudeIdeBridge(
       lastStatusUpdateSentAt.clear();
       ipcMain.removeListener(IPC_CHANNELS.MCP_SELECTION_CHANGED, onSelectionChanged);
       ipcMain.removeListener(IPC_CHANNELS.MCP_AT_MENTIONED, onAtMentioned);
+      // Forcefully terminate connected clients: wss.close() only stops new
+      // connections, existing sockets (and their callback closures) would
+      // otherwise stay alive until the remote end closes them.
+      for (const client of clients.values()) {
+        try {
+          client.ws.terminate();
+        } catch {
+          // Ignore
+        }
+      }
+      clients.clear();
       try {
         wss.close();
       } catch {

--- a/src/main/services/files/FileWatcher.ts
+++ b/src/main/services/files/FileWatcher.ts
@@ -13,6 +13,10 @@ export class FileWatcher {
   }
 
   async start(): Promise<void> {
+    // Guard against double-start: don't orphan an existing subscription
+    if (this.subscription) {
+      await this.stop();
+    }
     this.subscription = await subscribe(
       this.dirPath,
       (err: Error | null, events: Event[]) => {

--- a/src/main/services/git/GitAutoFetchService.ts
+++ b/src/main/services/git/GitAutoFetchService.ts
@@ -13,6 +13,7 @@ const IDLE_FETCH_THRESHOLD = 3;
 class GitAutoFetchService {
   private mainWindow: BrowserWindow | null = null;
   private intervalId: NodeJS.Timeout | null = null;
+  private initialFetchTimer: NodeJS.Timeout | null = null;
   private lastFetchTime = 0;
   private worktreePaths: Set<string> = new Set();
   private enabled = false;
@@ -41,6 +42,15 @@ class GitAutoFetchService {
     };
     window.on('focus', this.onFocusHandler);
 
+    // Release the reference when the window closes so it can be GC'd and a
+    // new window can re-initialize the service (multi-window scenario)
+    window.once('closed', () => {
+      if (this.mainWindow === window) {
+        this.mainWindow = null;
+        this.onFocusHandler = null;
+      }
+    });
+
     if (this.enabled) {
       this.start();
     }
@@ -56,13 +66,19 @@ class GitAutoFetchService {
       this.mainWindow.off('focus', this.onFocusHandler);
       this.onFocusHandler = null;
     }
+    // Release the window reference so a closed window can be garbage collected
+    this.mainWindow = null;
   }
 
   start(): void {
     if (this.intervalId) return;
     this.consecutiveNoChange = 0;
     this.scheduleNextFetch();
-    setTimeout(() => this.fetchAll(), 5000);
+    if (this.initialFetchTimer) clearTimeout(this.initialFetchTimer);
+    this.initialFetchTimer = setTimeout(() => {
+      this.initialFetchTimer = null;
+      this.fetchAll();
+    }, 5000);
   }
 
   private scheduleNextFetch(): void {
@@ -81,6 +97,10 @@ class GitAutoFetchService {
     if (this.intervalId) {
       clearTimeout(this.intervalId);
       this.intervalId = null;
+    }
+    if (this.initialFetchTimer) {
+      clearTimeout(this.initialFetchTimer);
+      this.initialFetchTimer = null;
     }
   }
 

--- a/src/main/services/terminal/WindowsPtyHelper.ts
+++ b/src/main/services/terminal/WindowsPtyHelper.ts
@@ -114,7 +114,11 @@ export function startWindowsPtyHelper(
   let timer: NodeJS.Timeout | undefined;
   let cancelPromise: Promise<void> | null = null;
   let session: WindowsPtyHelperSession | null = null;
+  // Output buffered until the renderer calls activate(). Capped: a burst of
+  // output before activation must not grow main-process memory without bound.
+  const PENDING_DATA_MAX_CHARS = 2 * 1024 * 1024;
   const pendingData: string[] = [];
+  let pendingDataChars = 0;
   let pendingExit: { exitCode: number; signal?: number } | null = null;
 
   let resolveReady: (value: WindowsPtyHelperSession) => void = () => undefined;
@@ -183,6 +187,7 @@ export function startWindowsPtyHelper(
         const activate = (): void => {
           if (activated) return;
           activated = true;
+          pendingDataChars = 0;
           for (const data of pendingData.splice(0)) callbacks.onData(data);
           if (pendingExit) {
             const { exitCode, signal } = pendingExit;
@@ -243,8 +248,17 @@ export function startWindowsPtyHelper(
         return;
       }
       case 'data':
-        if (activated) callbacks.onData(message.data);
-        else pendingData.push(message.data);
+        if (activated) {
+          callbacks.onData(message.data);
+        } else {
+          pendingData.push(message.data);
+          pendingDataChars += message.data.length;
+          // Drop oldest chunks beyond the cap (keeps the most recent output)
+          while (pendingDataChars > PENDING_DATA_MAX_CHARS && pendingData.length > 1) {
+            const dropped = pendingData.shift();
+            pendingDataChars -= dropped?.length ?? 0;
+          }
+        }
         return;
       case 'exit':
         if (!creationCompleted) {

--- a/src/main/services/terminal/ptyHelperRuntime.ts
+++ b/src/main/services/terminal/ptyHelperRuntime.ts
@@ -34,7 +34,10 @@ export function createPtyHelperRuntime(
   let creationReported = false;
   let helperExited = false;
   let destroyRequested = false;
+  // Cap output buffered before the 'created' event is sent (drop oldest chunks)
+  const PENDING_DATA_MAX_CHARS = 2 * 1024 * 1024;
   const pendingData: string[] = [];
+  let pendingDataChars = 0;
   let sendQueue = Promise.resolve();
 
   const sendEvent = (event: PtyHelperEvent): void => {
@@ -85,6 +88,11 @@ export function createPtyHelperRuntime(
       dataDisposable = spawned.onData((data) => {
         if (!creationReported) {
           pendingData.push(data);
+          pendingDataChars += data.length;
+          while (pendingDataChars > PENDING_DATA_MAX_CHARS && pendingData.length > 1) {
+            const dropped = pendingData.shift();
+            pendingDataChars -= dropped?.length ?? 0;
+          }
           return;
         }
         sendEvent({ type: 'data', data });
@@ -101,6 +109,7 @@ export function createPtyHelperRuntime(
 
       sendEvent({ type: 'created', ptyPid: spawned.pid });
       creationReported = true;
+      pendingDataChars = 0;
       for (const data of pendingData.splice(0)) {
         sendEvent({ type: 'data', data });
       }

--- a/src/main/services/updater/AutoUpdater.ts
+++ b/src/main/services/updater/AutoUpdater.ts
@@ -29,6 +29,7 @@ class AutoUpdaterService {
   private updateDownloaded = false;
   private _isQuittingForUpdate = false;
   private checkIntervalId: NodeJS.Timeout | null = null;
+  private initialCheckTimer: NodeJS.Timeout | null = null;
   private lastCheckTime = 0;
   private onFocusHandler: (() => void) | null = null;
 
@@ -106,6 +107,14 @@ class AutoUpdaterService {
     };
     window.on('focus', this.onFocusHandler);
 
+    // Release the reference when the window closes so it can be GC'd
+    window.once('closed', () => {
+      if (this.mainWindow === window) {
+        this.mainWindow = null;
+        this.onFocusHandler = null;
+      }
+    });
+
     // Apply initial auto-update setting
     this.setAutoUpdateEnabled(autoUpdateEnabled);
   }
@@ -115,10 +124,16 @@ class AutoUpdaterService {
       clearInterval(this.checkIntervalId);
       this.checkIntervalId = null;
     }
+    if (this.initialCheckTimer) {
+      clearTimeout(this.initialCheckTimer);
+      this.initialCheckTimer = null;
+    }
     if (this.mainWindow && this.onFocusHandler) {
       this.mainWindow.off('focus', this.onFocusHandler);
       this.onFocusHandler = null;
     }
+    // Release the window reference so a closed window can be garbage collected
+    this.mainWindow = null;
   }
 
   private sendStatus(status: UpdateStatus): void {
@@ -179,11 +194,19 @@ class AutoUpdaterService {
           this.checkForUpdates();
         }, CHECK_INTERVAL_MS);
       }
-      setTimeout(() => this.checkForUpdates(), 3000);
+      if (this.initialCheckTimer) clearTimeout(this.initialCheckTimer);
+      this.initialCheckTimer = setTimeout(() => {
+        this.initialCheckTimer = null;
+        this.checkForUpdates();
+      }, 3000);
     } else {
       if (this.checkIntervalId) {
         clearInterval(this.checkIntervalId);
         this.checkIntervalId = null;
+      }
+      if (this.initialCheckTimer) {
+        clearTimeout(this.initialCheckTimer);
+        this.initialCheckTimer = null;
       }
     }
   }

--- a/src/main/utils/shell.ts
+++ b/src/main/utils/shell.ts
@@ -155,6 +155,9 @@ export interface ExecInPtyOptions {
   killOnTimeout?: boolean;
 }
 
+// Upper bound for output collected by execInPty (detection commands are short)
+const MAX_EXEC_OUTPUT_CHARS = 512 * 1024;
+
 /**
  * Execute command in PTY to load user's environment (PATH, nvm, mise, volta, etc.)
  * Uses the same mechanism as terminal sessions to ensure consistent behavior.
@@ -232,6 +235,11 @@ export async function execInPty(command: string, options: ExecInPtyOptions = {})
 
       dataDisposable = ptyProcess.onData((data) => {
         output += data;
+        // Cap collected output (keep the tail): a chatty command must not
+        // accumulate an unbounded string in the main process
+        if (output.length > MAX_EXEC_OUTPUT_CHARS) {
+          output = output.slice(-Math.floor(MAX_EXEC_OUTPUT_CHARS / 2));
+        }
       });
 
       exitDisposable = ptyProcess.onExit(({ exitCode }) => {

--- a/src/main/windows/AgentTaskPanelWindow.ts
+++ b/src/main/windows/AgentTaskPanelWindow.ts
@@ -91,6 +91,12 @@ export function createAgentTaskPanelWindow(): BrowserWindow {
 
   agentTaskPanelWindow.on('resize', debouncedSaveBounds);
   agentTaskPanelWindow.on('move', debouncedSaveBounds);
+  agentTaskPanelWindow.once('closed', () => {
+    if (saveTimeout) {
+      clearTimeout(saveTimeout);
+      saveTimeout = null;
+    }
+  });
 
   // Load the agent task panel entry
   if (is.dev && process.env.ELECTRON_RENDERER_URL) {
@@ -148,4 +154,10 @@ export function resetAgentTaskPanelBounds(): void {
 
 export function setMainWindowRef(ref: BrowserWindow): void {
   mainWindowRef = ref;
+  // Release the reference when the window closes so it can be garbage collected
+  ref.once('closed', () => {
+    if (mainWindowRef === ref) {
+      mainWindowRef = null;
+    }
+  });
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -797,8 +797,11 @@ const electronAPI = {
       return () => ipcRenderer.off(IPC_CHANNELS.AGENT_TASK_PANEL_VISIBILITY_CHANGED, handler);
     },
     onGetSnapshot: (callback: () => void): (() => void) => {
-      ipcRenderer.on(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT, callback);
-      return () => ipcRenderer.off(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT, callback);
+      // Wrap in a stable handler like every other on* API so unsubscribe always
+      // removes the exact listener that was registered
+      const handler = () => callback();
+      ipcRenderer.on(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT, handler);
+      return () => ipcRenderer.off(IPC_CHANNELS.AGENT_TASK_GET_SNAPSHOT, handler);
     },
     sendSnapshotResponse: (snapshot: Record<string, unknown>): void => {
       ipcRenderer.send(IPC_CHANNELS.AGENT_TASK_SNAPSHOT_RESPONSE, snapshot);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -92,7 +92,9 @@ import { initCloneProgressListener } from './stores/cloneTasks';
 import { useEditorStore } from './stores/editor';
 import { useInitScriptStore } from './stores/initScript';
 import { useSettingsStore } from './stores/settings';
+import { useSourceControlStore } from './stores/sourceControl';
 import { useTempWorkspaceStore } from './stores/tempWorkspace';
+import { useTodoStore } from './stores/todo';
 import { useWorktreeStore } from './stores/worktree';
 import { initAgentActivityListener, useWorktreeActivityStore } from './stores/worktreeActivity';
 
@@ -533,6 +535,8 @@ export default function App() {
     (repoPath: string) => {
       const updated = repositories.filter((r) => r.path !== repoPath);
       saveRepositories(updated);
+      // Drop the repo's in-memory todo cache (SQLite data stays on disk)
+      useTodoStore.getState().unloadRepo(repoPath);
       // Clear selection if removed repo was selected
       if (selectedRepo === repoPath) {
         setSelectedRepo(null);
@@ -654,6 +658,7 @@ export default function App() {
       removeTempWorkspace(id);
       clearEditorWorktreeState(target.path);
       clearWorktreeActivity(target.path);
+      useSourceControlStore.getState().clearRootFolders(target.path);
 
       if (activeWorktree?.path === target.path) {
         const remaining = tempWorkspaces.filter((item) => item.id !== id);
@@ -947,6 +952,7 @@ export default function App() {
         closeAgentSessions(worktree.path);
         closeTerminalSessions(worktree.path);
         clearWorktreeActivity(worktree.path);
+        useSourceControlStore.getState().clearRootFolders(worktree.path);
         // Clear editor state for the removed worktree
         clearEditorWorktreeState(worktree.path);
         // Clear selection if the active worktree was removed

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -941,6 +941,12 @@ export default function App() {
         },
       })
       .then(() => {
+        // Close agent/terminal sessions and clear per-worktree store entries.
+        // Without this, sessions of the removed worktree stay in the stores
+        // (and persist to localStorage) for the rest of the app lifetime.
+        closeAgentSessions(worktree.path);
+        closeTerminalSessions(worktree.path);
+        clearWorktreeActivity(worktree.path);
         // Clear editor state for the removed worktree
         clearEditorWorktreeState(worktree.path);
         // Clear selection if the active worktree was removed

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -1161,11 +1161,16 @@ export function AgentTerminal({
     return () => container.removeEventListener('contextmenu', handleContextMenu);
   }, [handleContextMenu, containerRef]);
 
-  // Cleanup idle timer on unmount
+  // Cleanup idle/enter-delay timers on unmount
   useEffect(() => {
     return () => {
       if (idleTimerRef.current) {
         clearTimeout(idleTimerRef.current);
+        idleTimerRef.current = null;
+      }
+      if (enterDelayTimerRef.current) {
+        clearTimeout(enterDelayTimerRef.current);
+        enterDelayTimerRef.current = null;
       }
     };
   }, []);

--- a/src/renderer/components/files/EditorArea.tsx
+++ b/src/renderer/components/files/EditorArea.tsx
@@ -55,11 +55,11 @@ import { setupDoubleClickScope } from './editorScopeSelection';
 import { isImageFile, isPdfFile } from './fileIcons';
 import { ImagePreview } from './ImagePreview';
 import { MarkdownPreview } from './MarkdownPreview';
+// Monaco setup side effects + runtime instance for model management
+import { monaco as monacoRuntime } from './monacoSetup';
 import { CUSTOM_THEME_NAME, defineMonacoTheme } from './monacoTheme';
 import { PdfPreview } from './PdfPreview';
 import { useEditorBlame } from './useEditorBlame';
-// Import for side effects (Monaco setup)
-import './monacoSetup';
 
 type Monaco = typeof monaco;
 
@@ -330,6 +330,51 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
       if (editNavTimerRef.current) clearTimeout(editNavTimerRef.current);
     };
   }, []);
+
+  // Dispose Monaco models for files no longer open in any tab.
+  // @monaco-editor/react caches models per `path` and never disposes them, so
+  // every file ever opened would otherwise stay in memory for the whole session.
+  // Models for open tabs are kept (preserves undo history); dirty tabs saved in
+  // other worktrees are kept too so unsaved edits are never destroyed.
+  useEffect(() => {
+    const keepUris = new Set<string>(tabs.map((tab) => toMonacoFileUri(tab.path)));
+    const { worktreeStates } = useEditorStore.getState();
+    for (const state of Object.values(worktreeStates)) {
+      for (const tab of state.tabs) {
+        if (tab.isDirty) keepUris.add(toMonacoFileUri(tab.path));
+      }
+    }
+    for (const model of monacoRuntime.editor.getModels()) {
+      if (model.uri.scheme !== 'file') continue;
+      if (keepUris.has(model.uri.toString())) continue;
+      if (model.isAttachedToEditor()) continue;
+      model.dispose();
+    }
+  }, [tabs]);
+
+  // Reload content for tabs whose text was unloaded during a worktree switch
+  useEffect(() => {
+    const path = activeTab?.path;
+    if (!path || !activeTab?.contentUnloaded) return;
+    let cancelled = false;
+    void window.electronAPI.file.read(path).then(
+      ({ content, isBinary }) => {
+        if (cancelled) return;
+        const store = useEditorStore.getState();
+        const tab = store.tabs.find((t) => t.path === path);
+        if (!tab?.contentUnloaded) return;
+        store.updateFileContent(path, isBinary ? '' : content, false);
+      },
+      () => {
+        if (cancelled) return;
+        // File may have been deleted externally; show the tab as empty
+        useEditorStore.getState().updateFileContent(path, '', false);
+      }
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab?.path, activeTab?.contentUnloaded]);
 
   // Set editor value without triggering the onChange handler (not treated as user input)
   const setEditorValueProgrammatically = useCallback(
@@ -663,7 +708,8 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
 
       editor.onDidDispose(() => searchDisposable.dispose());
 
-      setupDoubleClickScope(editor);
+      const doubleClickDisposable = setupDoubleClickScope(editor);
+      editor.onDidDispose(() => doubleClickDisposable.dispose());
 
       definitionNavDisposableRef.current?.dispose();
       definitionNavDisposableRef.current = setupDefinitionNavigation(
@@ -1458,6 +1504,10 @@ export const EditorArea = forwardRef<EditorAreaRef, EditorAreaProps>(function Ed
                 <ImagePreview path={activeTab.path} />
               ) : isPdf ? (
                 <PdfPreview path={activeTab.path} />
+              ) : activeTab.contentUnloaded ? (
+                // Content is being reloaded from disk after a worktree switch;
+                // don't mount the editor with empty text (would pollute undo)
+                <div className="h-full w-full" />
               ) : (
                 <Editor
                   width="100%"

--- a/src/renderer/components/source-control/DiffViewer.tsx
+++ b/src/renderer/components/source-control/DiffViewer.tsx
@@ -165,13 +165,18 @@ export function DiffViewer({
   const diff = externalDiff ?? fetchedDiff;
 
   const editorRef = useRef<DiffEditorInstance | null>(null);
-  const modelsRef = useRef<{
-    original: ReturnType<typeof monaco.editor.createModel> | null;
-    modified: ReturnType<typeof monaco.editor.createModel> | null;
-  }>({
-    original: null,
-    modified: null,
-  });
+  // Everything created during one DiffEditor mount (listeners, timers, models).
+  // The DiffEditor remounts via `key` without unmounting DiffViewer, so this state
+  // must be disposed manually on the next mount and on DiffViewer unmount —
+  // @monaco-editor/react ignores values returned from onMount, and keepCurrent*
+  // prevents the library from disposing models itself.
+  const mountStateRef = useRef<{
+    disposables: { dispose: () => void }[];
+    original: monaco.editor.ITextModel | null;
+    modified: monaco.editor.ITextModel | null;
+    timers: ReturnType<typeof setTimeout>[];
+    intervals: ReturnType<typeof setInterval>[];
+  } | null>(null);
   const editorFilePathRef = useRef<string | null>(null); // Track which file the current editor is displaying
   const [currentDiffIndex, setCurrentDiffIndex] = useState(-1);
   const [lineChanges, setLineChanges] = useState<ReturnType<DiffEditorInstance['getLineChanges']>>(
@@ -807,6 +812,43 @@ export function DiffViewer({
     [setNavigationDirection, highlightCurrentDiff]
   );
 
+  // Dispose listeners/timers/models recorded for the previous DiffEditor mount.
+  // Models reused by the next mount (same URI returns the same instance) are kept.
+  const cleanupMountState = useCallback(
+    (keep?: {
+      original: monaco.editor.ITextModel | null;
+      modified: monaco.editor.ITextModel | null;
+    }) => {
+      const state = mountStateRef.current;
+      if (!state) return;
+      mountStateRef.current = null;
+      for (const timer of state.timers) clearTimeout(timer);
+      for (const interval of state.intervals) clearInterval(interval);
+      for (const disposable of state.disposables) {
+        try {
+          disposable.dispose();
+        } catch {
+          // Editor may already be disposed by the library
+        }
+      }
+      for (const model of [state.original, state.modified]) {
+        if (!model || model.isDisposed()) continue;
+        if (keep && (model === keep.original || model === keep.modified)) continue;
+        try {
+          model.dispose();
+        } catch {
+          // Ignore disposal races
+        }
+      }
+    },
+    []
+  );
+
+  // Dispose the last mount's resources when DiffViewer itself unmounts
+  useEffect(() => {
+    return () => cleanupMountState();
+  }, [cleanupMountState]);
+
   const handleEditorMount = useCallback(
     (editor: DiffEditorInstance) => {
       editorRef.current = editor;
@@ -818,15 +860,22 @@ export function DiffViewer({
       scheduleApplyHideUnchangedRegions(editor);
 
       const currentModel = editor.getModel();
-      const mountedModels = currentModel
-        ? { original: currentModel.original, modified: currentModel.modified }
-        : null;
-      if (currentModel) {
-        modelsRef.current.original = currentModel.original;
-        modelsRef.current.modified = currentModel.modified;
-      }
+      // The previous editor (if any) is already disposed at this point; release
+      // its listeners and models unless the new mount reuses the same models.
+      cleanupMountState({
+        original: currentModel?.original ?? null,
+        modified: currentModel?.modified ?? null,
+      });
+      const mountState: NonNullable<typeof mountStateRef.current> = {
+        disposables: [],
+        original: currentModel?.original ?? null,
+        modified: currentModel?.modified ?? null,
+        timers: [],
+        intervals: [],
+      };
+      mountStateRef.current = mountState;
 
-      const disposables: { dispose: () => void }[] = [];
+      const disposables = mountState.disposables;
 
       disposables.push(
         editor.onDidUpdateDiff(() => {
@@ -860,7 +909,7 @@ export function DiffViewer({
         })
       );
 
-      setTimeout(() => {
+      const navTimer = setTimeout(() => {
         const pendingDirection = pendingNavigationDirectionRef.current;
         if (pendingDirection && !hasAutoNavigatedRef.current) {
           const changes = editor.getLineChanges();
@@ -883,24 +932,13 @@ export function DiffViewer({
                 clearInterval(pollTimer);
               }
             }, 50);
+            mountState.intervals.push(pollTimer);
           }
         }
       }, 0);
-
-      return () => {
-        for (const d of disposables) {
-          d.dispose();
-        }
-        // Prevent commit-view Monaco models from accumulating in memory.
-        // We intentionally keep worktree models cached for performance, but commit history
-        // can generate many unique models (commitHash scoped URIs), so dispose on unmount.
-        if (isCommitView && mountedModels) {
-          mountedModels.original?.dispose();
-          mountedModels.modified?.dispose();
-        }
-      };
+      mountState.timers.push(navTimer);
     },
-    [file?.path, performAutoNavigation, isCommitView, scheduleApplyHideUnchangedRegions]
+    [file?.path, performAutoNavigation, scheduleApplyHideUnchangedRegions, cleanupMountState]
   );
 
   // Toggle hide unchanged regions
@@ -1386,7 +1424,8 @@ export function DiffViewer({
                 enabled: hideUnchangedRegions,
               },
             }}
-            // Prevent library from disposing models before DiffEditorWidget resets
+            // Prevent library from disposing models before DiffEditorWidget resets.
+            // Models are disposed manually via cleanupMountState on remount/unmount.
             keepCurrentOriginalModel
             keepCurrentModifiedModel
           />

--- a/src/renderer/components/source-control/SourceControlPanel.tsx
+++ b/src/renderer/components/source-control/SourceControlPanel.tsx
@@ -307,6 +307,12 @@ export function SourceControlPanel({
   const selectedRepoPath =
     selectedSubmodulePath && rootPath ? joinPath(rootPath, selectedSubmodulePath) : rootPath;
 
+  // Scope the changes-tree folder expand state to the current worktree/submodule
+  const setActiveExpandRoot = useSourceControlStore((s) => s.setActiveRoot);
+  useEffect(() => {
+    setActiveExpandRoot(selectedRepoPath ?? null);
+  }, [selectedRepoPath, setActiveExpandRoot]);
+
   // Refetch immediately when tab becomes active
   useEffect(() => {
     if (isActive && rootPath) {

--- a/src/renderer/components/worktree/MergeEditor.tsx
+++ b/src/renderer/components/worktree/MergeEditor.tsx
@@ -425,12 +425,28 @@ export function MergeEditor({
     });
   }, []);
 
+  const scrollSyncDisposablesRef = useRef(new Map<EditorInstance, { dispose: () => void }>());
+
   const setupScrollSync = useCallback(
     (editor: EditorInstance) => {
-      editor.onDidScrollChange(() => handleScroll(editor));
+      // Dispose a previous registration for this editor (guards double setup)
+      scrollSyncDisposablesRef.current.get(editor)?.dispose();
+      const disposable = editor.onDidScrollChange(() => handleScroll(editor));
+      scrollSyncDisposablesRef.current.set(editor, disposable);
     },
     [handleScroll]
   );
+
+  // Dispose scroll-sync listeners on unmount
+  useEffect(() => {
+    const disposables = scrollSyncDisposablesRef.current;
+    return () => {
+      for (const disposable of disposables.values()) {
+        disposable.dispose();
+      }
+      disposables.clear();
+    };
+  }, []);
 
   // Navigate to chunk
   const navigateToChunk = useCallback(

--- a/src/renderer/hooks/useSharedFileWatch.ts
+++ b/src/renderer/hooks/useSharedFileWatch.ts
@@ -6,10 +6,14 @@ type FileChangeEvent = {
   path: string;
 };
 
+type ChangeCallbackRef = { current: (event: FileChangeEvent) => void };
+
 type WatchEntry = {
   dirPath: string;
   normalizedDirPath: string;
   refCount: number;
+  // All subscribers' callbacks; the single IPC listener dispatches to each one
+  callbacks: Set<ChangeCallbackRef>;
   stop?: () => void;
 };
 
@@ -39,24 +43,33 @@ export function useSharedFileWatch(
     const key = normalizedDirPath;
     let entry = watches.get(key);
     if (!entry) {
-      entry = { dirPath, normalizedDirPath, refCount: 0 };
+      entry = { dirPath, normalizedDirPath, refCount: 0, callbacks: new Set() };
       watches.set(key, entry);
     }
     entry.refCount += 1;
+    // Register this subscriber's callback: previously only the first subscriber
+    // received events because the IPC listener captured a single onChangeRef
+    entry.callbacks.add(onChangeRef);
 
     if (!entry.stop) {
+      const currentEntry = entry;
+      const dispatch = (event: FileChangeEvent) => {
+        for (const callback of currentEntry.callbacks) {
+          callback.current(event);
+        }
+      };
       void window.electronAPI.file.watchStart(dirPath);
       const unsubscribe = window.electronAPI.file.onChange((event) => {
         const eventPath = normalizeWatchedPath(event.path);
         // Deliver only events under the watched dir (or the bulk marker inside it)
         if (eventPath === key || eventPath.startsWith(`${key}/`)) {
-          onChangeRef.current(event);
+          dispatch(event);
           return;
         }
 
         // Bulk marker: allow delivery even if the watcher reports a different prefix.
         if (getPathBasename(eventPath) === '.enso-bulk') {
-          onChangeRef.current(event);
+          dispatch(event);
         }
       });
       entry.stop = () => {
@@ -69,6 +82,7 @@ export function useSharedFileWatch(
       const current = watches.get(key);
       if (!current) return;
       current.refCount -= 1;
+      current.callbacks.delete(onChangeRef);
       if (current.refCount <= 0) {
         current.stop?.();
         watches.delete(key);

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -199,6 +199,9 @@ export function useXterm({
   // rAF write buffer for smooth rendering
   const writeBufferRef = useRef('');
   const isFlushPendingRef = useRef(false);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exitFlushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const compositionCleanupRef = useRef<(() => void) | null>(null);
 
   const write = useCallback((data: string) => {
     if (ptyIdRef.current) {
@@ -338,12 +341,16 @@ export function useXterm({
     // IME compositionend 兜底：清空 textarea 防止旧内容残留导致输入异常
     const textarea = terminal.textarea;
     if (textarea) {
-      textarea.addEventListener('compositionend', () => {
+      const handleCompositionEnd = () => {
         // 延迟清空，确保 xterm 先读取最终文本
         setTimeout(() => {
           textarea.value = '';
         }, 0);
-      });
+      };
+      textarea.addEventListener('compositionend', handleCompositionEnd);
+      compositionCleanupRef.current = () => {
+        textarea.removeEventListener('compositionend', handleCompositionEnd);
+      };
     }
 
     // Listen for title changes (OSC escape sequences)
@@ -647,7 +654,14 @@ export function useXterm({
 
           if (!isFlushPendingRef.current) {
             isFlushPendingRef.current = true;
-            setTimeout(() => {
+            flushTimerRef.current = setTimeout(() => {
+              flushTimerRef.current = null;
+              // Guard: the terminal may have been disposed while this flush was queued
+              if (terminalRef.current !== terminal) {
+                writeBufferRef.current = '';
+                isFlushPendingRef.current = false;
+                return;
+              }
               if (writeBufferRef.current.length > 0) {
                 const bufferedData = writeBufferRef.current;
 
@@ -692,7 +706,10 @@ export function useXterm({
       const exitCleanup = window.electronAPI.terminal.onExit((event) => {
         if (event.id === ptyId) {
           // Wait for any pending data events to arrive (IPC race condition)
-          setTimeout(() => {
+          exitFlushTimerRef.current = setTimeout(() => {
+            exitFlushTimerRef.current = null;
+            // Guard: the terminal may have been disposed while this was queued
+            if (terminalRef.current !== terminal) return;
             // Flush any remaining buffered data
             if (writeBufferRef.current.length > 0) {
               const bufferedData = writeBufferRef.current;
@@ -781,6 +798,17 @@ export function useXterm({
       createRequestIdRef.current += 1;
       cleanupRef.current?.();
       exitCleanupRef.current?.();
+      // Cancel pending flush timers and drop buffered output
+      if (flushTimerRef.current) {
+        clearTimeout(flushTimerRef.current);
+        flushTimerRef.current = null;
+      }
+      if (exitFlushTimerRef.current) {
+        clearTimeout(exitFlushTimerRef.current);
+        exitFlushTimerRef.current = null;
+      }
+      writeBufferRef.current = '';
+      isFlushPendingRef.current = false;
       if (ptyIdRef.current) {
         window.electronAPI.terminal.destroy(ptyIdRef.current);
         ptyIdRef.current = null;
@@ -793,6 +821,9 @@ export function useXterm({
         );
         copyOnSelectionHandlerRef.current = null;
       }
+      // Remove IME compositionend listener from the terminal textarea
+      compositionCleanupRef.current?.();
+      compositionCleanupRef.current = null;
       // Dispose addons before terminal to prevent async callback errors
       linkProviderDisposableRef.current?.dispose();
       linkProviderDisposableRef.current = null;
@@ -838,13 +869,11 @@ export function useXterm({
       }
     };
 
-    const debouncedResize = (() => {
-      let timeout: ReturnType<typeof setTimeout>;
-      return () => {
-        clearTimeout(timeout);
-        timeout = setTimeout(handleResize, 50);
-      };
-    })();
+    let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
+    const debouncedResize = () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = setTimeout(handleResize, 50);
+    };
 
     window.addEventListener('resize', debouncedResize);
 
@@ -863,6 +892,7 @@ export function useXterm({
     }
 
     return () => {
+      clearTimeout(resizeTimeout);
       window.removeEventListener('resize', debouncedResize);
       observer.disconnect();
       intersectionObserver.disconnect();

--- a/src/renderer/stores/agentSessions.ts
+++ b/src/renderer/stores/agentSessions.ts
@@ -127,10 +127,13 @@ function saveToStorage(sessions: Session[], activeIds: Record<string, string | n
   // Codex 必须先拿到真实 CLI 会话号，否则重启后只能误开成一段新对话。
   const persistableSessions = filterPersistableAgentSessions(sessions);
   const persistableIds = new Set(persistableSessions.map((s) => s.id));
-  // Only keep activeIds that reference persistable sessions
+  // Only keep activeIds that reference persistable sessions; skip null entries
+  // so stale repo::cwd keys don't accumulate in localStorage forever
   const persistableActiveIds: Record<string, string | null> = {};
   for (const [cwd, id] of Object.entries(activeIds)) {
-    persistableActiveIds[cwd] = id && persistableIds.has(id) ? id : null;
+    if (id && persistableIds.has(id)) {
+      persistableActiveIds[cwd] = id;
+    }
   }
   localStorage.setItem(
     SESSIONS_STORAGE_KEY,
@@ -225,16 +228,28 @@ export const useAgentSessionsStore = create<AgentSessionsState>()(
           if (removedSession.sessionId && removedSession.sessionId !== removedSession.id) {
             clearStatus(removedSession.sessionId);
           }
+          if (removedSession.cliSessionId) {
+            clearStatus(removedSession.cliSessionId);
+          }
         }
 
         const newSessions = state.sessions.filter((s) => s.id !== id);
+        // Composite keys of worktrees that still have sessions
+        const liveKeys = new Set(newSessions.map((s) => makeActiveKey(s.repoPath, s.cwd)));
         let newActiveIds = state.activeIds;
-        for (const [cwd, activeId] of Object.entries(state.activeIds)) {
-          if (activeId !== id) continue;
+        for (const [key, activeId] of Object.entries(state.activeIds)) {
+          const shouldDrop = !liveKeys.has(key);
+          if (activeId !== id && !shouldDrop) continue;
           if (newActiveIds === state.activeIds) {
             newActiveIds = { ...state.activeIds };
           }
-          newActiveIds[cwd] = null;
+          if (shouldDrop) {
+            // No sessions left under this worktree: drop the key entirely so
+            // activeIds doesn't accumulate an entry per repo::cwd forever
+            delete newActiveIds[key];
+          } else {
+            newActiveIds[key] = null;
+          }
         }
         // Clean up runtime states
         const newRuntimeStates = { ...state.runtimeStates };

--- a/src/renderer/stores/agentStatus.ts
+++ b/src/renderer/stores/agentStatus.ts
@@ -45,20 +45,32 @@ interface AgentStatusStore {
   getStatus: (sessionId: string) => StatusData | undefined;
 }
 
+// Status updates arrive for ANY Claude session on the machine (the status-line
+// hook is installed globally), so entries must be capped or they grow forever.
+const MAX_STATUS_ENTRIES = 100;
+
 export const useAgentStatusStore = create<AgentStatusStore>((set, get) => ({
   statuses: {},
 
   updateStatus: (sessionId, data) =>
-    set((state) => ({
-      statuses: {
+    set((state) => {
+      const statuses: Record<string, StatusData> = {
         ...state.statuses,
         [sessionId]: {
           ...state.statuses[sessionId],
           ...data,
           updatedAt: Date.now(),
         } as StatusData,
-      },
-    })),
+      };
+      const keys = Object.keys(statuses);
+      if (keys.length > MAX_STATUS_ENTRIES) {
+        keys.sort((a, b) => (statuses[a].updatedAt ?? 0) - (statuses[b].updatedAt ?? 0));
+        for (const key of keys.slice(0, keys.length - MAX_STATUS_ENTRIES)) {
+          delete statuses[key];
+        }
+      }
+      return { statuses };
+    }),
 
   clearStatus: (sessionId) =>
     set((state) => {

--- a/src/renderer/stores/agentTasks.ts
+++ b/src/renderer/stores/agentTasks.ts
@@ -310,12 +310,48 @@ export const useAgentTasksStore = create<AgentTasksState>()(
           };
         }
 
-        if (areAgentTaskRecordsEqual(state.tasks, newTasks)) {
+        // Prune per-session auxiliary records for sessions that no longer exist.
+        // Without this, startTimes/completionTimes/waitingReasons/descriptions
+        // grow for the app lifetime (descriptions even persist to localStorage).
+        const liveIds = new Set(sessions.map((s) => s.id));
+        const pruneRecord = <T>(record: Record<string, T>): Record<string, T> => {
+          let changed = false;
+          const next: Record<string, T> = {};
+          for (const [key, value] of Object.entries(record)) {
+            if (liveIds.has(key)) next[key] = value;
+            else changed = true;
+          }
+          return changed ? next : record;
+        };
+
+        const newStartTimes = pruneRecord(state.startTimes);
+        const newCompletionTimes = pruneRecord(state.completionTimes);
+        const newWaitingReasons = pruneRecord(state.waitingReasons);
+        const newDescriptions = pruneRecord(state.descriptions);
+        if (newDescriptions !== state.descriptions) {
+          saveDescriptions(newDescriptions);
+        }
+
+        const auxChanged =
+          newStartTimes !== state.startTimes ||
+          newCompletionTimes !== state.completionTimes ||
+          newWaitingReasons !== state.waitingReasons ||
+          newDescriptions !== state.descriptions;
+        const tasksEqual = areAgentTaskRecordsEqual(state.tasks, newTasks);
+
+        if (tasksEqual && !auxChanged) {
           return state;
         }
 
-        const derived = computeDerivedArrays(newTasks);
-        return { tasks: newTasks, ...derived };
+        const derived = tasksEqual ? {} : computeDerivedArrays(newTasks);
+        return {
+          tasks: tasksEqual ? state.tasks : newTasks,
+          startTimes: newStartTimes,
+          completionTimes: newCompletionTimes,
+          waitingReasons: newWaitingReasons,
+          descriptions: newDescriptions,
+          ...derived,
+        };
       });
     },
 

--- a/src/renderer/stores/editor.ts
+++ b/src/renderer/stores/editor.ts
@@ -11,6 +11,8 @@ export interface EditorTab {
   // External change conflict: set when file is modified externally while user has unsaved edits
   hasExternalChange?: boolean;
   externalContent?: string;
+  // Content was unloaded to save memory (worktree switch); reload from disk before display
+  contentUnloaded?: boolean;
 }
 
 export interface PendingCursor {
@@ -101,6 +103,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
                   // Clear external change state on explicit file open (fresh load)
                   hasExternalChange: false,
                   externalContent: undefined,
+                  contentUnloaded: false,
                 }
               : tab
           ),
@@ -113,6 +116,7 @@ export const useEditorStore = create<EditorState>((set, get) => ({
           {
             ...file,
             title: file.title ?? getTabTitle(file.path),
+            contentUnloaded: false,
           },
         ],
         activeTabPath: file.path,
@@ -173,7 +177,9 @@ export const useEditorStore = create<EditorState>((set, get) => ({
 
   updateFileContent: (path, content, isDirty = true) =>
     set((state) => ({
-      tabs: state.tabs.map((tab) => (tab.path === path ? { ...tab, content, isDirty } : tab)),
+      tabs: state.tabs.map((tab) =>
+        tab.path === path ? { ...tab, content, isDirty, contentUnloaded: false } : tab
+      ),
     })),
 
   markFileSaved: (path) =>
@@ -304,13 +310,20 @@ export const useEditorStore = create<EditorState>((set, get) => ({
     const state = get();
     const currentPath = state.currentWorktreePath;
 
-    // Save current worktree state (if we have one)
+    // Save current worktree state (if we have one).
+    // Unload contents of non-dirty tabs: keeping full file texts for every
+    // visited worktree grows memory without bound. Content is reloaded from
+    // disk when the worktree becomes active again (see EditorArea).
     let newWorktreeStates = state.worktreeStates;
     if (currentPath) {
       newWorktreeStates = {
         ...newWorktreeStates,
         [currentPath]: {
-          tabs: state.tabs,
+          tabs: state.tabs.map((tab) =>
+            tab.isDirty || tab.content.length === 0
+              ? tab
+              : { ...tab, content: '', contentUnloaded: true }
+          ),
           activeTabPath: state.activeTabPath,
         },
       };

--- a/src/renderer/stores/sourceControl.ts
+++ b/src/renderer/stores/sourceControl.ts
@@ -15,9 +15,19 @@ interface SourceControlState {
   setNavigationDirection: (direction: NavigationDirection) => void;
   viewMode: ViewMode;
   setViewMode: (mode: ViewMode) => void;
+  // Expanded folders of the active worktree (view over expandedByRoot)
   expandedFolders: Set<string>;
+  // Expanded folder paths stored per worktree root, so different worktrees
+  // don't share/pollute each other's expand state
+  expandedByRoot: Record<string, Set<string>>;
+  activeRoot: string | null;
+  setActiveRoot: (rootPath: string | null) => void;
   toggleFolder: (path: string) => void;
+  // Drop stored expand state for a removed worktree
+  clearRootFolders: (rootPath: string) => void;
 }
+
+const EMPTY_EXPANDED = new Set<string>();
 
 export const useSourceControlStore = create<SourceControlState>((set) => ({
   selectedFile: null,
@@ -26,15 +36,40 @@ export const useSourceControlStore = create<SourceControlState>((set) => ({
   setNavigationDirection: (navigationDirection) => set({ navigationDirection }),
   viewMode: 'list',
   setViewMode: (viewMode) => set({ viewMode }),
-  expandedFolders: new Set<string>(),
+  expandedFolders: EMPTY_EXPANDED,
+  expandedByRoot: {},
+  activeRoot: null,
+
+  setActiveRoot: (rootPath) =>
+    set((state) => {
+      if (state.activeRoot === rootPath) return state;
+      return {
+        activeRoot: rootPath,
+        expandedFolders: (rootPath && state.expandedByRoot[rootPath]) || EMPTY_EXPANDED,
+      };
+    }),
+
   toggleFolder: (path) =>
     set((state) => {
-      const newExpanded = new Set(state.expandedFolders);
+      const key = state.activeRoot ?? '';
+      const newExpanded = new Set(state.expandedByRoot[key] ?? state.expandedFolders);
       if (newExpanded.has(path)) {
         newExpanded.delete(path);
       } else {
         newExpanded.add(path);
       }
-      return { expandedFolders: newExpanded };
+      return {
+        expandedFolders: newExpanded,
+        expandedByRoot: { ...state.expandedByRoot, [key]: newExpanded },
+      };
+    }),
+
+  clearRootFolders: (rootPath) =>
+    set((state) => {
+      const { [rootPath]: _, ...rest } = state.expandedByRoot;
+      return {
+        expandedByRoot: rest,
+        ...(state.activeRoot === rootPath ? { expandedFolders: EMPTY_EXPANDED } : {}),
+      };
     }),
 }));

--- a/src/renderer/stores/todo.ts
+++ b/src/renderer/stores/todo.ts
@@ -30,6 +30,9 @@ interface TodoState {
   moveTask: (repoPath: string, taskId: string, newStatus: TaskStatus, newOrder: number) => void;
   reorderTasks: (repoPath: string, status: TaskStatus, orderedIds: string[]) => void;
 
+  /** Drop in-memory cache for a repo removed from the workspace (DB data stays) */
+  unloadRepo: (repoPath: string) => void;
+
   // Auto-Execute Actions
   startAutoExecute: (repoPath: string, taskIds: string[]) => void;
   stopAutoExecute: (repoPath: string) => void;
@@ -201,6 +204,20 @@ export const useTodoStore = create<TodoState>()(
       window.electronAPI.todo
         .reorderTasks(key, status, orderedIds)
         .catch((err) => console.error('[TodoStore] reorderTasks IPC failed:', err));
+    },
+
+    unloadRepo: (repoPath) => {
+      const key = getKey(repoPath);
+      set((state) => {
+        if (!(key in state.tasks) && !state._loaded.has(key) && !(key in state.autoExecute)) {
+          return state;
+        }
+        const { [key]: _, ...restTasks } = state.tasks;
+        const { [key]: __, ...restAutoExecute } = state.autoExecute;
+        const newLoaded = new Set(state._loaded);
+        newLoaded.delete(key);
+        return { tasks: restTasks, autoExecute: restAutoExecute, _loaded: newLoaded };
+      });
     },
 
     // Auto-Execute Actions

--- a/src/renderer/stores/worktreeActivity.ts
+++ b/src/renderer/stores/worktreeActivity.ts
@@ -229,7 +229,12 @@ export const useWorktreeActivityStore = create<WorktreeActivityState>()(
         // Clean up session mappings - agentSessions handles session cleanup
         const { [worktreePath]: _, ...restActivities } = state.activities;
         const { [worktreePath]: __, ...restActivityStates } = state.activityStates;
-        return { activities: restActivities, activityStates: restActivityStates };
+        const { [worktreePath]: ___, ...restDiffStats } = state.diffStats;
+        return {
+          activities: restActivities,
+          activityStates: restActivityStates,
+          diffStats: restDiffStats,
+        };
       }),
 
     // Close handler registry


### PR DESCRIPTION
## Summary

修复用户反馈的「长时间使用后内存持续增长、最终崩溃」问题。经排查，主因是渲染进程多处无界内存增长导致 OOM，PTY 原生层此前已有较完善防护。

### 渲染进程（OOM 主因）
- **Monaco model 泄露**：`DiffViewer` 的 commit diff 清理逻辑写在 `onMount` 返回值里（库不会调用，属死代码），且 `keepCurrent*` 关闭了库的默认释放——浏览提交历史时每个文件 diff 永久泄露 2 个 model；`EditorArea` 关闭 tab 从不 dispose model。两处均已改为正确的生命周期释放
- **编辑器全文缓存**：切换 worktree 时卸载非 dirty tab 的内容，切回按需从磁盘重读
- **Store 清理缺口**：删除 worktree 现在会关闭会话并清理 sessions/tasks/activity/diffStats（含 localStorage 持久化残留）；`agentTasks` 辅助记录随会话集合自动收敛；`agentStatus` 加上限（全局 hook 会收到任意 Claude 会话的状态）
- **定时器/监听器**：`useXterm` 的 flush 定时器与 `compositionend` 监听器成对清理，防止写入已 dispose 的终端；`AgentTerminal`、`MergeEditor` 等补齐
- `useSharedFileWatch` 顺带修复同目录多订阅者只有第一个能收到事件的 bug

### 主进程
- Claude IDE Bridge：`dispose` 时终止已连接的 WebSocket；`/agent-hook`、`/status-line` 请求体加 1MB 上限；节流 Map 加 TTL
- Windows PTY 激活前缓冲、`execInPty`/code review 输出缓冲加上限
- `gitServices`/`worktreeServices` 改为 LRU；GitAutoFetch/AutoUpdater 孤儿定时器收口；窗口关闭时释放 BrowserWindow 引用
- `FileWatcher` 防重入

### 崩溃观测（新增）
- `render-process-gone` / `child-process-gone` 写入日志（可区分 `oom` 与原生崩溃），渲染进程崩溃后自动 reload（10 秒防循环）
- `crashReporter` 保留本地 minidump

### 其他
- Todo store 随仓库移除清理内存缓存；源码控制展开状态按 worktree/子模块隔离

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm test` 与 main 基线一致（8 个既有失败均为 macOS 上运行 Windows 路径断言，与本次改动无关）
- [x] 改动文件 biome 检查零错误
- [ ] 手动回归：多 worktree 打开/关闭文件与 commit diff，观察 `monaco.editor.getModels()` 数量不再单调增长
- [ ] 手动回归：删除 worktree 后会话/任务面板无残留，重启后不再恢复已删 worktree 的会话
- [ ] 长时间使用后内存曲线对比（Activity Monitor / 任务管理器）

Made with [Cursor](https://cursor.com)