### PR TITLE
fix: 修复背景图目录加载和终端透明渲染

### DIFF
--- a/src/main/ipc/files.ts
+++ b/src/main/ipc/files.ts
@@ -323,6 +323,11 @@ export function registerFileHandlers(): void {
     }
   );
 
+  ipcMain.handle(IPC_CHANNELS.FILE_LIST_MEDIA, async (_, dirPath: string): Promise<string[]> => {
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    return entries.filter((entry) => entry.isFile()).map((entry) => join(dirPath, entry.name));
+  });
+
   ipcMain.handle(
     IPC_CHANNELS.FILE_LIST,
     async (event, dirPath: string, gitRoot?: string): Promise<FileEntry[]> => {

--- a/src/main/services/terminal/PtyManager.ts
+++ b/src/main/services/terminal/PtyManager.ts
@@ -468,6 +468,7 @@ export class PtyManager {
       }
     }
 
+    const forceColorOutput = options.forceColorOutput === true;
     const baseEnv: Record<string, string> = {
       ...process.env,
       ...getProxyEnvVars(),
@@ -478,6 +479,12 @@ export class PtyManager {
       LANG: process.env.LANG || 'en_US.UTF-8',
       LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
     } as Record<string, string>;
+    if (forceColorOutput && !options.env?.NO_COLOR) {
+      delete baseEnv.NO_COLOR;
+      baseEnv.CLICOLOR = '1';
+      baseEnv.CLICOLOR_FORCE = '1';
+      baseEnv.FORCE_COLOR = '1';
+    }
     applyEnhancedPath(baseEnv);
 
     const windowsConptyCompatibility = createWindowsConptyCompatibilityOptions({
@@ -527,16 +534,7 @@ export class PtyManager {
               cols: options.cols || 80,
               rows: options.rows || 24,
               cwd,
-              env: {
-                ...process.env,
-                ...getProxyEnvVars(),
-                ...options.env,
-                TERM: 'xterm-256color',
-                COLORTERM: 'truecolor',
-                // Ensure proper locale for UTF-8 support (GUI apps may not inherit LANG)
-                LANG: process.env.LANG || 'en_US.UTF-8',
-                LC_ALL: process.env.LC_ALL || process.env.LANG || 'en_US.UTF-8',
-              } as Record<string, string>,
+              env: baseEnv,
             });
             shell = fallbackShell;
             args = fallbackArgs;

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -394,6 +394,8 @@ const electronAPI = {
       ipcRenderer.invoke(IPC_CHANNELS.FILE_DELETE, targetPath, options),
     list: (dirPath: string, gitRoot?: string): Promise<FileEntry[]> =>
       ipcRenderer.invoke(IPC_CHANNELS.FILE_LIST, dirPath, gitRoot),
+    listMedia: (dirPath: string): Promise<string[]> =>
+      ipcRenderer.invoke(IPC_CHANNELS.FILE_LIST_MEDIA, dirPath),
     exists: (filePath: string): Promise<boolean> =>
       ipcRenderer.invoke(IPC_CHANNELS.FILE_EXISTS, filePath),
     revealInFileManager: (filePath: string): Promise<void> =>

--- a/src/renderer/components/chat/AgentTerminal.tsx
+++ b/src/renderer/components/chat/AgentTerminal.tsx
@@ -1243,7 +1243,12 @@ export function AgentTerminal({
     <div
       ref={terminalWrapperRef}
       className="relative h-full w-full"
-      style={{ backgroundColor: settings.theme.background, contain: 'strict' }}
+      style={{
+        backgroundColor: settings.backgroundImageEnabled
+          ? 'transparent'
+          : settings.theme.background,
+        contain: 'strict',
+      }}
       onClick={handleClick}
     >
       <div ref={containerRef} className="h-full w-full" />

--- a/src/renderer/components/layout/BackgroundLayer.tsx
+++ b/src/renderer/components/layout/BackgroundLayer.tsx
@@ -65,8 +65,8 @@ function pickRandom<T>(arr: T[]): T | undefined {
 
 async function listMediaInFolder(folderPath: string): Promise<string[]> {
   try {
-    const entries = await window.electronAPI.file.list(folderPath);
-    return entries.filter((e) => !e.isDirectory && isMediaFile(e.name)).map((e) => e.path);
+    const paths = await window.electronAPI.file.listMedia(folderPath);
+    return paths.filter(isMediaFile);
   } catch (error) {
     console.error('[BackgroundLayer] Failed to list media in folder:', error);
     return [];
@@ -117,22 +117,33 @@ export function BackgroundLayer() {
   // Pick a random file from folder
   const pickRandomFile = useCallback(async () => {
     if (!activePath || backgroundSourceType !== 'folder') return;
-    const files = await listMediaInFolder(activePath);
+    const sourcePath = activePath;
+    const files = await listMediaInFolder(sourcePath);
     const picked = pickRandom(files);
-    if (picked) {
+    if (picked && useSettingsStore.getState().backgroundFolderPath.trim() === sourcePath.trim()) {
       setResolvedFile(picked);
     }
   }, [activePath, backgroundSourceType]);
 
   // On mount, folder path change, or manual refresh trigger → pick random file
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshCount is intentionally used to trigger re-pick
+  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshCount intentionally triggers a re-scan
   useEffect(() => {
+    let cancelled = false;
+
     if (backgroundSourceType === 'folder' && activePath && !isRemoteUrl) {
-      pickRandomFile();
+      void listMediaInFolder(activePath).then((files) => {
+        if (cancelled) return;
+        const picked = pickRandom(files);
+        setResolvedFile(picked ?? '');
+      });
     } else {
       setResolvedFile('');
     }
-  }, [backgroundSourceType, activePath, pickRandomFile, refreshCount, isRemoteUrl]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [backgroundSourceType, activePath, refreshCount, isRemoteUrl]);
 
   // Auto-random interval: works for folder mode (re-pick) and URL mode (re-fetch via refresh)
   useEffect(() => {

--- a/src/renderer/components/settings/AppearanceSettings.tsx
+++ b/src/renderer/components/settings/AppearanceSettings.tsx
@@ -525,6 +525,19 @@ export function AppearanceSettings() {
         ? setBackgroundUrlPath
         : setBackgroundImagePath;
 
+  const handleActivePathBlur = async () => {
+    const path = activePath.trim();
+    if (!path) return;
+
+    try {
+      await window.electronAPI.file.listMedia(path);
+      setBackgroundFolderPath(path);
+      setBackgroundSourceType('folder');
+    } catch {
+      // The path is a file, URL, or an unavailable directory.
+    }
+  };
+
   return (
     <div className="space-y-6">
       {/* Theme Mode Section */}
@@ -649,6 +662,7 @@ export function AppearanceSettings() {
                       : t('Local file path or URL')
                 }
                 className="flex-1"
+                onBlur={handleActivePathBlur}
               />
               <Button
                 variant="outline"

--- a/src/renderer/components/terminal/ShellTerminal.tsx
+++ b/src/renderer/components/terminal/ShellTerminal.tsx
@@ -154,7 +154,12 @@ export function ShellTerminal({
   return (
     <div
       className="relative h-full w-full"
-      style={{ backgroundColor: settings.theme.background, contain: 'strict' }}
+      style={{
+        backgroundColor: settings.backgroundImageEnabled
+          ? 'transparent'
+          : settings.theme.background,
+        contain: 'strict',
+      }}
     >
       <div ref={containerRef} className="h-full w-full" />
       <TerminalSearchBar

--- a/src/renderer/hooks/useXterm.ts
+++ b/src/renderer/hooks/useXterm.ts
@@ -8,6 +8,10 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { defaultDarkTheme, getXtermTheme } from '@/lib/ghosttyTheme';
 import { matchesKeybinding } from '@/lib/keybinding';
 import { stripTerminalColorQueryResponses } from '@/lib/terminalInputFilter';
+import {
+  createTerminalBackgroundFilter,
+  softenTerminalDomBackgrounds,
+} from '@/lib/terminalOutputFilter';
 import { buildWindowsPtyCompatibilityOptions } from '@/lib/windowsPtyCompatibility';
 import { useNavigationStore } from '@/stores/navigation';
 import { useSettingsStore } from '@/stores/settings';
@@ -142,6 +146,8 @@ export function useXterm({
   const containerRef = useRef<HTMLDivElement>(null);
   const terminalRef = useRef<Terminal | null>(null);
   const settings = useTerminalSettings();
+  const backgroundImageEnabledRef = useRef(settings.backgroundImageEnabled);
+  backgroundImageEnabledRef.current = settings.backgroundImageEnabled;
   const terminalRenderer = useSettingsStore((s) => s.terminalRenderer);
   const windowsConptyCompatibilityFixEnabled = useSettingsStore(
     (s) => s.windowsConptyCompatibilityFixEnabled
@@ -199,6 +205,8 @@ export function useXterm({
   // rAF write buffer for smooth rendering
   const writeBufferRef = useRef('');
   const isFlushPendingRef = useRef(false);
+  const backgroundFilterRef = useRef(createTerminalBackgroundFilter());
+  const domBackgroundCleanupRef = useRef<(() => void) | null>(null);
 
   const write = useCallback((data: string) => {
     if (ptyIdRef.current) {
@@ -334,7 +342,10 @@ export function useXterm({
 
     terminal.open(containerRef.current);
     fitAddon.fit();
-
+    if (settings.backgroundImageEnabled) {
+      domBackgroundCleanupRef.current?.();
+      domBackgroundCleanupRef.current = softenTerminalDomBackgrounds(containerRef.current);
+    }
     // IME compositionend 兜底：清空 textarea 防止旧内容残留导致输入异常
     const textarea = terminal.textarea;
     if (textarea) {
@@ -351,8 +362,8 @@ export function useXterm({
       onTitleChangeRef.current?.(title);
     });
 
-    // Load renderer
-    loadRenderer(terminal, terminalRenderer);
+    // ANSI background cells need the DOM renderer so their colors can be made translucent.
+    loadRenderer(terminal, settings.backgroundImageEnabled ? 'dom' : terminalRenderer);
 
     // Register file path link provider for click-to-open-in-editor
     const linkProviderDisposable = terminal.registerLinkProvider({
@@ -614,6 +625,7 @@ export function useXterm({
         cols: terminal.cols,
         rows: terminal.rows,
         env,
+        forceColorOutput: settings.backgroundImageEnabled,
         windowsConptyCompatibilityFixEnabled: useWindowsConptyCompatibility,
         initialCommand: initialCommandRef.current,
       });
@@ -660,7 +672,15 @@ export function useXterm({
                 const shouldLockViewport = offsetFromBottom > 0;
                 const savedOffsetFromBottom = shouldLockViewport ? offsetFromBottom : 0;
 
-                terminal.write(bufferedData);
+                const displayData = backgroundImageEnabledRef.current
+                  ? backgroundFilterRef.current.process(bufferedData)
+                  : bufferedData;
+                if (!backgroundImageEnabledRef.current) {
+                  backgroundFilterRef.current.reset();
+                }
+                if (displayData) {
+                  terminal.write(displayData);
+                }
 
                 // Restore viewport if it was moved by the write
                 if (shouldLockViewport) {
@@ -696,9 +716,18 @@ export function useXterm({
             // Flush any remaining buffered data
             if (writeBufferRef.current.length > 0) {
               const bufferedData = writeBufferRef.current;
-              terminal.write(bufferedData);
+              const displayData = backgroundImageEnabledRef.current
+                ? backgroundFilterRef.current.process(bufferedData)
+                : bufferedData;
+              if (displayData) {
+                terminal.write(displayData);
+              }
               onDataRef.current?.(bufferedData);
               writeBufferRef.current = '';
+            }
+            const pendingDisplayData = backgroundFilterRef.current.flush();
+            if (pendingDisplayData) {
+              terminal.write(pendingDisplayData);
             }
             onExitRef.current?.();
           }, 30);
@@ -763,9 +792,9 @@ export function useXterm({
   // Handle dynamic renderer switching
   useEffect(() => {
     if (terminalRef.current) {
-      loadRenderer(terminalRef.current, terminalRenderer);
+      loadRenderer(terminalRef.current, settings.backgroundImageEnabled ? 'dom' : terminalRenderer);
     }
-  }, [terminalRenderer, loadRenderer]);
+  }, [terminalRenderer, settings.backgroundImageEnabled, loadRenderer]);
 
   // Cleanup on unmount.
   // Setup: reset isUnmountedRef so StrictMode re-mount can re-initialize.
@@ -781,6 +810,8 @@ export function useXterm({
       createRequestIdRef.current += 1;
       cleanupRef.current?.();
       exitCleanupRef.current?.();
+      domBackgroundCleanupRef.current?.();
+      domBackgroundCleanupRef.current = null;
       if (ptyIdRef.current) {
         window.electronAPI.terminal.destroy(ptyIdRef.current);
         ptyIdRef.current = null;
@@ -803,19 +834,41 @@ export function useXterm({
     };
   }, []);
 
-  // Update settings dynamically
+  // Keep the background observer stable across parent renders. Recreating it for every
+  // render briefly exposes xterm's opaque base cells and causes a visible flash.
   useEffect(() => {
-    if (terminalRef.current) {
-      terminalRef.current.options.theme = settings.theme;
-      terminalRef.current.options.fontSize = settings.fontSize;
-      terminalRef.current.options.fontFamily = settings.fontFamily;
-      terminalRef.current.options.fontWeight = settings.fontWeight;
-      terminalRef.current.options.fontWeightBold = settings.fontWeightBold;
-      // Update transparency options dynamically
-      terminalRef.current.options.allowTransparency = settings.backgroundImageEnabled;
-      fitAddonRef.current?.fit();
+    domBackgroundCleanupRef.current?.();
+    domBackgroundCleanupRef.current = null;
+
+    if (settings.backgroundImageEnabled && containerRef.current) {
+      domBackgroundCleanupRef.current = softenTerminalDomBackgrounds(containerRef.current);
     }
-  }, [settings]);
+
+    return () => {
+      domBackgroundCleanupRef.current?.();
+      domBackgroundCleanupRef.current = null;
+    };
+  }, [settings.backgroundImageEnabled]);
+
+  // Update terminal options without restarting the background observer.
+  useEffect(() => {
+    if (!terminalRef.current) return;
+
+    terminalRef.current.options.theme = settings.theme;
+    terminalRef.current.options.fontSize = settings.fontSize;
+    terminalRef.current.options.fontFamily = settings.fontFamily;
+    terminalRef.current.options.fontWeight = settings.fontWeight;
+    terminalRef.current.options.fontWeightBold = settings.fontWeightBold;
+    terminalRef.current.options.allowTransparency = settings.backgroundImageEnabled;
+    fitAddonRef.current?.fit();
+  }, [
+    settings.theme,
+    settings.fontSize,
+    settings.fontFamily,
+    settings.fontWeight,
+    settings.fontWeightBold,
+    settings.backgroundImageEnabled,
+  ]);
 
   // Handle resize
   useEffect(() => {

--- a/src/renderer/lib/__tests__/terminalOutputFilter.test.ts
+++ b/src/renderer/lib/__tests__/terminalOutputFilter.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import {
+  createTerminalBackgroundFilter,
+  softenTerminalDomBackgrounds,
+  stripTerminalWideBackgroundColors,
+} from '../terminalOutputFilter';
+
+describe('stripTerminalWideBackgroundColors', () => {
+  it('removes OSC 11 color changes but preserves OSC 11 queries', () => {
+    const data = 'a\x1b]11;#111111\x1b\\b\x1b]11;?\x1b\\c';
+
+    expect(stripTerminalWideBackgroundColors(data)).toBe('ab\x1b]11;?\x1b\\c');
+  });
+});
+
+describe('softenTerminalDomBackgrounds', () => {
+  it('softens diff backgrounds while leaving the repeated base surface transparent', async () => {
+    const root = document.createElement('div');
+    const style = document.createElement('style');
+    style.textContent = `
+      .xterm-bg-base { background-color: rgb(20, 20, 20); }
+      .xterm-bg-insert { background-color: rgb(6, 56, 6); }
+      .xterm-bg-delete { background-color: rgb(66, 14, 20); }
+      .xterm-fg-code { color: rgb(122, 162, 247); }
+    `;
+    const rows = document.createElement('div');
+    rows.className = 'xterm-rows';
+    const row = document.createElement('div');
+    const baseCells = Array.from({ length: 12 }, () => {
+      const cell = document.createElement('span');
+      cell.className = 'xterm-bg-base';
+      cell.style.backgroundColor = '#141414';
+      return cell;
+    });
+    const insertCell = document.createElement('span');
+    insertCell.className = 'xterm-bg-insert xterm-fg-code';
+    insertCell.style.backgroundColor = '#063806';
+    const deleteCell = document.createElement('span');
+    deleteCell.className = 'xterm-bg-delete';
+    deleteCell.style.backgroundColor = '#420e14';
+    row.append(...baseCells, insertCell, deleteCell);
+    rows.appendChild(row);
+    root.append(style, rows);
+    document.body.appendChild(root);
+
+    const cleanup = softenTerminalDomBackgrounds(root);
+
+    expect(getComputedStyle(baseCells[0]).backgroundColor).toBe('rgba(0, 0, 0, 0)');
+    expect(insertCell.style.getPropertyValue('--ensoai-terminal-background')).toBe(
+      'rgba(6, 56, 6, 0.35)'
+    );
+    expect(deleteCell.style.getPropertyValue('--ensoai-terminal-background')).toBe(
+      'rgba(66, 14, 20, 0.35)'
+    );
+    expect(getComputedStyle(insertCell).color).toBe('rgb(122, 162, 247)');
+
+    cleanup();
+    root.remove();
+    await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+  });
+});
+
+describe('createTerminalBackgroundFilter', () => {
+  it('handles OSC 11 sequences split across terminal data packets', () => {
+    const filter = createTerminalBackgroundFilter();
+
+    expect(filter.process('before\x1b]11;#111')).toBe('before');
+    expect(filter.process('111\x1b\\after')).toBe('after');
+  });
+
+  it('drops an incomplete background color sequence when the terminal exits', () => {
+    const filter = createTerminalBackgroundFilter();
+
+    expect(filter.process('before\x1b]11;#111')).toBe('before');
+    expect(filter.flush()).toBe('');
+  });
+});

--- a/src/renderer/lib/terminalOutputFilter.ts
+++ b/src/renderer/lib/terminalOutputFilter.ts
@@ -1,0 +1,209 @@
+// biome-ignore lint/complexity/useRegexLiterals: string form avoids control characters in the regex literal
+const OSC_BACKGROUND_COLOR_REGEX = new RegExp(
+  String.raw`\x1b\]11;(?!\?)[^\x07\x1b]*(?:\x07|\x1b\\)`,
+  'g'
+);
+// biome-ignore lint/complexity/useRegexLiterals: string form avoids control characters in the regex literal
+const INCOMPLETE_OSC_BACKGROUND_REGEX = new RegExp(String.raw`(?:\x1b\]11;[^\x07\x1b]*|\x1b)$`);
+const RGB_COLOR_REGEX =
+  /^rgba?\(\s*(\d+)\s*[, ]\s*(\d+)\s*[, ]\s*(\d+)(?:\s*[,/]\s*([\d.]+))?\s*\)$/i;
+const HEX_COLOR_REGEX = /^#([\da-f]{3,8})$/i;
+const TERMINAL_BACKGROUND_ATTRIBUTE = 'data-ensoai-terminal-background';
+const TERMINAL_BACKGROUND_VARIABLE = '--ensoai-terminal-background';
+
+type ParsedRgb = { r: number; g: number; b: number; alpha: number; key: string };
+
+function parseRgbColor(value: string): ParsedRgb | null {
+  const match = value.match(RGB_COLOR_REGEX);
+  if (!match) return null;
+
+  const alpha = match[4] === undefined ? 1 : Number.parseFloat(match[4]);
+  return {
+    r: Number.parseInt(match[1], 10),
+    g: Number.parseInt(match[2], 10),
+    b: Number.parseInt(match[3], 10),
+    alpha,
+    key: `${match[1]},${match[2]},${match[3]}`,
+  };
+}
+
+function parseCssColor(value: string): ParsedRgb | null {
+  const rgb = parseRgbColor(value.trim());
+  if (rgb) return rgb;
+
+  const match = value.trim().match(HEX_COLOR_REGEX);
+  if (!match) return null;
+
+  const hex = match[1];
+  const expanded = hex.length <= 4 ? [...hex].map((digit) => `${digit}${digit}`).join('') : hex;
+  const r = Number.parseInt(expanded.slice(0, 2), 16);
+  const g = Number.parseInt(expanded.slice(2, 4), 16);
+  const b = Number.parseInt(expanded.slice(4, 6), 16);
+  const hasAlpha = expanded.length === 8;
+  const alpha = hasAlpha ? Number.parseInt(expanded.slice(6, 8), 16) / 255 : 1;
+  return {
+    r,
+    g,
+    b,
+    alpha,
+    key: `${r},${g},${b}`,
+  };
+}
+
+function colorChroma(color: ParsedRgb): number {
+  return Math.max(color.r, color.g, color.b) - Math.min(color.r, color.g, color.b);
+}
+
+function colorLuminance(color: ParsedRgb): number {
+  return (color.r * 299 + color.g * 587 + color.b * 114) / 1000;
+}
+
+/** Remove terminal-wide background changes while preserving ANSI cell colors. */
+export function stripTerminalWideBackgroundColors(data: string): string {
+  return data.replace(OSC_BACKGROUND_COLOR_REGEX, '');
+}
+
+/**
+ * Make non-base ANSI cell backgrounds translucent without changing foreground colors.
+ * Grok paints its base surface into every cell; that color is left transparent while
+ * diff and selection colors remain visible through the workspace image.
+ */
+export function softenTerminalDomBackgrounds(root: HTMLElement, opacity = 0.35): () => void {
+  const marked = new Set<HTMLElement>();
+  const inlineBackgrounds = new WeakMap<HTMLElement, string>();
+  const style = document.createElement('style');
+  style.textContent = `
+    [${TERMINAL_BACKGROUND_ATTRIBUTE}="base"] {
+      background-color: transparent !important;
+    }
+    [${TERMINAL_BACKGROUND_ATTRIBUTE}="soft"] {
+      background-color: var(${TERMINAL_BACKGROUND_VARIABLE}) !important;
+    }
+  `;
+  root.prepend(style);
+
+  const clearMarker = (element: HTMLElement) => {
+    element.removeAttribute(TERMINAL_BACKGROUND_ATTRIBUTE);
+    element.style.removeProperty(TERMINAL_BACKGROUND_VARIABLE);
+  };
+
+  const soften = () => {
+    // Remove only the overlay markers. Inline xterm colors stay untouched, so the
+    // original color can be measured again without flashing an opaque frame.
+    for (const element of marked) {
+      clearMarker(element);
+      inlineBackgrounds.delete(element);
+    }
+    marked.clear();
+
+    const elements = [...root.querySelectorAll<HTMLElement>('.xterm-rows > div, .xterm-rows span')];
+    const backgrounds = elements.map((element) => {
+      const inlineValue = element.style.getPropertyValue('background-color');
+      const color =
+        parseCssColor(inlineValue) ?? parseCssColor(getComputedStyle(element).backgroundColor);
+      return { element, color, inlineValue };
+    });
+    const counts = new Map<string, { color: ParsedRgb; count: number }>();
+
+    for (const { color } of backgrounds) {
+      if (!color || color.alpha < 1) continue;
+      const entry = counts.get(color.key);
+      if (entry) {
+        entry.count += 1;
+      } else {
+        counts.set(color.key, { color, count: 1 });
+      }
+    }
+
+    const baseBackground = [...counts.values()]
+      .filter(
+        ({ color, count }) => count > 1 && colorLuminance(color) < 120 && colorChroma(color) < 40
+      )
+      .sort((a, b) => b.count - a.count)[0]?.color;
+
+    for (const { element, color, inlineValue } of backgrounds) {
+      if (element.classList.contains('xterm-cursor') || !color || color.alpha < 1) continue;
+
+      inlineBackgrounds.set(element, inlineValue);
+      if (baseBackground && color.key === baseBackground.key) {
+        element.setAttribute(TERMINAL_BACKGROUND_ATTRIBUTE, 'base');
+      } else {
+        element.style.setProperty(
+          TERMINAL_BACKGROUND_VARIABLE,
+          `rgba(${color.r}, ${color.g}, ${color.b}, ${opacity})`
+        );
+        element.setAttribute(TERMINAL_BACKGROUND_ATTRIBUTE, 'soft');
+      }
+      marked.add(element);
+    }
+  };
+
+  // MutationObserver callbacks run before the next paint. Processing directly avoids
+  // a requestAnimationFrame gap in which newly rendered cells can show their base fill.
+  soften();
+  const observer = new MutationObserver((records) => {
+    const shouldSoften = records.some((record) => {
+      if (record.type !== 'attributes') return true;
+      if (record.attributeName === TERMINAL_BACKGROUND_ATTRIBUTE) return false;
+      if (record.attributeName !== 'style') return true;
+
+      const element = record.target;
+      if (!(element instanceof HTMLElement)) return true;
+      const inlineBackground = element.style.getPropertyValue('background-color');
+      return inlineBackgrounds.has(element)
+        ? inlineBackground !== inlineBackgrounds.get(element)
+        : inlineBackground.length > 0;
+    });
+    if (shouldSoften) soften();
+  });
+  observer.observe(root, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeFilter: ['class', 'style'],
+  });
+
+  return () => {
+    observer.disconnect();
+    for (const element of marked) {
+      clearMarker(element);
+    }
+    marked.clear();
+    style.remove();
+  };
+}
+
+export interface TerminalBackgroundFilter {
+  process: (data: string) => string;
+  flush: () => string;
+  reset: () => void;
+}
+
+export function createTerminalBackgroundFilter(): TerminalBackgroundFilter {
+  let carry = '';
+
+  return {
+    process(data) {
+      const combined = carry + data;
+      carry = '';
+
+      const incompleteMatch = combined.match(INCOMPLETE_OSC_BACKGROUND_REGEX);
+      const completeData = incompleteMatch
+        ? combined.slice(0, combined.length - incompleteMatch[0].length)
+        : combined;
+
+      if (incompleteMatch) {
+        carry = incompleteMatch[0];
+      }
+
+      return stripTerminalWideBackgroundColors(completeData);
+    },
+    flush() {
+      carry = '';
+      return '';
+    },
+    reset() {
+      carry = '';
+    },
+  };
+}

--- a/src/shared/types/ipc.ts
+++ b/src/shared/types/ipc.ts
@@ -93,6 +93,7 @@ export const IPC_CHANNELS = {
   FILE_CHECK_CONFLICTS: 'file:checkConflicts',
   FILE_DELETE: 'file:delete',
   FILE_LIST: 'file:list',
+  FILE_LIST_MEDIA: 'file:listMedia',
   FILE_EXISTS: 'file:exists',
   FILE_REVEAL_IN_FILE_MANAGER: 'file:revealInFileManager',
   FILE_WATCH_START: 'file:watch:start',

--- a/src/shared/types/terminal.ts
+++ b/src/shared/types/terminal.ts
@@ -20,6 +20,8 @@ export interface TerminalCreateOptions {
   cols?: number;
   rows?: number;
   env?: Record<string, string>;
+  /** Enable ANSI colors even when the host process exports color-disabled variables. */
+  forceColorOutput?: boolean;
   shellConfig?: import('./shell').ShellConfig;
   /** Windows 滚屏补丁：使用随包新版 ConPTY/OpenConsole 改善旧系统滚动异常。 */
   windowsConptyCompatibilityFixEnabled?: boolean;

--- a/src/shared/utils/__tests__/fileUrl.test.ts
+++ b/src/shared/utils/__tests__/fileUrl.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { customProtocolUriToPath, toCustomProtocolFileUrl } from '../fileUrl';
+
+describe('custom protocol file URLs', () => {
+  it('round-trips Windows drive paths', () => {
+    const filePath = String.raw`C:\Users\test\Pictures\background image.webp`;
+    const url = toCustomProtocolFileUrl(filePath, 'local-image');
+
+    expect(url).toBe('local-image://c/Users/test/Pictures/background%20image.webp');
+    expect(customProtocolUriToPath(url, 'local-image', 'win32')).toBe(filePath);
+  });
+
+  it('round-trips Windows UNC paths', () => {
+    const filePath = String.raw`\\wsl.localhost\Ubuntu\home\test\background.png`;
+    const url = toCustomProtocolFileUrl(filePath, 'local-image');
+
+    expect(url).toBe('local-image://wsl.localhost/Ubuntu/home/test/background.png');
+    expect(customProtocolUriToPath(url, 'local-image', 'win32')).toBe(filePath);
+  });
+});

--- a/src/shared/utils/fileUrl.ts
+++ b/src/shared/utils/fileUrl.ts
@@ -5,12 +5,15 @@ export type SupportedFileUrlPlatform = 'darwin' | 'linux' | 'win32';
  *
  * This does NOT URL-encode; URL will handle encoding when converting to string.
  */
+const PATH_HOST = 'ensoai';
+
 function normalizeAbsolutePathForUrlPathname(absPath: string): string {
   let normalized = absPath.replace(/\\/g, '/');
 
   if (/^[a-zA-Z]:\//.test(normalized)) {
-    normalized = `/${normalized}`;
-  } else if (!normalized.startsWith('/')) {
+    normalized = normalized.slice(2);
+  }
+  if (!normalized.startsWith('/')) {
     normalized = `/${normalized}`;
   }
 
@@ -22,9 +25,20 @@ function normalizeAbsolutePathForUrlPathname(absPath: string): string {
  * Supports Windows UNC paths such as \\wsl.localhost\Ubuntu\home\user.
  */
 export function toCustomProtocolFileUrl(absPath: string, scheme: string): string {
-  const url = new URL(`${scheme}://`);
-  assignAbsolutePathToUrl(url, absPath);
-  return url.toString();
+  const normalized = absPath.replace(/\\/g, '/');
+  if (normalized.startsWith('//')) {
+    const withoutPrefix = normalized.slice(2);
+    const firstSlashIndex = withoutPrefix.indexOf('/');
+    const hostname =
+      firstSlashIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, firstSlashIndex);
+    const pathname = firstSlashIndex === -1 ? '/' : withoutPrefix.slice(firstSlashIndex);
+    return `${scheme}://${hostname}${encodeURI(pathname)}`;
+  }
+
+  const driveLetter = /^[a-zA-Z]:\//.exec(normalized)?.[0][0] ?? '';
+  const encodedPath = encodeURI(normalizeAbsolutePathForUrlPathname(absPath));
+  const hostname = driveLetter ? driveLetter.toLowerCase() : PATH_HOST;
+  return `${scheme}://${hostname}${encodedPath}`;
 }
 
 /**
@@ -32,8 +46,8 @@ export function toCustomProtocolFileUrl(absPath: string, scheme: string): string
  * Ensures the resulting URL.pathname ends with a trailing slash.
  */
 export function toCustomProtocolFileBaseUrl(absDirPath: string, scheme: string): URL {
-  const url = new URL(`${scheme}://`);
-  assignAbsolutePathToUrl(url, absDirPath);
+  const urlString = toCustomProtocolFileUrl(absDirPath, scheme);
+  const url = new URL(urlString);
   url.pathname = `${url.pathname.replace(/\/+$/, '')}/`;
   return url;
 }
@@ -73,34 +87,18 @@ export function customProtocolUriToPath(
   }
 }
 
-function assignAbsolutePathToUrl(url: URL, absPath: string): void {
-  const normalized = absPath.replace(/\\/g, '/');
-
-  if (normalized.startsWith('//')) {
-    const withoutPrefix = normalized.slice(2);
-    const firstSlashIndex = withoutPrefix.indexOf('/');
-    const hostname =
-      firstSlashIndex === -1 ? withoutPrefix : withoutPrefix.slice(0, firstSlashIndex);
-
-    if (hostname) {
-      url.hostname = hostname;
-      url.pathname = firstSlashIndex === -1 ? '/' : withoutPrefix.slice(firstSlashIndex);
-      return;
-    }
-  }
-
-  url.pathname = normalizeAbsolutePathForUrlPathname(absPath);
-}
-
 function urlToFilePath(url: URL, platform: SupportedFileUrlPlatform): string {
   const pathname = decodeURIComponent(url.pathname);
+
+  if (url.hostname === PATH_HOST) {
+    return platform === 'win32' ? pathname.replace(/\//g, '\\') : pathname;
+  }
 
   if (url.hostname) {
     if (platform === 'win32') {
       if (/^[a-zA-Z]$/.test(url.hostname)) {
-        return `${url.hostname}:${pathname.replace(/\//g, '\\')}`;
+        return `${url.hostname.toUpperCase()}:${pathname.replace(/\//g, '\\')}`;
       }
-
       return `\\\\${url.hostname}${pathname.replace(/\//g, '\\')}`;
     }
 


### PR DESCRIPTION
## 变更内容\n\n- 支持从指定本地目录扫描并随机加载背景图片或视频\n- 修复 Windows 本地图片自定义协议路径解析\n- 保持 Grok/Codex 终端彩色文字、选择高亮和红绿 diff，同时移除终端级不透明背景\n- 修复终端外层容器和基础单元格背景闪烁\n- 在背景图模式下确保 PTY 继承彩色输出环境\n\n## 验证\n\n- pnpm test：30 个测试文件、230 个测试全部通过\n- pnpm typecheck：通过\n- pnpm build：通过\n- 已在 Windows Electron 测试版中实际验证背景图、Grok 终端透明渲染和连续重绘状态