### PR TITLE
fix(terminal): 修复 Agent 终端布局与启动尺寸问题

### DIFF
--- a/src/renderer/components/chat/AgentPanel.tsx
+++ b/src/renderer/components/chat/AgentPanel.tsx
@@ -27,6 +27,7 @@ import { useTerminalStore } from '@/stores/terminal';
 import { useWorktreeActivityStore } from '@/stores/worktreeActivity';
 import { AgentGroup } from './AgentGroup';
 import { AgentTerminal } from './AgentTerminal';
+import { getTerminalBottomOffset } from './agentPanelLayout';
 import { CodexHistoryPanel } from './CodexHistoryPanel';
 import { CodexSessionPickerDialog, type CodexSessionSelection } from './CodexSessionPickerDialog';
 import { EnhancedInputContainer } from './EnhancedInputContainer';
@@ -189,7 +190,15 @@ const GroupBottomBar = memo(function GroupBottomBar({
     const observer = new ResizeObserver(report);
     observer.observe(el);
     report();
-    return () => observer.disconnect();
+    return () => {
+      observer.disconnect();
+      onHeightChange((prev) => {
+        if (!(groupId in prev)) return prev;
+        const next = { ...prev };
+        delete next[groupId];
+        return next;
+      });
+    };
   }, [groupId, onHeightChange]);
 
   return (
@@ -1467,14 +1476,6 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isActive, handleToggleQuickTerminal]);
 
-  const maxStatusLineHeight = useMemo(() => {
-    let max = 0;
-    for (const h of Object.values(statusLineHeightsByGroupId)) {
-      if (h > max) max = h;
-    }
-    return max;
-  }, [statusLineHeightsByGroupId]);
-
   const handleOpenCodexHistory = useCallback((session: Session) => {
     setHistorySourceSessionId(session.id);
     setHistorySessionWslDistro(session.codexWslDistro);
@@ -1703,11 +1704,8 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
       {/* All terminals - rendered in a SINGLE container with stable sessionId keys */}
       {/* This container is NOT inside any worktree-specific wrapper, ensuring stable mounting */}
       {/* All sessions across ALL repos are rendered here to keep them mounted */}
-      {/* bottom is dynamically set based on StatusLine height */}
-      <div
-        className="absolute top-2 left-2 right-2 z-0"
-        style={{ bottom: maxStatusLineHeight + 8 }}
-      >
+      {/* Each terminal wrapper reserves only its own group's bottom bar height. */}
+      <div className="absolute top-2 left-2 right-2 bottom-0 z-0">
         {Array.from(globalSessionIds).map((sessionId) => {
           const session = allSessions.find((s) => s.id === sessionId);
           if (!session) return null;
@@ -1744,16 +1742,18 @@ export function AgentPanel({ repoPath, cwd, isActive = false, onSwitchWorktree }
 
           // Only show terminals from current repo + current worktree + active session
           const shouldShow = isCurrentRepo && isCurrentWorktree && isSessionVisible;
+          const terminalBottomOffset = getTerminalBottomOffset(groupId, statusLineHeightsByGroupId);
 
           return (
             <div
               key={sessionId}
               className={
-                shouldShow ? 'absolute h-full' : 'absolute h-full opacity-0 pointer-events-none'
+                shouldShow ? 'absolute top-0' : 'absolute top-0 opacity-0 pointer-events-none'
               }
               style={{
                 left: `${left}%`,
                 width: `${width}%`,
+                bottom: terminalBottomOffset,
               }}
             >
               {/* Inactive overlay - like TerminalGroup */}

--- a/src/renderer/components/chat/agentPanelLayout.ts
+++ b/src/renderer/components/chat/agentPanelLayout.ts
@@ -1,0 +1,8 @@
+export const TERMINAL_BOTTOM_GAP_PX = 8;
+
+export function getTerminalBottomOffset(
+  groupId: string | null,
+  heightsByGroupId: Readonly<Record<string, number>>
+): number {
+  return TERMINAL_BOTTOM_GAP_PX + (groupId ? (heightsByGroupId[groupId] ?? 0) : 0);
+}

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -33,6 +33,63 @@ function hasVisibleContent(data: string): boolean {
   return stripped.trim().length > 0;
 }
 
+/**
+ * Wait until the element's size stays unchanged for N consecutive animation
+ * frames (or until the timeout expires).
+ *
+ * Full-screen TUIs (e.g. opencode) draw their splash screen once at PTY spawn
+ * based on the spawn-time cols/rows, so the PTY must not be spawned before the
+ * container reaches its final size - otherwise the TUI gets locked into a
+ * stale (smaller) layout that no later resize will redraw.
+ */
+async function waitForContainerSizeStable(
+  container: HTMLElement,
+  options: { stableFrames?: number; timeoutMs?: number } = {}
+): Promise<void> {
+  const stableFrames = options.stableFrames ?? 3;
+  const timeoutMs = options.timeoutMs ?? 2000;
+
+  await new Promise<void>((resolve) => {
+    let lastWidth = container.clientWidth;
+    let lastHeight = container.clientHeight;
+    let stableCount = 0;
+    let rafId = 0;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    let done = false;
+
+    const finish = (): void => {
+      if (done) return;
+      done = true;
+      cancelAnimationFrame(rafId);
+      if (timeoutId !== null) {
+        clearTimeout(timeoutId);
+      }
+      resolve();
+    };
+    // Never hang forever if the layout never settles
+    timeoutId = setTimeout(finish, timeoutMs);
+
+    const tick = (): void => {
+      const width = container.clientWidth;
+      const height = container.clientHeight;
+      if (width === lastWidth && height === lastHeight) {
+        stableCount += 1;
+        if (stableCount >= stableFrames) {
+          finish();
+          return;
+        }
+      } else {
+        lastWidth = width;
+        lastHeight = height;
+        stableCount = 0;
+      }
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+  });
+}
+
 function openTerminalExternalLink(_event: MouseEvent, uri: string): void {
   void window.electronAPI.shell.openExternal(uri);
 }
@@ -301,6 +358,15 @@ export function useXterm({
     if (!containerRef.current || terminalRef.current) return;
 
     setIsLoading(true);
+
+    // Wait for the container to reach its final size before opening the
+    // terminal: the PTY spawn dims are captured from the first fit below, and
+    // TUI splash screens (e.g. opencode) never redraw on later resizes.
+    if (containerRef.current) {
+      await waitForContainerSizeStable(containerRef.current);
+    }
+    // Re-check after the async wait (StrictMode unmount or re-init may have happened)
+    if (isUnmountedRef.current || !containerRef.current || terminalRef.current) return;
 
     const terminal = new Terminal({
       cursorBlink: true,
@@ -718,6 +784,10 @@ export function useXterm({
         throw error;
       }
 
+      // PTY 创建期间容器尺寸可能已变化（彼时 ptyId 尚未就绪，resize 被跳过），
+      // 激活后立即补发一次 fit，把最终容器尺寸同步给 PTY。
+      fit();
+
       // Handle input
       terminal.onData((data) => {
         const ptyInput = filterTerminalColorQueryResponses
@@ -820,12 +890,16 @@ export function useXterm({
   // Handle resize
   useEffect(() => {
     const handleResize = () => {
-      if (fitAddonRef.current && terminalRef.current && ptyIdRef.current) {
+      if (fitAddonRef.current && terminalRef.current) {
+        // 即使 PTY 尚未创建完成（ptyId 为空）也要重算 xterm 网格，
+        // 否则启动期容器变化会被永久丢弃，终端定格在旧尺寸。
         fitAddonRef.current.fit();
-        window.electronAPI.terminal.resize(ptyIdRef.current, {
-          cols: terminalRef.current.cols,
-          rows: terminalRef.current.rows,
-        });
+        if (ptyIdRef.current) {
+          window.electronAPI.terminal.resize(ptyIdRef.current, {
+            cols: terminalRef.current.cols,
+            rows: terminalRef.current.rows,
+          });
+        }
         // Clear WebGL texture atlas on resize to prevent glitches
         const addon = rendererAddonRef.current;
         if (addon && 'clearTextureAtlas' in addon) {


### PR DESCRIPTION
  PR 内容：

  ## 变更说明

  修复  OpenCode、Codex 等终端底部出现空白区域的问题。

  ## 问题原因

  Agent 面板之前使用所有分组中最大的底部栏高度，统一缩短所有终端区域。Claude 的状态栏或增强输入框出现后，其他 Agent 也会被错误扣除相同高度。

  同时修复终端启动时容器尺寸尚未稳定，导致全屏终端程序使用过期 cols/rows 的问题。

  ## 修改内容

  - 按分组计算终端底部预留高度。
  - 没有底部栏的 Agent 只保留 8px 边距。
  - 清理已销毁分组的旧高度记录。
  - 等待终端容器尺寸稳定后再创建 PTY。
  - PTY 激活后补发一次最终尺寸。

  ## 涉及文件

  - `src/renderer/components/chat/AgentPanel.tsx`
  - `src/renderer/components/chat/agentPanelLayout.ts`
  - `src/renderer/hooks/useXterm.ts`
  - `src/renderer/hooks/__tests__/useXtermConptyDisplay.test.ts`